### PR TITLE
Servo/ES08A Clean-up

### DIFF
--- a/examples/es08a.cxx
+++ b/examples/es08a.cxx
@@ -33,13 +33,25 @@ main(int argc, char **argv)
 {
     //! [Interesting]
     upm::ES08A *servo = new upm::ES08A(5);    
-    servo->setAngle (180);
-    //! [Interesting]
 
-    servo->setAngle (90);
-    servo->setAngle (0);
-    servo->setAngle (90);
+    // Sets the shaft to 180, then to 90, then to 0,
+    // then back to 90, and finally back to 180,
+    // pausing for a second in between each angle
     servo->setAngle (180);
+    std::cout << "Set angle to 180" << std::endl;
+    sleep(1);
+    servo->setAngle (90);
+    std::cout << "Set angle to 90" << std::endl;
+    sleep(1);
+    servo->setAngle (0);
+    std::cout << "Set angle to 0" << std::endl;
+    sleep(1);
+    servo->setAngle (90);
+    std::cout << "Set angle to 90" << std::endl;
+    sleep(1);
+    servo->setAngle (180);
+    std::cout << "Set angle to 180" << std::endl;
+    //! [Interesting]
 
     std::cout << "exiting application" << std::endl;
 

--- a/examples/javascript/servo.js
+++ b/examples/javascript/servo.js
@@ -43,11 +43,11 @@ function startServo(timeOffset, timeInterval, angle)
     // Start running this instance after timeOffset milliseconds
     setTimeout(function()
     {
-        console.log("Starting angle is " + angle);
         // run this instance every timeInterval milliseconds
         setInterval(function()
         {
             servo.setAngle(angle);
+            console.log("Set angle to " + angle);
         }, timeInterval);
     }, timeOffset);
     // timeOffset tells setTimeout when

--- a/examples/python/es08a.py
+++ b/examples/python/es08a.py
@@ -29,14 +29,17 @@ gServo = servo.ES08A(5)
 for i in range(0,10): 
     # Set the servo arm to 0 degrees
     gServo.setAngle(0)
+    print 'Set angle to 0'
     time.sleep(1)
 
     # Set the servo arm to 90 degrees
     gServo.setAngle(90)
+    print 'Set angle to 90'
     time.sleep(1)
 
     # Set the servo arm to 180 degrees
     gServo.setAngle(180)
+    print 'Set angle to 180'
     time.sleep(1)
 
 # Delete the servo object

--- a/src/servo/es08a.h
+++ b/src/servo/es08a.h
@@ -31,7 +31,11 @@ namespace upm {
 /**
  * @brief C++ API for ES08A servo component
  *
- * This file defines the ES08A C++ interface for libes08a
+ * This file defines the ES08A C++ interface for ES08A servos.
+ * Like other servos, the ES08A servo has a shaft that can be controlled
+ * by setting the desired angle.  There are also routines for setting
+ * and getting the minimum and maximum pulse width as well as the
+ * maximum period.
  *
  * @ingroup servo pwm
  * @snippet es08a.cxx Interesting
@@ -39,7 +43,7 @@ namespace upm {
 class ES08A : public Servo {
     public:
         /**
-         * Instanciates a ES08A object
+         * Instantiates an ES08A object
          *
          * @param pin servo pin number
          */

--- a/src/servo/servo.cxx
+++ b/src/servo/servo.cxx
@@ -85,8 +85,6 @@ mraa_result_t Servo::setAngle (int angle) {
     }
     mraa_pwm_enable (m_pwmServoContext, 0);
 
-    std::cout << "angle = " << angle << " ,pulse = " << calcPulseTraveling(angle) << ", cycles " << cycles << std::endl;
-
     m_currAngle = angle;
 }
 

--- a/src/servo/servo.h
+++ b/src/servo/servo.h
@@ -36,13 +36,18 @@ namespace upm {
 #define LOW                   0
 
 /**
- * @brief servo libraries
+ * @brief C++ API for servo libraries 
+ *
+ * The base class Servo provides routines for setting the angle of the shaft
+ * as well as setting and getting the minimum and maximum pulse width and 
+ * the maximum period.
+ *
  * @defgroup servo libupm-servo
  */
 class Servo {
     public:
         /**
-         * Instanciates a servo object
+         * Instantiates a servo object
          *
          * @param pin servo pin number
          */
@@ -54,24 +59,17 @@ class Servo {
         ~Servo();
 
         /**
-         * Set the of the servo engine.
-         *
-         * X = between (MIN_PULSE_WIDTH , MAX_PULSE_WIDTH)
-         *
-         * X usec
-         * _______
-         *        |_______________________________________
-         *                      20000 usec
-         *
-         * Max period can be only 7968750(nses) which is ~8(msec)
-         * so the servo will not work as expected.
+         * Set the angle of the servo engine.
          *
          * @param angle number between 0 and 180
+         * @return 0 on success; non-zero otherwise
          */
         mraa_result_t setAngle (int angle);
 
         /**
          * Return name of the component
+         *
+         * @return name of the component
          */
         std::string name()
         {
@@ -79,38 +77,44 @@ class Servo {
         }
 
         /**
-         * Set min pulse width
+         * Set minimum pulse width
          *
-         * @param width HIGH signal width
+         * @param width minimum HIGH signal width
          */
         void setMinPulseWidth (int width);
 
         /**
-         * Set max pulse width
+         * Set maximum pulse width
          *
-         * @param width HIGH signal width
+         * @param width maximum HIGH signal width
          */
         void setMaxPulseWidth (int width);
 
         /**
-         * Set max period width
+         * Set maximum period width
          *
-         * @param width PWM period width
+         * @param width maximum PWM period width
          */
         void setMaxPeriod (int width);
 
         /**
-         * Return min pulse width
+         * Return minimum pulse width
+         *
+         * @return minimum pulse width
          */
         int getMinPulseWidth ();
 
         /**
-         * Return max pulse width
+         * Return maximum pulse width
+         *
+         * @return maximum pulse width
          */
         int getMaxPulseWidth ();
 
         /**
-         * Return max PWM period width
+         * Return maximum PWM period width
+         *
+         * @return maximum PWM period width
          */
         int getMaxPeriod ();
 
@@ -120,7 +124,7 @@ class Servo {
         std::string         m_name;
         int                 m_servoPin;
         float               m_maxAngle;
-        mraa_pwm_context     m_pwmServoContext;
+        mraa_pwm_context    m_pwmServoContext;
         int                 m_currAngle;
 
         int                 m_minPulseWidth;


### PR DESCRIPTION
Key changes:
•	Improved documentation
•	Removal of output from a routine in the library
•	Added output to examples
•	Added a one second sleep between angles in the C++ example
