### PR TITLE
Pull upm exceptions

### DIFF
--- a/src/ecs1030/ecs1030.cxx
+++ b/src/ecs1030/ecs1030.cxx
@@ -25,22 +25,18 @@
 #include <iostream>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string>
+#include <stdexcept>
 
 #include "ecs1030.h"
 
 using namespace upm;
 
-struct ECS1030Exception : public std::exception {
-    std::string message;
-    ECS1030Exception (std::string msg) : message (msg) { }
-    ~ECS1030Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
-
 ECS1030::ECS1030 (uint8_t pinNumber) {
     m_dataPinCtx = mraa_aio_init(pinNumber);
     if (m_dataPinCtx == NULL) {
-        throw ECS1030Exception ("GPIO failed to initilize");
+      throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                  ": mraa_aio_init() failed");
     }
 
     m_calibration = 111.1;

--- a/src/hx711/hx711.cxx
+++ b/src/hx711/hx711.cxx
@@ -24,39 +24,37 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdexcept>
 #include "hx711.h"
 
 using namespace upm;
 using namespace std;
-
-struct HX711Exception : public std::exception {
-    std::string message;
-    HX711Exception (std::string msg) : message (msg) { }
-    ~HX711Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
 
 HX711::HX711(uint8_t data, uint8_t sck, uint8_t gain) {
     mraa_result_t error = MRAA_SUCCESS;
 
     this->m_dataPinCtx = mraa_gpio_init(data);
     if (this->m_dataPinCtx == NULL) {
-        throw HX711Exception ("Couldn't initilize DATA pin.");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": Couldn't initialize DATA pin.");
     }
 
     this->m_sckPinCtx = mraa_gpio_init(sck);
     if (this->m_sckPinCtx == NULL) {
-        throw HX711Exception ("Couldn't initilize CLOCK pin.");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": Couldn't initialize CLOCK pin.");
     }
 
     error = mraa_gpio_dir (this->m_dataPinCtx, MRAA_GPIO_IN);
     if (error != MRAA_SUCCESS) {
-        throw HX711Exception ("Couldn't set direction for DATA pin.");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": Couldn't set direction for DATA pin.");
     }
 
     error = mraa_gpio_dir (this->m_sckPinCtx, MRAA_GPIO_OUT);
     if (error != MRAA_SUCCESS) {
-        throw HX711Exception ("Couldn't set direction for CLOCK pin.");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": Couldn't set direction for CLOCK pin.");
     }
 
     this->setGain(gain);

--- a/src/lpd8806/lpd8806.cxx
+++ b/src/lpd8806/lpd8806.cxx
@@ -26,17 +26,11 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <cstring>
+#include <stdexcept>
 
 #include "lpd8806.h"
 
 using namespace upm;
-
-struct LPD8806Exception : public std::exception {
-    std::string message;
-    LPD8806Exception (std::string msg) : message (msg) { }
-    ~LPD8806Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
 
 LPD8806::LPD8806 (uint16_t pixelCount, uint8_t csn) {
     mraa_result_t error = MRAA_SUCCESS;
@@ -46,19 +40,22 @@ LPD8806::LPD8806 (uint16_t pixelCount, uint8_t csn) {
 
     m_csnPinCtx = mraa_gpio_init (csn);
     if (m_csnPinCtx == NULL) {
-        throw LPD8806Exception ("GPIO failed to initilize");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": GPIO failed to initialize");
     }
 
     error = mraa_gpio_dir (m_csnPinCtx, MRAA_GPIO_OUT);
     if (error != MRAA_SUCCESS) {
-        throw LPD8806Exception ("GPIO failed to initilize");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": GPIO failed to set direction");
     }
 
     CSOff ();
 
     m_spi = mraa_spi_init (0);
     if (m_spi == NULL) {
-        throw LPD8806Exception ("SPI failed to initilize");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": SPI failed to initialize");
     }
 
     // set spi mode to mode2 (CPOL = 0, CPHA = 0)

--- a/src/lsm9ds0/lsm9ds0.cxx
+++ b/src/lsm9ds0/lsm9ds0.cxx
@@ -24,7 +24,7 @@
 
 #include <unistd.h>
 #include <iostream>
-#include <exception>
+#include <stdexcept>
 #include <string.h>
 
 #include "lsm9ds0.h"
@@ -61,9 +61,6 @@ LSM9DS0::LSM9DS0(int bus, uint8_t gAddress, uint8_t xmAddress) :
   mraa_result_t rv;
   if ( (rv = m_i2cG.address(m_gAddr)) != MRAA_SUCCESS)
     {
-      cerr << __FUNCTION__ << ": Could not initialize Gyro i2c address." 
-           << endl;
-      mraa_result_print(rv);
       throw std::runtime_error(string(__FUNCTION__) +
                                ": Could not initialize Gyro i2c address");
       return;
@@ -71,8 +68,6 @@ LSM9DS0::LSM9DS0(int bus, uint8_t gAddress, uint8_t xmAddress) :
 
   if ( (rv = m_i2cXM.address(m_xmAddr)) != MRAA_SUCCESS)
     {
-      cerr << __FUNCTION__ << ": Could not initialize XM i2c address. " << endl;
-      mraa_result_print(rv);
       throw std::runtime_error(string(__FUNCTION__) + 
                                ": Could not initialize XM i2c address");
       return;
@@ -745,7 +740,7 @@ mraa::Gpio*& LSM9DS0::getPin(INTERRUPT_PINS_T intr)
       return m_gpioXM_GEN2;
       break;
     default:
-      throw std::logic_error(string(__FUNCTION__) +
-                             ": Invalid interrupt enum passed");
+      throw std::out_of_range(string(__FUNCTION__) +
+                              ": Invalid interrupt enum passed");
     }
 }

--- a/src/max31723/max31723.cxx
+++ b/src/max31723/max31723.cxx
@@ -25,17 +25,11 @@
 #include <iostream>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdexcept>
 
 #include "max31723.h"
 
 using namespace upm;
-
-struct MAX31723Exception : public std::exception {
-    std::string message;
-    MAX31723Exception (std::string msg) : message (msg) { }
-    ~MAX31723Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
 
 MAX31723::MAX31723 (int csn) {
     mraa_result_t error = MRAA_SUCCESS;
@@ -43,19 +37,22 @@ MAX31723::MAX31723 (int csn) {
 
     m_csnPinCtx = mraa_gpio_init (csn);
     if (m_csnPinCtx == NULL) {
-        throw MAX31723Exception ("GPIO failed to initilize");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_gpio_init() failed");
     }
 
     error = mraa_gpio_dir (m_csnPinCtx, MRAA_GPIO_OUT);
     if (error != MRAA_SUCCESS) {
-        throw MAX31723Exception ("GPIO failed to initilize");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_gpio_dir() failed");
     }
 
     CSOff ();
 
     m_spi = mraa_spi_init (0);
     if (m_spi == NULL) {
-        throw MAX31723Exception ("SPI failed to initilize");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_spi_init() failed");
     }
 
     // set spi mode to mode2 (CPOL = 1, CPHA = 0)

--- a/src/max5487/max5487.cxx
+++ b/src/max5487/max5487.cxx
@@ -25,17 +25,11 @@
 #include <iostream>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdexcept>
 
 #include "max5487.h"
 
 using namespace upm;
-
-struct MAX5487Exception : public std::exception {
-    std::string message;
-    MAX5487Exception (std::string msg) : message (msg) { }
-    ~MAX5487Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
 
 MAX5487::MAX5487 (int csn) {
     mraa_result_t error = MRAA_SUCCESS;
@@ -45,18 +39,21 @@ MAX5487::MAX5487 (int csn) {
     if (csn != -1) {
         m_csnPinCtx = mraa_gpio_init (csn);
         if (m_csnPinCtx == NULL) {
-            throw MAX5487Exception ("GPIO failed to initilize");
+            throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                      ": mraa_gpio_init() failed");
         }
 
         error = mraa_gpio_dir (m_csnPinCtx, MRAA_GPIO_OUT);
         if (error != MRAA_SUCCESS) {
-            throw MAX5487Exception ("GPIO failed to initilize");
+            throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                        ": mraa_gpio_dir() failed");
         }
     }
 
     m_spi = mraa_spi_init (0);
     if (m_spi == NULL) {
-        throw MAX5487Exception ("SPI failed to initilize");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_spi_init() failed");
     }
 
     CSOff ();

--- a/src/maxds3231m/maxds3231m.cxx
+++ b/src/maxds3231m/maxds3231m.cxx
@@ -25,17 +25,11 @@
 #include <iostream>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdexcept>
 
 #include "maxds3231m.h"
 
 using namespace upm;
-
-struct DS3231Exception : public std::exception {
-    std::string message;
-    DS3231Exception (std::string msg) : message (msg) { }
-    ~DS3231Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
 
 MAXDS3231M::MAXDS3231M (int bus, int devAddr) {
     m_name = "MAXDS3231M";
@@ -43,11 +37,16 @@ MAXDS3231M::MAXDS3231M (int bus, int devAddr) {
     m_i2cAddr = devAddr;
     m_bus = bus;
 
-    m_i2Ctx = mraa_i2c_init(m_bus);
+    if (!(m_i2Ctx = mraa_i2c_init(m_bus)))
+      {
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_i2c_init() failed");
+      }
 
     mraa_result_t ret = mraa_i2c_address(m_i2Ctx, m_i2cAddr);
     if (ret != MRAA_SUCCESS) {
-        throw DS3231Exception ("Couldn't initilize I2C.");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_i2c_address() failed");
     }
 }
 
@@ -109,10 +108,6 @@ uint16_t
 MAXDS3231M::i2cReadReg_N (int reg, unsigned int len, uint8_t * buffer) {
     int readByte = 0;
 
-    if (m_i2Ctx == NULL) {
-        throw DS3231Exception ("Couldn't find initilized I2C.");
-    }
-
     mraa_i2c_address(m_i2Ctx, m_i2cAddr);
     mraa_i2c_write_byte(m_i2Ctx, reg);
 
@@ -124,10 +119,6 @@ MAXDS3231M::i2cReadReg_N (int reg, unsigned int len, uint8_t * buffer) {
 mraa_result_t
 MAXDS3231M::i2cWriteReg_N (uint8_t reg, unsigned int len, uint8_t * buffer) {
     mraa_result_t error = MRAA_SUCCESS;
-
-    if (m_i2Ctx == NULL) {
-        throw DS3231Exception ("Couldn't find initilized I2C.");
-    }
 
     error = mraa_i2c_address (m_i2Ctx, m_i2cAddr);
     error = mraa_i2c_write (m_i2Ctx, buffer, len);

--- a/src/mlx90614/mlx90614.cxx
+++ b/src/mlx90614/mlx90614.cxx
@@ -25,17 +25,11 @@
 #include <iostream>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdexcept>
 
 #include "mlx90614.h"
 
 using namespace upm;
-
-struct MLX90614Exception : public std::exception {
-    std::string message;
-    MLX90614Exception (std::string msg) : message (msg) { }
-    ~MLX90614Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
 
 MLX90614::MLX90614 (int bus, int devAddr) {
     m_name = "MLX90614";
@@ -43,11 +37,16 @@ MLX90614::MLX90614 (int bus, int devAddr) {
     m_i2cAddr = devAddr;
     m_bus = bus;
 
-    m_i2Ctx = mraa_i2c_init(m_bus);
+    if (!(m_i2Ctx = mraa_i2c_init(m_bus)))
+      {
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_i2c_init() failed");
+      }
 
     mraa_result_t ret = mraa_i2c_address(m_i2Ctx, m_i2cAddr);
     if (ret != MRAA_SUCCESS) {
-        throw MLX90614Exception ("Couldn't initilize I2C.");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_i2c_address() failed");
     }
 }
 
@@ -84,10 +83,6 @@ uint16_t
 MLX90614::i2cReadReg_N (int reg, unsigned int len, uint8_t * buffer) {
     int readByte = 0;
 
-    if (m_i2Ctx == NULL) {
-        throw MLX90614Exception ("Couldn't find initilized I2C.");
-    }
-
     mraa_i2c_address(m_i2Ctx, m_i2cAddr);
     mraa_i2c_write_byte(m_i2Ctx, reg);
 
@@ -98,10 +93,6 @@ MLX90614::i2cReadReg_N (int reg, unsigned int len, uint8_t * buffer) {
 mraa_result_t
 MLX90614::i2cWriteReg_N (uint8_t reg, unsigned int len, uint8_t * buffer) {
     mraa_result_t error = MRAA_SUCCESS;
-
-    if (m_i2Ctx == NULL) {
-        throw MLX90614Exception ("Couldn't find initilized I2C.");
-    }
 
     error = mraa_i2c_address (m_i2Ctx, m_i2cAddr);
     error = mraa_i2c_write (m_i2Ctx, buffer, len);

--- a/src/sm130/sm130.cxx
+++ b/src/sm130/sm130.cxx
@@ -36,10 +36,10 @@ using namespace upm;
 SM130::SM130 (int bus, int devAddr, int rst, int dready) {
     mraa_result_t error = MRAA_SUCCESS;
 
-    this->m_name = "SM130";
+    m_name = "SM130";
 
-    this->m_i2cAddr = devAddr;
-    this->m_bus = bus;
+    m_i2cAddr = devAddr;
+    m_bus = bus;
 
     if (!(m_i2Ctx = mraa_i2c_init(m_bus)))
       {
@@ -47,31 +47,31 @@ SM130::SM130 (int bus, int devAddr, int rst, int dready) {
                                     ": mraa_i2c_init() failed");
       }
 
-    mraa_result_t ret = mraa_i2c_address(this->m_i2Ctx, this->m_i2cAddr);
+    mraa_result_t ret = mraa_i2c_address(m_i2Ctx, m_i2cAddr);
     if (ret != MRAA_SUCCESS) {
         throw std::invalid_argument(std::string(__FUNCTION__) + 
                                     ": mraa_i2c_address() failed");
     }
 
-    this->m_resetPinCtx = mraa_gpio_init (rst);
+    m_resetPinCtx = mraa_gpio_init (rst);
     if (m_resetPinCtx == NULL) {
         throw std::invalid_argument(std::string(__FUNCTION__) + 
                                     ": mraa_gpio_init(RESET) failed");
     }
 
-    this->m_dataReadyPinCtx = mraa_gpio_init (dready);
+    m_dataReadyPinCtx = mraa_gpio_init (dready);
     if (m_dataReadyPinCtx == NULL) {
         throw std::invalid_argument(std::string(__FUNCTION__) + 
                                     ": mraa_gpio_init(DATA READY) failed");
     }
 
-    error = mraa_gpio_dir (this->m_resetPinCtx, MRAA_GPIO_OUT);
+    error = mraa_gpio_dir (m_resetPinCtx, MRAA_GPIO_OUT);
     if (error != MRAA_SUCCESS) {
         throw std::invalid_argument(std::string(__FUNCTION__) + 
                                     ": mraa_gpio_dir(RESET) failed");
     }
 
-    error = mraa_gpio_dir (this->m_dataReadyPinCtx, MRAA_GPIO_OUT);
+    error = mraa_gpio_dir (m_dataReadyPinCtx, MRAA_GPIO_OUT);
     if (error != MRAA_SUCCESS) {
         throw std::invalid_argument(std::string(__FUNCTION__) + 
                                     ": mraa_gpio_dir(DATA READY) failed");
@@ -81,15 +81,15 @@ SM130::SM130 (int bus, int devAddr, int rst, int dready) {
 SM130::~SM130 () {
     mraa_result_t error = MRAA_SUCCESS;
 
-    error = mraa_i2c_stop(this->m_i2Ctx);
+    error = mraa_i2c_stop(m_i2Ctx);
     if (error != MRAA_SUCCESS) {
         mraa_result_print(error);
     }
-    error = mraa_gpio_close (this->m_resetPinCtx);
+    error = mraa_gpio_close (m_resetPinCtx);
     if (error != MRAA_SUCCESS) {
         mraa_result_print(error);
     }
-    error = mraa_gpio_close (this->m_dataReadyPinCtx);
+    error = mraa_gpio_close (m_dataReadyPinCtx);
     if (error != MRAA_SUCCESS) {
         mraa_result_print(error);
     }
@@ -111,15 +111,15 @@ SM130::getFirmwareVersion () {
 uint8_t
 SM130::available () {
     // If in SEEK mode and using DREADY pin, check the status
-    if (this->m_LastCMD == CMD_SEEK_TAG) {
-        if (!mraa_gpio_read(this->m_dataReadyPinCtx)) {
+    if (m_LastCMD == CMD_SEEK_TAG) {
+        if (!mraa_gpio_read(m_dataReadyPinCtx)) {
             return false;
         }
     }
 
     // Set the maximum length of the expected response packet
     uint8_t len;
-    switch(this->m_LastCMD) {
+    switch(m_LastCMD) {
         case CMD_ANTENNA_POWER:
         case CMD_AUTHENTICATE:
         case CMD_DEC_VALUE:
@@ -142,32 +142,32 @@ SM130::available () {
     }
 
     // If valid data received, process the response packet
-    if (this->i2cRecievePacket(len) > 0) {
+    if (i2cRecievePacket(len) > 0) {
         // Init response variables
-        this->m_TagType = this->m_TagLength = *this->m_TagString = 0;
+        m_TagType = m_TagLength = *m_TagString = 0;
 
         // If packet length is 2, the command failed. Set error code.
-        errorCode = this->getPacketLength () < 3 ? this->m_Data[2] : 0;
+        errorCode = getPacketLength () < 3 ? m_Data[2] : 0;
 
         // Process command response
-        switch (this->getCommand ()) {
+        switch (getCommand ()) {
             case CMD_RESET:
             case CMD_VERSION:
                 // RESET and VERSION commands produce the firmware version
-                len = std::min ((unsigned int) getPacketLength(), (unsigned int) sizeof(this->m_Version)) - 1;
-                memcpy(this->m_Version, this->m_Data + 2, len);
-                this->m_Version[len] = 0;
+                len = std::min ((unsigned int) getPacketLength(), (unsigned int) sizeof(m_Version)) - 1;
+                memcpy(m_Version, m_Data + 2, len);
+                m_Version[len] = 0;
                 break;
 
             case CMD_SEEK_TAG:
             case CMD_SELECT_TAG:
                 // If no error, get tag number
-                if(errorCode == 0 && this->getPacketLength () >= 6)
+                if(errorCode == 0 && getPacketLength () >= 6)
                 {
-                    this->m_TagLength = this->getPacketLength () - 2;
-                    this->m_TagType = this->m_Data[2];
-                    memcpy(this->m_TagNumber, this->m_Data + 3, this->m_TagLength);
-                    this->arrayToHex (this->m_TagString, this->m_TagNumber, this->m_TagLength);
+                    m_TagLength = getPacketLength () - 2;
+                    m_TagType = m_Data[2];
+                    memcpy(m_TagNumber, m_Data + 3, m_TagLength);
+                    arrayToHex (m_TagString, m_TagNumber, m_TagLength);
                 }
                 break;
 
@@ -183,7 +183,7 @@ SM130::available () {
 
             case CMD_ANTENNA_POWER:
                 errorCode = 0;
-                antennaPower = this->m_Data[2];
+                antennaPower = m_Data[2];
                 break;
 
             case CMD_SLEEP:
@@ -202,19 +202,19 @@ uint16_t
 SM130::i2cRecievePacket (uint32_t len) {
     int readByte = 0;
 
-    mraa_i2c_address(this->m_i2Ctx, this->m_i2cAddr);
-    readByte = mraa_i2c_read(this->m_i2Ctx, this->m_Data, len);
+    mraa_i2c_address(m_i2Ctx, m_i2cAddr);
+    readByte = mraa_i2c_read(m_i2Ctx, m_Data, len);
 
     if (readByte > 0) {
         // verify checksum if length > 0 and <= SIZE_PAYLOAD
-        if (this->m_Data[0] > 0 && this->m_Data[0] <= SIZE_PAYLOAD)
+        if (m_Data[0] > 0 && m_Data[0] <= SIZE_PAYLOAD)
         {
             uint8_t i, sum;
-            for (i = 0, sum = 0; i <= this->m_Data[0]; i++) {
-                sum += this->m_Data[i];
+            for (i = 0, sum = 0; i <= m_Data[0]; i++) {
+                sum += m_Data[i];
             }
             // return with length of response, or -1 if invalid checksum
-            return sum == this->m_Data[i] ? this->m_Data[0] : -1;
+            return sum == m_Data[i] ? m_Data[0] : -1;
         }
     }
 
@@ -244,26 +244,26 @@ SM130::i2cTransmitPacket (uint32_t len) {
     uint8_t sum = 0;
 
     // Save last command
-    this->m_LastCMD = this->m_Data[0];
+    m_LastCMD = m_Data[0];
 
     // calculate the sum check
     for (int i = 0; i < len; i++) {
-        sum += this->m_Data[i];
+        sum += m_Data[i];
     }
 
     // placing the sum check to the last byte of the packet
-    this->m_Data[len + 1] = sum;
+    m_Data[len + 1] = sum;
 
-    error = mraa_i2c_address (this->m_i2Ctx, this->m_i2cAddr);
-    error = mraa_i2c_write (this->m_i2Ctx, this->m_Data, len + 1);
+    error = mraa_i2c_address (m_i2Ctx, m_i2cAddr);
+    error = mraa_i2c_write (m_i2Ctx, m_Data, len + 1);
 
     return error;
 }
 
 mraa_result_t
 SM130::sendCommand (uint8_t cmd) {
-    this->m_Data[0] = 1;
-    this->m_Data[1] = cmd;
-    this->i2cTransmitPacket(2);
+    m_Data[0] = 1;
+    m_Data[1] = cmd;
+    i2cTransmitPacket(2);
 }
 

--- a/src/th02/th02.cxx
+++ b/src/th02/th02.cxx
@@ -28,18 +28,12 @@
 #include <iostream>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdexcept>
 
 #include "th02.h"
 
 using namespace std;
 using namespace upm;
-
-struct TH02Exception : public std::exception {
-    std::string message;
-    TH02Exception (std::string msg) : message (msg) { }
-    ~TH02Exception () throw () { }
-    const char* what() const throw () { return message.c_str(); }
-};
 
 TH02::TH02 (int bus, uint8_t addr) : m_i2c(bus) {
     m_addr = addr;
@@ -47,7 +41,8 @@ TH02::TH02 (int bus, uint8_t addr) : m_i2c(bus) {
 
     mraa_result_t ret = m_i2c.address(m_addr);
     if (ret != MRAA_SUCCESS) {
-        throw TH02Exception ("Couldn't initilize I2C.");
+        throw std::invalid_argument(std::string(__FUNCTION__) + 
+                                    ": mraa_i2c_address() failed");
     }
 }
 

--- a/src/upm.i
+++ b/src/upm.i
@@ -1,5 +1,6 @@
 %include "std_string.i"
 %include "stdint.i"
+%include "upm_exception.i"
 
 %typemap(out) mraa_result_t = int;
 

--- a/src/upm_exception.i
+++ b/src/upm_exception.i
@@ -1,0 +1,65 @@
+/* Standardized exception handling for UPM 
+ *
+ * catch blocks should be listed in order from most specific to least
+ * specific.
+ */
+
+%include "exception.i"
+
+%exception { 
+    try {
+      $action
+    } catch (std::invalid_argument& e) {
+      std::string s1("UPM Invalid Argument: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_ValueError, s1.c_str());
+
+    } catch (std::domain_error& e) {
+      std::string s1("UPM Domain Error: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_ValueError, s1.c_str() );
+
+    } catch (std::overflow_error& e) {
+      std::string s1("UPM Overflow Error: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_OverflowError, s1.c_str() );
+
+    } catch (std::out_of_range& e) {
+      std::string s1("UPM Out of Range: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_IndexError, s1.c_str() );
+
+    } catch (std::length_error& e) {
+      std::string s1("UPM Length Error: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_IndexError, s1.c_str() );
+
+    } catch (std::logic_error& e) {
+      std::string s1("UPM Logic Error: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_RuntimeError, s1.c_str() );
+
+    } catch (std::bad_alloc& e) {
+      /* for an allocation exception, don't try to create a string... */
+      SWIG_exception(SWIG_MemoryError, e.what() );
+
+    } catch (std::runtime_error& e) {
+      /* catch other std::runtime_error exceptions here */
+      std::string s1("UPM Runtime Error: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_RuntimeError, s1.c_str());
+
+    } catch (std::exception& e) {
+      /* catch other std::exceptions here */
+      std::string s1("UPM Error: "), s2(e.what());
+      s1 = s1 + s2;
+      SWIG_exception(SWIG_SystemError, s1.c_str() );
+
+    } catch (...) {
+      /* catch everything else */
+      SWIG_exception(SWIG_UnknownError, "UPM Unknown exception" );
+
+    }
+
+}
+


### PR DESCRIPTION
upm: add facility for exception handling in upm
    
We add a new src/upm_exception.i interface file for SWIG to catch
common exceptions and propagate them through SWIG.
    
src/upm.i is modified to include this interface file, so all UPM
drivers have it.
    
In theory, this should be language agnostic - if the target language
supports exceptions, then it should just work.

Next, existing drivers with their own exception classes are modified to remove those classes and use appropriate standard exceptions instead.