### PR TITLE
hcsr04: Fixed compilation error after MRAA enum renaming

### DIFF
--- a/src/hcsr04/hcsr04.cxx
+++ b/src/hcsr04/hcsr04.cxx
@@ -49,8 +49,7 @@ HCSR04::HCSR04 (uint8_t triggerPin, uint8_t echoPin, void (*fptr)(void *)) {
     }
 
     mraa_gpio_dir(m_echoPinCtx, MRAA_GPIO_IN);
-    gpio_edge_t edge = MRAA_GPIO_EDGE_BOTH;
-    mraa_gpio_isr (m_echoPinCtx, edge, fptr, NULL);
+    mraa_gpio_isr(m_echoPinCtx, MRAA_GPIO_EDGE_BOTH, fptr, NULL);
 }
 
 HCSR04::~HCSR04 () {


### PR DESCRIPTION
Closes #214.

It also closes #215, which is a duplicate of #214.

Signed-off-by: Alex Tereschenko <alext.mkrs@gmail.com>