### PR TITLE
cmake: allows to build in source tree by filtering subdirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required (VERSION 2.8.11)
 project (upm)
 
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+message("WARNING: building into sources dir can be risky, prefer other directory")
+endif ()
+
 find_package (SWIG)
 if (SWIG_FOUND)
   include (${SWIG_USE_FILE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,5 +125,7 @@ endmacro(upm_module_init)
 
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
 foreach(subdir ${SUBDIRS})
-    add_subdirectory(${subdir})
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}/CMakeLists.txt)
+        add_subdirectory(${subdir})
+    endif()
 endforeach()


### PR DESCRIPTION
Without it FTBFS and displays this error message :

  cmake . && make
  (...)
  The source directory
  (...) src/CMakeFiles
  does not contain a CMakeLists.txt file.

Change-Id: I08efc4667d1004a5d19575dd4464dcd89d03fb28
Signed-off-by: Philippe Coval <philippe.coval@open.eurogiciel.org>