### PR TITLE
Pull lcd 1602 and rgb lcd (jhd1313m1) enhancments

### DIFF
--- a/examples/c++/jhd1313m1-lcd.cxx
+++ b/examples/c++/jhd1313m1-lcd.cxx
@@ -34,6 +34,9 @@ main(int argc, char **argv)
     lcd->write("Hello World");
     lcd->setCursor(1,2);
     lcd->write("Hello World");
+
+    printf("Sleeping for 5 seconds\n");
+    sleep(5);
     delete lcd;
 //! [Interesting]
     return 0;

--- a/src/lcd/jhd1313m1.h
+++ b/src/lcd/jhd1313m1.h
@@ -2,6 +2,8 @@
  * Author: Yevgeniy Kiveisha <yevgeniy.kiveisha@intel.com>
  * Copyright (c) 2014 Intel Corporation.
  *
+ * Contributions: Jon Trulson <jtrulson@ics.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -24,8 +26,7 @@
 #pragma once
 
 #include <string>
-#include <mraa/i2c.hpp>
-#include "lcd.h"
+#include "lcm1602.h"
 
 namespace upm
 {
@@ -51,7 +52,7 @@ namespace upm
  * @image html grovergblcd.jpg
  * @snippet jhd1313m1-lcd.cxx Interesting
  */
-class Jhd1313m1 : public LCD
+class Jhd1313m1 : public Lcm1602
 {
   public:
     /**
@@ -82,48 +83,13 @@ class Jhd1313m1 : public LCD
      * @return Result of operation
      */
     mraa_result_t setColor(uint8_t r, uint8_t g, uint8_t b);
-    /**
-     * Write a string to LCD
-     *
-     * @param msg The std::string to write to display, note only ascii
-     *     chars are supported
-     * @return Result of operation
-     */
-    mraa_result_t write(std::string msg);
-    /**
-     * Set cursor to a coordinate
-     *
-     * @param row The row to set cursor to
-     * @param column The column to set cursor to
-     * @return Result of operation
-     */
-    mraa_result_t setCursor(int row, int column);
-    /**
-     * Clear display from characters
-     *
-     * @return Result of operatio
-     */
-    mraa_result_t clear();
-    /**
-     * Return to coordinate 0,0
-     *
-     * @return Result of operation
-     */
-    mraa_result_t home();
 
-    /**
-     * Create a custom character
-     *
-     * @param charSlot the character slot to write, only 8 are available
-     * @param charData The character data (8 bytes) making up the character
-     * @return Result of operation
-     */
-    mraa_result_t createChar(uint8_t charSlot, uint8_t charData[]);
+ protected:
+    virtual mraa_result_t command(uint8_t cmd);
+    virtual mraa_result_t data(uint8_t data);
 
   private:
     int m_rgb_address;
     mraa::I2c m_i2c_lcd_rgb;
-    int m_lcd_control_address;
-    mraa::I2c m_i2c_lcd_control;
 };
 }

--- a/src/lcd/jsupm_i2clcd.i
+++ b/src/lcd/jsupm_i2clcd.i
@@ -14,14 +14,14 @@
     #include "lcd.h"
 %}
 
-%include "jhd1313m1.h"
-%{
-    #include "jhd1313m1.h"
-%}
-
 %include "lcm1602.h"
 %{
     #include "lcm1602.h"
+%}
+
+%include "jhd1313m1.h"
+%{
+    #include "jhd1313m1.h"
 %}
 
 %include "ssd1327.h"

--- a/src/lcd/lcm1602.cxx
+++ b/src/lcd/lcm1602.cxx
@@ -55,6 +55,9 @@ Lcm1602::Lcm1602(int bus_in, int addr_in, bool isExpander) :
         return;
     }
 
+    // default display control
+    m_displayControl = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
+
     // if we are not dealing with an expander (say via a derived class
     // like Jhd1313m1), then we do not want to execute the rest of the
     // code below.  Rather, the derived class's constructor should

--- a/src/lcd/lcm1602.cxx
+++ b/src/lcd/lcm1602.cxx
@@ -9,22 +9,25 @@
  *
  * Contributions: Jon Trulson <jtrulson@ics.com>
  * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 #include <string>
@@ -66,13 +69,15 @@ Lcm1602::Lcm1602(int bus_in, int addr_in) :
     // Put into 4 bit mode
     write4bits(0x20);
 
+    m_displayControl = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
     // Set numeber of lines
     send(LCD_FUNCTIONSET | 0x0f, 0);
-    send(LCD_DISPLAYCONTROL | LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF, 0);
+    send(LCD_DISPLAYCONTROL | m_displayControl, 0);
     clear();
 
     // Set entry mode.
-    send(LCD_ENTRYMODESET | LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT, 0);
+    m_entryDisplayMode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
+    send(LCD_ENTRYMODESET | m_entryDisplayMode, 0);
 
     home();
 }
@@ -127,12 +132,14 @@ Lcm1602::Lcm1602(uint8_t rs,  uint8_t enable, uint8_t d0,
 
     // Set number of lines
     send(LCD_FUNCTIONSET | LCD_2LINE | LCD_4BITMODE | LCD_5x8DOTS, 0);
-    send(LCD_DISPLAYCONTROL | LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF, 0);
+    m_displayControl = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
+    send(LCD_DISPLAYCONTROL | m_displayControl, 0);
     usleep(2000);
     clear();
 
     // Set entry mode.
-    send(LCD_ENTRYMODESET | LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT, 0);
+    m_entryDisplayMode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
+    send(LCD_ENTRYMODESET | m_entryDisplayMode, 0);
 
     home();
 }
@@ -214,6 +221,77 @@ Lcm1602::createChar(uint8_t charSlot, uint8_t charData[])
 
     return error;
 }
+
+void Lcm1602::displayOn()
+{
+  m_displayControl |= LCD_DISPLAYON;
+  send(LCD_DISPLAYCONTROL | m_displayControl, 0);
+}
+
+void Lcm1602::displayOff()
+{
+  m_displayControl &= ~LCD_DISPLAYON;
+  send(LCD_DISPLAYCONTROL | m_displayControl, 0);
+}
+
+void Lcm1602::cursorOn()
+{
+  m_displayControl |= LCD_CURSORON;
+  send(LCD_DISPLAYCONTROL | m_displayControl, 0);
+}
+
+void Lcm1602::cursorOff()
+{
+  m_displayControl &= ~LCD_CURSORON;
+  send(LCD_DISPLAYCONTROL | m_displayControl, 0);
+}
+
+void Lcm1602::cursorBlinkOn()
+{
+  m_displayControl |= LCD_BLINKON;
+  send(LCD_DISPLAYCONTROL | m_displayControl, 0);
+}
+
+void Lcm1602::cursorBlinkOff()
+{
+  m_displayControl &= ~LCD_BLINKON;
+  send(LCD_DISPLAYCONTROL | m_displayControl, 0);
+}
+
+void Lcm1602::scrollDisplayLeft()
+{
+  send(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT, 0);
+}
+
+void Lcm1602::scrollDisplayRight()
+{
+  send(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT, 0);
+}
+
+void Lcm1602::entryLeftToRight()
+{
+  m_entryDisplayMode |= LCD_ENTRYLEFT;
+  send(LCD_ENTRYMODESET | m_entryDisplayMode, 0);
+}
+
+void Lcm1602::entryRightToLeft()
+{
+  m_entryDisplayMode &= ~LCD_ENTRYLEFT;
+  send(LCD_ENTRYMODESET | m_entryDisplayMode, 0);
+}
+
+void Lcm1602::autoscrollOn()
+{
+  m_entryDisplayMode |= LCD_ENTRYSHIFTINCREMENT;
+  send(LCD_ENTRYMODESET | m_entryDisplayMode, 0);
+}
+
+void Lcm1602::autoscrollOff()
+{
+  m_entryDisplayMode &= ~LCD_ENTRYSHIFTINCREMENT;
+  send(LCD_ENTRYMODESET | m_entryDisplayMode, 0);
+}
+
 
 /*
  * **************

--- a/src/lcd/lcm1602.h
+++ b/src/lcd/lcm1602.h
@@ -230,9 +230,10 @@ class Lcm1602 : public LCD
     virtual mraa_result_t command(uint8_t cmd);
     virtual mraa_result_t data(uint8_t data);
 
-  private:
     int m_lcd_control_address;
     mraa::I2c* m_i2c_lcd_control;
+
+  private:
 
     // true if using i2c, false otherwise (gpio)
     bool m_isI2C;

--- a/src/lcd/lcm1602.h
+++ b/src/lcd/lcm1602.h
@@ -67,8 +67,10 @@ class Lcm1602 : public LCD
      *
      * @param bus i2c bus to use
      * @param address the slave address the lcd is registered on
+     * @param isExpander true if we are dealing with an I2C expander,
+     * false otherwise.  Default is true.
      */
-    Lcm1602(int bus, int address);
+  Lcm1602(int bus, int address, bool isExpander=true);
 
     /**
      * Lcm1602 alternate constructor, used for GPIO based hd44780
@@ -108,7 +110,7 @@ class Lcm1602 : public LCD
     /**
      * Clear display from characters
      *
-     * @return Result of operatio
+     * @return Result of operation
      */
     mraa_result_t clear();
     /**
@@ -130,74 +132,86 @@ class Lcm1602 : public LCD
     /**
      * Turn the display on
      *
+     * @return Result of operation
      */
-    void displayOn();
+    mraa_result_t displayOn();
 
     /**
      * Turn the display off
      *
+     * @return Result of operation
      */
-    void displayOff();
+    mraa_result_t displayOff();
 
     /**
      * Turn the cursor on
      *
+     * @return Result of operation
      */
-    void cursorOn();
+    mraa_result_t cursorOn();
 
     /**
      * Turn the cursor off
      *
+     * @return Result of operation
      */
-    void cursorOff();
+    mraa_result_t cursorOff();
 
     /**
      * Turn cursor blink on
      *
+     * @return Result of operation
      */
-    void cursorBlinkOn();
+    mraa_result_t cursorBlinkOn();
 
     /**
      * Turn cursor blink off
      *
+     * @return Result of operation
      */
-    void cursorBlinkOff();
+    mraa_result_t cursorBlinkOff();
 
     /**
      * Scroll the display left, without changing the character RAM
      *
+     * @return Result of operation
      */
-    void scrollDisplayLeft();
+    mraa_result_t scrollDisplayLeft();
 
     /**
      * Scroll the display right, without changing the character RAM
      *
+     * @return Result of operation
      */
-    void scrollDisplayRight();
+    mraa_result_t scrollDisplayRight();
 
     /**
      * set the entry mode so that characters are added left to right
      *
+     * @return Result of operation
      */
-    void entryLeftToRight();
+    mraa_result_t entryLeftToRight();
 
     /**
      * set the entry mode so that characters are added right to left
      *
+     * @return Result of operation
      */
-    void entryRightToLeft();
+    mraa_result_t entryRightToLeft();
 
     /**
      * Right justify text entered from the cursor
      *
+     * @return Result of operation
      */
-    void autoscrollOn();
+    mraa_result_t autoscrollOn();
 
     /**
      * Left justify text entered from the cursor
      *
+     * @return Result of operation
      */
-    void autoscrollOff();
+    mraa_result_t autoscrollOff();
 
 
   protected:
@@ -205,6 +219,16 @@ class Lcm1602 : public LCD
     mraa_result_t write4bits(uint8_t value);
     mraa_result_t expandWrite(uint8_t value);
     mraa_result_t pulseEnable(uint8_t value);
+
+    uint8_t m_displayControl;
+    uint8_t m_entryDisplayMode;
+
+    // Add a command() and data() virtual member functions, with a
+    // default implementation in lcm1602.  This is expected to be
+    // implemented by derived classes with different needs (Jhd1313m1,
+    // for example).
+    virtual mraa_result_t command(uint8_t cmd);
+    virtual mraa_result_t data(uint8_t data);
 
   private:
     int m_lcd_control_address;
@@ -220,9 +244,5 @@ class Lcm1602 : public LCD
     mraa::Gpio* m_gpioD1;
     mraa::Gpio* m_gpioD2;
     mraa::Gpio* m_gpioD3;
-
-    uint8_t m_displayControl;
-    uint8_t m_entryDisplayMode;
-
 };
 }

--- a/src/lcd/lcm1602.h
+++ b/src/lcd/lcm1602.h
@@ -9,22 +9,25 @@
  *
  * Contributions: Jon Trulson <jtrulson@ics.com>
  *
- * Permission is hereby granted, free of uint8_tge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
+ * Permission is hereby granted, free of uint8_tge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 #pragma once
@@ -124,6 +127,79 @@ class Lcm1602 : public LCD
      */
     mraa_result_t createChar(uint8_t charSlot, uint8_t charData[]);
 
+    /**
+     * Turn the display on
+     *
+     */
+    void displayOn();
+
+    /**
+     * Turn the display off
+     *
+     */
+    void displayOff();
+
+    /**
+     * Turn the cursor on
+     *
+     */
+    void cursorOn();
+
+    /**
+     * Turn the cursor off
+     *
+     */
+    void cursorOff();
+
+    /**
+     * Turn cursor blink on
+     *
+     */
+    void cursorBlinkOn();
+
+    /**
+     * Turn cursor blink off
+     *
+     */
+    void cursorBlinkOff();
+
+    /**
+     * Scroll the display left, without changing the character RAM
+     *
+     */
+    void scrollDisplayLeft();
+
+    /**
+     * Scroll the display right, without changing the character RAM
+     *
+     */
+    void scrollDisplayRight();
+
+    /**
+     * set the entry mode so that characters are added left to right
+     *
+     */
+    void entryLeftToRight();
+
+    /**
+     * set the entry mode so that characters are added right to left
+     *
+     */
+    void entryRightToLeft();
+
+    /**
+     * Right justify text entered from the cursor
+     *
+     */
+    void autoscrollOn();
+
+    /**
+     * Left justify text entered from the cursor
+     *
+     */
+    void autoscrollOff();
+
+
   protected:
     mraa_result_t send(uint8_t value, int mode);
     mraa_result_t write4bits(uint8_t value);
@@ -144,5 +220,9 @@ class Lcm1602 : public LCD
     mraa::Gpio* m_gpioD1;
     mraa::Gpio* m_gpioD2;
     mraa::Gpio* m_gpioD3;
+
+    uint8_t m_displayControl;
+    uint8_t m_entryDisplayMode;
+
 };
 }

--- a/src/lcd/pyupm_i2clcd.i
+++ b/src/lcd/pyupm_i2clcd.i
@@ -17,14 +17,14 @@
     #include "lcd.h"
 %}
 
-%include "jhd1313m1.h"
-%{
-    #include "jhd1313m1.h"
-%}
-
 %include "lcm1602.h"
 %{
     #include "lcm1602.h"
+%}
+
+%include "jhd1313m1.h"
+%{
+    #include "jhd1313m1.h"
 %}
 
 %include "ssd1327.h"


### PR DESCRIPTION
These patches add missing functionality to lcm1602, and make modifications so that it can be used as a base class for jhd1313m1 and others (in the future).

In addition, jhd1313m1 is modified to use lcm1602 as a base class (inheriting it's new functionality), and removing duplicate functionality already supported by the lcm1602 base class.

In addition, a sleep(5) is added to the jhd1313m1 example so that you have a chance to see the display, before it's destructor turns it off on exit.

Signed-off-by: Jon Trulson <jtrulson@ics.com>