### PR TITLE
Doxygen tag additions

### DIFF
--- a/src/sm130/sm130.h
+++ b/src/sm130/sm130.h
@@ -39,18 +39,28 @@
 #define LOW                   0
 
 namespace upm {
-
-/**
- * @brief sm130 rfid module library
- * @defgroup sm130 libupm-sm130
- */
-
 /**
  * @brief C++ API for SM130 RFID reader module
  *
- * This file defines the SM130 C++ interface for libsm130
+ *   This file defines the C++ interface for sm130 RFID library
  *
- * @ingroup sm130
+ * @defgroup sm130 libupm-sm130
+ * @ingroup sparkfun gpio rfid
+ */
+/**
+ * @library sm130
+ * @sensor sm130
+ * @comname RFID module
+ * @type rfid
+ * @man sparkfun
+ * @web https://www.sparkfun.com/products/10126
+ * @con gpio
+ *
+ * @brief C++ API for SM130 RFID reader module
+ * 
+ *   This file defines the C++ interface for sm130 RFID library
+ *
+ * @snippet sm130.cxx Interesting
  */
 class SM130 {
 

--- a/src/st7735/st7735.h
+++ b/src/st7735/st7735.h
@@ -494,16 +494,26 @@ const unsigned char font[] = {
 };
 
 /**
- * @brief st7735 lcd display library
+ * @brief C++ API for the st7735 lcd display library
+ *
+ *   This file defines the C++ interface for ST7735 display library
+ *
  * @defgroup st7735 libupm-st7735
+ * @ingroup adafruit spi display
  */
-
 /**
- * @brief C++ API for ST7735 SPI LCD module
+ * @library st7735
+ * @sensor st7735
+ * @comname LCD display
+ * @type display
+ * @man adafruit
+ * @web http://www.adafruit.com/product/358
+ * @con spi
  *
- * This file defines the ST7735 C++ interface for libst7735
+ * @brief C++ API for the st7735 lcd display library
+ * 
+ *   This file defines the C++ interface for ST7735 display library
  *
- * @ingroup st7735 spi
  * @snippet st7735.cxx Interesting
  */
 class ST7735 : public GFX {

--- a/src/stepmotor/stepmotor.h
+++ b/src/stepmotor/stepmotor.h
@@ -40,18 +40,27 @@
 #define LOW                0
 
 namespace upm {
-
 /**
- * @brief Stepper motor library
+ * @brief C++ API for the Stepper motor library
+ *
+ *   This file defines the stepmotor C++ interface
+ *
  * @defgroup stepper libupm-stepper
+ * @ingroup seeed pwm gpio motor
  */
-
 /**
- * @brief C++ API for StepMotor Drivers
+ * @library stepper
+ * @sensor stepper
+ * @comname Stepper motor
+ * @type motor
+ * @man seeed
+ * @web http://www.seeedstudio.com/wiki/Grove_-_I2C_Motor_Driver_V1.3
+ * @con pwm gpio
  *
- * This file defines the stepmotor C++ interface for libstepmotor
+ * @brief C++ API for the Stepper motor library
+ * 
+ *   This file defines the stepmotor C++ interface
  *
- * @ingroup stepper pwm
  * @snippet stepmotor.cxx Interesting
  */
 class StepMotor {

--- a/src/ta12200/ta12200.h
+++ b/src/ta12200/ta12200.h
@@ -33,18 +33,35 @@
 #define TA12200_ADC_RES 1024
 
 namespace upm {
-
-  /**
-   * @brief C++ API for the TA12-200 current transformer
-   *
-   * UPM module for the TA12-200 current transformer, which is found,
-   * for instance, in the Grove Electricity Sensor. 
-   * This module can measure AC current moving through a wire at up 
-   * to 5A.
-   *
-   * @ingroup analog
-   * @snippet ta12200.cxx Interesting
-   */
+/**
+ * @brief C++ API for the TA12-200 current transformer
+ *
+ *   UPM module for the TA12-200 current transformer, which is found,
+ *   for instance, in the Grove Electricity Sensor. 
+ *   This module can measure AC current moving through a wire at up 
+ *   to 5A.
+ *
+ * @defgroup ta12200 libupm-ta12200
+ * @ingroup seeed analog electric
+ */
+/**
+ * @library ta12200
+ * @sensor ta12200
+ * @comname Current transformer
+ * @type electric
+ * @man seeed
+ * @web http://www.seeedstudio.com/wiki/Grove_-_Electricity_Sensor
+ * @con analog
+ *
+ * @brief C++ API for the TA12-200 current transformer
+ * 
+ *   UPM module for the TA12-200 current transformer, which is found,
+ *   for instance, in the Grove Electricity Sensor. 
+ *   This module can measure AC current moving through a wire at up 
+ *   to 5A.
+ *
+ * @snippet ta12200.cxx Interesting
+ */
   class TA12200 {
   public:
     /**

--- a/src/tcs3414cs/tcs3414cs.h
+++ b/src/tcs3414cs/tcs3414cs.h
@@ -105,16 +105,26 @@ typedef struct {
 } tcs3414sc_rgb_t;
 
 /**
- * @brief tcs3414cs color sensor library
- * @defgroup tcs3414cs libupm-tcs3414cs
- */
-
-/**
  * @brief C++ API for TCS3414CS chip (Color sensor)
  *
- * This file defines the TCS3414CS C++ interface for libtcs3414cs
+ *   his file defines the TCS3414CS C++ interface for the color sensor
  *
- * @ingroup tcs3414cs i2c
+ * @defgroup tcs3414cs libupm-tcs3414cs
+ * @ingroup seeed i2c color
+ */
+/**
+ * @library tcs3414cs
+ * @sensor tcs3414cs
+ * @comname Color sensor
+ * @type color
+ * @man seeed
+ * @web http://www.seeedstudio.com/wiki/Grove_-_I2C_Color_Sensor
+ * @con i2c
+ *
+ * @brief C++ API for TCS3414CS chip (Color sensor)
+ * 
+ *   This file defines the TCS3414CS C++ interface for the color sensor
+ *
  * @snippet tcs3414cs.cxx Interesting
  */
 class TCS3414CS {

--- a/src/th02/th02.h
+++ b/src/th02/th02.h
@@ -50,24 +50,6 @@
 namespace upm {
 
 /**
- * @brief th02 temperature & humidity sensor library
- * @defgroup th02 libupm-th02
- */
-
-/**
- * @brief C++ API for TH02 chip (Temperature and Humidity Sensor Pro)
- *
- * This file defines the TH02 C++ interface for libth02
- *
- * @ingroup th02
- * @snippet th02.cxx Interesting
- */
-
-
-
-
-
-/**
  * @brief C++ API for th02 temperature & humidity sensor library
  *
  *   This file defines the TH02 C++ interface for libth02

--- a/src/th02/th02.h
+++ b/src/th02/th02.h
@@ -62,6 +62,34 @@ namespace upm {
  * @ingroup th02
  * @snippet th02.cxx Interesting
  */
+
+
+
+
+
+/**
+ * @brief C++ API for th02 temperature & humidity sensor library
+ *
+ *   This file defines the TH02 C++ interface for libth02
+ *
+ * @defgroup th02 libupm-th02
+ * @ingroup seeed i2c temp
+ */
+/**
+ * @library th02
+ * @sensor th02
+ * @comname temperature and humidity sensor
+ * @type temp
+ * @man seeed
+ * @web http://www.seeedstudio.com/wiki/Grove_-_Tempture%26Humidity_Sensor_(High-Accuracy_%26Mini)_v1.0
+ * @con i2c
+ *
+ * @brief C++ API for th02 temperature & humidity sensor library
+ * 
+ *   This file defines the TH02 C++ interface for libth02
+ *
+ * @snippet th02.cxx Interesting
+ */
 class TH02 {
     public:
         /**

--- a/src/tm1637/tm1637.h
+++ b/src/tm1637/tm1637.h
@@ -45,20 +45,26 @@
 #define LOW                 0
 
 namespace upm {
-
-/**
- * @brief tm1637 7-segment screen library
- * @defgroup tm1637 libupm-tm1637
- */
-
-/**
+ /**
  * @brief C++ API for Seven segments screen
  *
- * This file defines the TM1637 C++ interface for lib4digitdisplay
+ *   This file defines the TM1637 C++ interface for lib4digitdisplay
  *
- * @ingroup tm1637 gpio
- * @snippet tm1637.cxx Interesting
+ * @defgroup tm1637 libupm-tm1637
+ * @ingroup seeed gpio display
+ */
+/**
+ * @library tm1637
+ * @sensor tm1637
+ * @comname Seven segment screen display
+ * @type display
+ * @man seeed
+ * @web http://www.seeedstudio.com/wiki/Grove_-_4-Digit_Display
+ * @con gpio
  *
+ * @brief C++ API for Seven segments screen
+ * 
+ *   This file defines the TM1637 C++ interface for lib4digitdisplay
  *      A
  *     ---
  *  F |   | B
@@ -67,6 +73,7 @@ namespace upm {
  *     ---
  *      D
  *
+ * @snippet tm1637.cxx Interesting
  */
 class TM1637 {
     public:

--- a/src/tsl2561/tsl2561.h
+++ b/src/tsl2561/tsl2561.h
@@ -91,22 +91,35 @@ namespace upm {
 #define LUX_B8C           (0x0000)  // 0.000 * 2^LUX_SCALE
 #define LUX_M8C           (0x0000)  // 0.000 * 2^LUX_SCALE
 
-/**
+ /**
  * @brief TSL2561 Digital Light Sensor library
+ *
+ *   The LIGHT-TO-DIGITAL CONVERTER [TAOS-TSL2561]
+ *   (http://www.adafruit.com/datasheets/TSL2561.pdf)
+ *   The TSL2560 and TSL2561 are light-to-digital converters that transform
+ *   light intensity to a digital signal output capable of direct I2C (TSL2561)
+ *
  * @defgroup tsl2561 libupm-tsl2561
+ * @ingroup seeed i2c light
  */
-
 /**
- * @brief C++ API for TSL2561 chip (Digital Light Sensor library)
+ * @library tsl2561
+ * @sensor tsl2561
+ * @comname Light sensor
+ * @type light
+ * @man seeed
+ * @web http://www.seeedstudio.com/wiki/Grove_-_Digital_Light_Sensor
+ * @con i2c
  *
- * The LIGHT-TO-DIGITAL CONVERTER [TAOS-TSL2561]
- * (http://www.adafruit.com/datasheets/TSL2561.pdf)
- * The TSL2560 and TSL2561 are light-to-digital converters that transform light
- * intensity to a digital signal output capable of direct I2C (TSL2561).
+ * @brief TSL2561 Digital Light Sensor library
+ * 
+ *   The LIGHT-TO-DIGITAL CONVERTER [TAOS-TSL2561]
+ *   (http://www.adafruit.com/datasheets/TSL2561.pdf)
+ *   The TSL2560 and TSL2561 are light-to-digital converters that transform
+ *   light intensity to a digital signal output capable of direct I2C (TSL2561)
  *
- * @ingroup tsl2561
- * @snippet tsl2561.cxx Interesting
  * @image html grovetsl2561.jpeg
+ * @snippet tsl2561.cxx Interesting
  */
 class TSL2561{
     public:

--- a/src/ttp223/ttp223.h
+++ b/src/ttp223/ttp223.h
@@ -27,22 +27,33 @@
 #include <mraa/gpio.h>
 
 namespace upm {
-
 /**
  * @brief TTP223 Touch Detector sensor library
+ *
+ *   This touch sensor detects when a finger is near the metallic pad
+ *   by a change in capacitance.  It can replace a more traditional push
+ *   button.  The touch sensor can still function when placed under a 
+ *   non-metallic surface like glass or plastic.
+ *
  * @defgroup ttp223 libupm-ttp223
+ * @ingroup seeed gpio touch
  */
-
 /**
- * @brief C++ API for TTP223 touch detector-based sensors,
- * such as the Grove Touch sensor
+ * @library ttp223
+ * @sensor ttp223
+ * @comname Touch sensor
+ * @type touch
+ * @man seeed
+ * @web http://www.seeedstudio.com/depot/Grove-Touch-Sensor-p-747.html
+ * @con gpio
  *
- * This touch sensor detects when a finger is near the metallic pad
- * by a change in capacitance.  It can replace a more traditional push
- * button.  The touch sensor can still function when placed under a 
- * non-metallic surface like glass or plastic.
+ * @brief TTP223 Touch Detector sensor library
+ * 
+ *   This touch sensor detects when a finger is near the metallic pad
+ *   by a change in capacitance.  It can replace a more traditional push
+ *   button.  The touch sensor can still function when placed under a 
+ *   non-metallic surface like glass or plastic.
  *
- * @ingroup ttp223 gpio
  * @snippet ttp223.cxx Interesting
  */
 class TTP223 {

--- a/src/ublox6/ublox6.h
+++ b/src/ublox6/ublox6.h
@@ -43,15 +43,29 @@
 const int  UBLOX6_DEFAULT_UART = 0;
 
 namespace upm {
-
-  /**
-   * @brief C++ API for the U-BLOX 6 GPS module
-   *
-   * UPM support for the U-BLOX 6 GPS Module
-   *
-   * @ingroup grove uart
-   * @snippet ublox6.cxx Interesting
-   */
+    /**
+     * @brief C++ API for the U-BLOX 6 GPS module
+     *
+     *   UPM support for the U-BLOX 6 GPS Module
+     *
+     * @defgroup ublox6 libupm-ublox6
+     * @ingroup seeed uart gps
+     */
+    /**
+     * @library ublox6
+     * @sensor ublox6
+     * @comname GPS module
+     * @type gps
+     * @man seeed
+     * @web http://www.seeedstudio.com/depot/Grove-GPS-p-959.html
+     * @con uart
+     *
+     * @brief C++ API for the U-BLOX 6 GPS module
+     * 
+     *   UPM support for the U-BLOX 6 GPS Module
+     *
+     * @snippet ublox6.cxx Interesting
+     */
   class Ublox6 {
   public:
     /**

--- a/src/wt5001/wt5001.h
+++ b/src/wt5001/wt5001.h
@@ -48,16 +48,31 @@ const uint8_t WT5001_START = 0x7e;
 const uint8_t WT5001_END   = 0x7e;
 
 namespace upm {
-
-  /**
-   * @brief C++ API for the WT5001 Serial MP3 module
-   *
-   * UPM support for the WT5001 Serial MP3 Module.  This was tested
-   * specifically with the Grove Serial MP3 module.
-   *
-   * @ingroup grove uart
-   * @snippet wt5001.cxx Interesting
-   */
+    /**
+     * @brief C++ API for the WT5001 Serial MP3 module
+     *
+     *   UPM support for the WT5001 Serial MP3 Module.  This was tested
+     *   specifically with the Grove Serial MP3 module.
+     *
+     * @defgroup wt5001 libupm-wt5001
+     * @ingroup seeed uart sound
+     */
+    /**
+     * @library wt5001
+     * @sensor wt5001
+     * @comname Serial MP3 Module
+     * @type sound
+     * @man seeed
+     * @web http://www.seeedstudio.com/wiki/Grove_%E2%80%93_Serial_MP3_Player
+     * @con uart
+     *
+     * @brief C++ API for the WT5001 Serial MP3 module
+     * 
+     *   UPM support for the WT5001 Serial MP3 Module.  This was tested
+     *   specifically with the Grove Serial MP3 module.
+     *
+     * @snippet wt5001.cxx Interesting
+     */
   class WT5001 {
   public:
 

--- a/src/yg1006/yg1006.h
+++ b/src/yg1006/yg1006.h
@@ -27,16 +27,31 @@
 #include <mraa/gpio.h>
 
 namespace upm {
-
-  /**
-   * @brief C++ API for the YG1006 flame sensor
-   *
-   * UPM module for the YG1006 flame sensor.  It detects flame or any
-   * other light in the 760nm - 1100nm wavelength range.
-   *
-   * @ingroup gpio
-   * @snippet yg1006.cxx Interesting
-   */
+    /**
+     * @brief Library for the YG1006 flame sensor
+     *
+     *   UPM module for the YG1006 flame sensor.  It detects flame or any
+     *   other light in the 760nm - 1100nm wavelength range.
+     *
+     * @defgroup yg1006 libupm-yg1006
+     * @ingroup seeed gpio light
+     */
+    /**
+     * @library yg1006
+     * @sensor yg1006
+     * @comname flame sensor
+     * @type light
+     * @man seeed
+     * @web http://www.seeedstudio.com/wiki/Grove_-_Flame_Sensor
+     * @con gpio
+     *
+     * @brief C++ API for the YG1006 flame sensor
+     * 
+     *   UPM module for the YG1006 flame sensor.  It detects flame or any
+     *   other light in the 760nm - 1100nm wavelength range.
+     *
+     * @snippet yg1006.cxx Interesting
+     */
   class YG1006 {
   public:
     /**


### PR DESCRIPTION
Adding doxygen tags to the following 12 sensor header files: yg1006, wt5001, ublox6, ttp223, tsl2561, tm1637, th02, tcs3414cs, ta12200, stepmotor, st7735, and sm130.
