### PR TITLE
pkgconfig.in: allow a module to specify dependencies on another module

### DIFF
--- a/src/pkgconfig.in
+++ b/src/pkgconfig.in
@@ -9,3 +9,6 @@ Version: @upm_VERSION_STRING@
 
 Libs: -L${libdir} -lupm-@libname@
 Cflags: -I${includedir}/upm
+
+Requires: @reqlibname@
+Requires.private: @reqplibname@


### PR DESCRIPTION
This patch adds the

Requires: @reqlibname@

and

Requires.private: @reqplibname@

clauses to the src/pkgconfig.in file.

This allows a UPM module to declare a dependency on another module
with a line of the form:

set (reqlibname "upm-somelib")
and/or
set (reqplibname "upm-somelib")

to the CMakeLists.txt file.

Signed-off-by: Jon Trulson <jtrulson@ics.com>