### PR TITLE
Add createChar method to I2CLcd class

### DIFF
--- a/src/lcd/i2clcd.cxx
+++ b/src/lcd/i2clcd.cxx
@@ -48,6 +48,20 @@ I2CLcd::write (int row, int column, std::string msg) {
 }
 
 mraa_result_t
+I2CLcd::createChar(uint8_t charSlot, uint8_t charData[]) {
+    mraa_result_t error = MRAA_SUCCESS;
+    charSlot &= 0x07; // only have 8 positions we can set
+    error = i2Cmd(m_i2c_lcd_control, LCD_SETCGRAMADDR | (charSlot << 3));
+    if (error == MRAA_SUCCESS) {
+        for (int i = 0; i < 8; i++) {
+            error = i2cData(m_i2c_lcd_control, charData[i]);
+        }
+    }
+
+    return error;
+}
+
+mraa_result_t
 I2CLcd::close() {
     return mraa_i2c_stop(m_i2c_lcd_control);
 }

--- a/src/lcd/i2clcd.h
+++ b/src/lcd/i2clcd.h
@@ -68,6 +68,9 @@ namespace upm {
 #define LCD_5x10DOTS 0x04
 #define LCD_5x8DOTS 0x00
 
+// flags for CGRAM
+#define LCD_SETCGRAMADDR 0x40
+
 #define LCD_EN 0x04 // Enable bit
 #define LCD_RW 0x02 // Read/Write bit
 #define LCD_RS 0x01 // Register select bit
@@ -85,6 +88,7 @@ class I2CLcd {
         virtual mraa_result_t setCursor (int row, int column) = 0;
         virtual mraa_result_t clear () = 0;
         virtual mraa_result_t home () = 0;
+        virtual mraa_result_t createChar(uint8_t charSlot, uint8_t charData[]);
         virtual mraa_result_t i2Cmd (mraa_i2c_context ctx, uint8_t value);
         virtual mraa_result_t i2cReg (mraa_i2c_context ctx, int deviceAdress, int addr, uint8_t data);
         virtual mraa_result_t i2cData (mraa_i2c_context ctx, uint8_t value);

--- a/src/lcd/jhd1313m1.cxx
+++ b/src/lcd/jhd1313m1.cxx
@@ -101,7 +101,6 @@ mraa_result_t
 Jhd1313m1::write (std::string msg) {
     usleep(1000);
     mraa_result_t error = MRAA_SUCCESS;
-    uint8_t data[2] = {0x40, 0};
     for (std::string::size_type i = 0; i < msg.size(); ++i) {
         error = i2cData (m_i2c_lcd_control, msg[i]);
     }


### PR DESCRIPTION
LCDs based on the HD44780 allow for setting 8 custom characters.
This patch adds a method that exposes this capability.