### PR TITLE
tp401: added sensor to readme

### DIFF
--- a/src/gas/README.txt
+++ b/src/gas/README.txt
@@ -1,8 +1,8 @@
-Grove - Gas Sensor(MQ-2)：Combustible Gas Smoke [medium sensitivity]
-Grove - Gas Sensor(MQ-3)：Alcohol and Benzine [high sensitivity] Long warm-up
-Grove - Gas Sensor(MQ-5)：LPG, Natural Gas, Town Gas [high sensitivity]
-Grove - Gas Sensor(MQ-9)：LPG, CO, CH4 [low sensitivity]
+Grove - Gas Sensor(MQ-2):Combustible Gas Smoke [medium sensitivity]
+Grove - Gas Sensor(MQ-3):Alcohol and Benzine [high sensitivity] Long warm-up
+Grove - Gas Sensor(MQ-5):LPG, Natural Gas, Town Gas [high sensitivity]
+Grove - Gas Sensor(MQ-9):LPG, CO, CH4 [low sensitivity]
+Grove - Air Quality Sensor(TP-401): CO, alcohol, acetone, thinner, others [high sensitivity].
 
 Note - Gas sensors need to be heated, first minute the data is incorrect. Air
-Quality sensor needs 48h to stabilize
-
+Quality sensor needs 48h to stabilize.


### PR DESCRIPTION
The line with the sensor name and details got left out from the readme, probably because of the order of commits.

Signed-off-by: Mihai Tudor Panu mihai.t.panu@intel.com
