### PR TITLE
lcd jhd1313m1 clear() patch - added usleep after i2Cmd

### DIFF
--- a/src/lcd/jhd1313m1.cxx
+++ b/src/lcd/jhd1313m1.cxx
@@ -120,7 +120,11 @@ Jhd1313m1::setCursor (int row, int column) {
 
 mraa_result_t
 Jhd1313m1::clear () {
-    return i2Cmd (m_i2c_lcd_control, LCD_CLEARDISPLAY);
+    mraa_result_t error = MRAA_SUCCESS;
+    error = i2Cmd (m_i2c_lcd_control, LCD_CLEARDISPLAY);
+    usleep(4500);
+    
+    return error;
 }
 
 mraa_result_t


### PR DESCRIPTION
This patch fixes issue with putting a clear() right before a write()
resulting in loss of characters on the write.  The usleep delays for
a short time then the write() data is displayed properly.

Signed-off-by: John Van Drasek <john.r.van.drasek@intel.com>