### PR TITLE
Pull fixup uart for mraa7 changes

### DIFF
--- a/src/grovescam/grovescam.cxx
+++ b/src/grovescam/grovescam.cxx
@@ -50,7 +50,7 @@ GROVESCAM::GROVESCAM(int uart, uint8_t camAddr)
     }
 
   // This requires a recent MRAA (1/2015)
-  char *devPath = mraa_uart_get_dev_path(m_uart);
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
 
   if (!devPath)
     {

--- a/src/hm11/hm11.cxx
+++ b/src/hm11/hm11.cxx
@@ -42,7 +42,7 @@ HM11::HM11(int uart)
     }
 
   // This requires a recent MRAA (1/2015)
-  char *devPath = mraa_uart_get_dev_path(m_uart);
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
 
   if (!devPath)
     {

--- a/src/hmtrp/hmtrp.cxx
+++ b/src/hmtrp/hmtrp.cxx
@@ -46,7 +46,7 @@ HMTRP::HMTRP(int uart)
     }
 
   // This requires a recent MRAA (1/2015)
-  char *devPath = mraa_uart_get_dev_path(m_uart);
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
 
   if (!devPath)
     {

--- a/src/mhz16/mhz16.cxx
+++ b/src/mhz16/mhz16.cxx
@@ -42,7 +42,7 @@ MHZ16::MHZ16(int uart)
     }
 
   // This requires a recent MRAA (1/2015)
-  char *devPath = mraa_uart_get_dev_path(m_uart);
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
 
   if (!devPath)
     {

--- a/src/ublox6/ublox6.cxx
+++ b/src/ublox6/ublox6.cxx
@@ -40,7 +40,7 @@ Ublox6::Ublox6(int uart)
     }
 
   // This requires a recent MRAA (1/2015)
-  char *devPath = mraa_uart_get_dev_path(m_uart);
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
 
   if (!devPath)
     {

--- a/src/wt5001/wt5001.cxx
+++ b/src/wt5001/wt5001.cxx
@@ -42,7 +42,7 @@ WT5001::WT5001(int uart)
     }
 
   // This requires a recent MRAA (1/2015)
-  char *devPath = mraa_uart_get_dev_path(m_uart);
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
 
   if (!devPath)
     {

--- a/src/zfm20/zfm20.cxx
+++ b/src/zfm20/zfm20.cxx
@@ -42,7 +42,7 @@ ZFM20::ZFM20(int uart)
     }
 
   // This requires a recent MRAA (1/2015)
-  char *devPath = mraa_uart_get_dev_path(m_uart);
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
 
   if (!devPath)
     {


### PR DESCRIPTION
A 'const' was added to the prototype declaration for mraa_uart_get_dev_path() in MRAA v7.  This causes all of the current UPM uart-based drivers to fail to build.

These patches fix up those issues, and UPM now builds with MRAA v7.