### PR TITLE
th02: fix non-working driver

### DIFF
--- a/examples/c++/th02.cxx
+++ b/examples/c++/th02.cxx
@@ -50,7 +50,7 @@ main(int argc, char **argv)
 
     while (!doWork) {
         temperature = sensor->getTemperature ();
-        // humidity = sensor->getHumidity ();
+        humidity = sensor->getHumidity ();
         std::cout << "Temperature = " << temperature << ", Humidity = " << humidity << std::endl;
         usleep (500000);
     }

--- a/src/th02/th02.cxx
+++ b/src/th02/th02.cxx
@@ -1,5 +1,6 @@
 /*
  * Author: Yevgeniy Kiveisha <yevgeniy.kiveisha@intel.com>
+ * Contributions: Jon Trulson <jtlulson@ics.com>
  * Copyright (c) 2014 Intel Corporation.
  *
  * Credits to Seeed Studeo.
@@ -30,6 +31,7 @@
 
 #include "th02.h"
 
+using namespace std;
 using namespace upm;
 
 struct TH02Exception : public std::exception {
@@ -39,122 +41,68 @@ struct TH02Exception : public std::exception {
     const char* what() const throw () { return message.c_str(); }
 };
 
-TH02::TH02 () {
+TH02::TH02 (int bus, uint8_t addr) : m_i2c(bus) {
+    m_addr = addr;
     m_name = "TH02";
-    m_i2Ctx = mraa_i2c_init(0);
 
-    mraa_result_t ret = mraa_i2c_address(m_i2Ctx, ADDR);
+    mraa_result_t ret = m_i2c.address(m_addr);
     if (ret != MRAA_SUCCESS) {
         throw TH02Exception ("Couldn't initilize I2C.");
     }
 }
 
 TH02::~TH02 () {
-    mraa_i2c_stop(m_i2Ctx);
 }
 
 float
 TH02::getTemperature () {
-    uint8_t buffer[3];
     uint16_t temperature = 0;
 
     /* Start a new temperature conversion */
-    i2cWriteReg (REG_CONFIG, CMD_MEASURE_TEMP);
+    if (m_i2c.writeReg(TH02_REG_CONFIG, TH02_CMD_MEASURE_TEMP)) {
+        cerr << __FUNCTION__ << "@" << __LINE__ 
+             << ": writeReg failed" << endl;
+        return 0.0;
+    }
 
     /* Wait until conversion is done */
     while (getStatus() == false);
 
-    if (i2cReadReg_N (REG_DATA_H, 3, buffer) > 2) {
-        temperature = (buffer[1] << 8) | buffer[2];
-        temperature >>= 2;
+    temperature = m_i2c.readReg(TH02_REG_DATA_H) << 8;
+    temperature |= m_i2c.readReg(TH02_REG_DATA_L);
+    temperature >>= 2;
 
-        return (temperature / 32.0) - 50.0;
-    }
-
-    return 0.0;
+    return ((float(temperature) / 32.0) - 50.0);
 }
 
 float
 TH02::getHumidity () {
-    uint8_t buffer[3];
     uint16_t humidity = 0;
 
-    /* Start a new humility conversion */
-    i2cWriteReg (REG_CONFIG, CMD_MEASURE_HUMI);
+    /* Start a new humidity conversion */
+    if (m_i2c.writeReg(TH02_REG_CONFIG, TH02_CMD_MEASURE_HUMI)) {
+        cerr << __FUNCTION__ << "@" << __LINE__ 
+             << ": writeReg failed" << endl;
+        return 0.0;
+    }
 
     /* Wait until conversion is done */
     while (getStatus() == false);
 
-    if (i2cReadReg_N (REG_DATA_H, 3, buffer) > 2) {
-        humidity = (buffer[1] << 8) | buffer[2];
-        humidity >>= 4;
+    humidity = m_i2c.readReg(TH02_REG_DATA_H) << 8;
+    humidity |= m_i2c.readReg(TH02_REG_DATA_L);
+    humidity >>= 4;
 
-        return (humidity / 16.0) - 24.0;
-    }
-
-    return 0.0;
+    return ((float(humidity) / 16.0) - 24.0);
 }
 
 bool
 TH02::getStatus () {
-    uint8_t buffer[1];
+    uint8_t status = m_i2c.readReg(TH02_REG_STATUS);
 
-    if (i2cReadReg_N (REG_STATUS, 1, buffer) > 0) {
-        if (buffer[0] & STATUS_RDY_MASK) {
-            return true;    // ready
-        }
-    }
-
-    return false;
+    if (status & TH02_STATUS_RDY_MASK)
+        return false;           // NOT ready
+    else
+        return true;            // ready
 }
 
-/*
- * **************
- *  private area
- * **************
- */
-uint16_t
-TH02::i2cReadReg_N (int reg, unsigned int len, uint8_t * buffer) {
-    int readByte = 0;
-
-    if (m_i2Ctx == NULL) {
-        throw TH02Exception ("Couldn't find initilized I2C.");
-    }
-
-    mraa_i2c_address(m_i2Ctx, ADDR);
-    mraa_i2c_write_byte(m_i2Ctx, reg);
-
-    mraa_i2c_address(m_i2Ctx, ADDR);
-    readByte = mraa_i2c_read(m_i2Ctx, buffer, len);
-    return readByte;
-}
-
-mraa_result_t
-TH02::i2cWriteReg_N (uint8_t reg, unsigned int len, uint8_t * buffer) {
-    mraa_result_t error = MRAA_SUCCESS;
-
-    if (m_i2Ctx == NULL) {
-        throw TH02Exception ("Couldn't find initilized I2C.");
-    }
-
-    error = mraa_i2c_address (m_i2Ctx, ADDR);
-    error = mraa_i2c_write_byte (m_i2Ctx, reg);
-    error = mraa_i2c_write (m_i2Ctx, buffer, len);
-
-    return error;
-}
-
-mraa_result_t
-TH02::i2cWriteReg (uint8_t reg, uint8_t data) {
-    mraa_result_t error = MRAA_SUCCESS;
-
-    if (m_i2Ctx == NULL) {
-        throw TH02Exception ("Couldn't find initilized I2C.");
-    }
-
-    error = mraa_i2c_address (m_i2Ctx, ADDR);
-    error = mraa_i2c_write_byte (m_i2Ctx, reg);
-    error = mraa_i2c_write_byte (m_i2Ctx, data);
-
-    return error;
-}

--- a/src/th02/th02.h
+++ b/src/th02/th02.h
@@ -1,5 +1,6 @@
 /*
  * Author: Yevgeniy Kiveisha <yevgeniy.kiveisha@intel.com>
+ * Contributions: Jon Trulson <jtlulson@ics.com>
  * Copyright (c) 2014 Intel Corporation.
  *
  * Credits to Seeed Studeo.
@@ -26,26 +27,20 @@
 #pragma once
 
 #include <string>
-#include <mraa/i2c.h>
+#include <mraa/i2c.hpp>
 
-#define ADDR                0x40 // device address
+#define TH02_ADDR                0x40 // device address
 
-#define REG_STATUS          0x00
-#define REG_DATA_H          0x01
-#define REG_DATA_L          0x02
-#define REG_CONFIG          0x03
-#define REG_ID              0x11
+#define TH02_REG_STATUS          0x00
+#define TH02_REG_DATA_H          0x01
+#define TH02_REG_DATA_L          0x02
+#define TH02_REG_CONFIG          0x03
+#define TH02_REG_ID              0x11
 
-#define STATUS_RDY_MASK     0x01
+#define TH02_STATUS_RDY_MASK     0x01
 
-#define CMD_MEASURE_HUMI    0x01
-#define CMD_MEASURE_TEMP    0x11
-
-#define TH02_WR_REG_MODE    0xC0
-#define TH02_RD_REG_MODE    0x80
-
-#define HIGH                1
-#define LOW                 0
+#define TH02_CMD_MEASURE_HUMI    0x01
+#define TH02_CMD_MEASURE_TEMP    0x11
 
 namespace upm {
 
@@ -68,7 +63,10 @@ namespace upm {
  *
  * @brief C++ API for th02 temperature & humidity sensor library
  * 
- *   This file defines the TH02 C++ interface for libth02
+ *   This file defines the TH02 C++ interface for libth02 
+ *
+ *   NOTE: For use on the Edison with the arduino breakout board, the
+ *   Edison must be set to 3v rather than 5v.
  *
  * @snippet th02.cxx Interesting
  */
@@ -77,7 +75,7 @@ class TH02 {
         /**
          * Instanciates a TH02 object
          */
-        TH02 ();
+        TH02 (int bus=0, uint8_t addr=TH02_ADDR);
 
         /**
          * TH02 object destructor, basicaly it close i2c connection.
@@ -106,13 +104,11 @@ class TH02 {
         {
             return m_name;
         }
+
     private:
         std::string m_name;
-        mraa_i2c_context m_i2Ctx;
-
-        uint16_t i2cReadReg_N (int reg, unsigned int len, uint8_t * buffer);
-        mraa_result_t i2cWriteReg_N (uint8_t reg, unsigned int len, uint8_t * buffer);
-        mraa_result_t i2cWriteReg (uint8_t reg, uint8_t data);
+        mraa::I2c m_i2c;
+        uint8_t m_addr;
 };
 
 }


### PR DESCRIPTION
There were a few issues with this driver, corrected in this update.

1) i2c transactions were not working - I replaced the i2c
implementation with the MRAA i2c class implementation.

2) status check was inverted - fixed.

3) fixed up #defines in header file to avoid naming collisions (ADDR,
etc).

4) Added capability to supply bus and i2c address to ctor, setting
defaults of 0, and TH02_ADDR respectively.

NOTE: For proper operation on Edison using the arduino breakout
board, the voltage needs to be set to 3.3V rather than 5v.  On G2, 5v
works fine.

Signed-off-by: Jon Trulson <jtrulson@ics.com>