### PR TITLE
cmake: Change error message when git not found to say UPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include(GNUInstallDirs)
 include (GetGitRevisionDescription)
 git_describe (VERSION "--tags")
 if ("x_${VERSION}" STREQUAL "x_GIT-NOTFOUND")
-  message (WARNING " - Install git to compile a production libmraa!")
+  message (WARNING " - Install git to compile a production UPM!")
   set (VERSION "v0.3.1-dirty")
 endif ()
 


### PR DESCRIPTION
Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>