### PR TITLE
pca9685: fix problem where setting pwm accidentally cleared full bits

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,10 +89,10 @@ macro(upm_SWIG_JAVA)
     add_custom_command (TARGET javaupm_${libname}
         POST_BUILD
         COMMAND cmake -E echo "Compiling java.."
-        COMMAND cmake -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/upm_${libname}
+        COMMAND cmake -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/javaupm_${libname}
         COMMAND ${JAVAC} *.java -d ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND cmake -E echo "Creating jar"
-        COMMAND ${JAR} cvf upm_${libname}.jar upm_${libname}
+        COMMAND ${JAR} cvf javaupm_${libname}.jar javaupm_${libname}
     )
 
   endif()

--- a/src/pca9685/pca9685.cxx
+++ b/src/pca9685/pca9685.cxx
@@ -182,9 +182,9 @@ bool PCA9685::ledFullOn(uint8_t led, bool val)
   uint8_t bits = readByte(regoff);
 
   if (val)
-    bits |= ((1 << 4) & 0xff);
+    bits |= 0x10;
   else
-    bits &= ~((1 << 4) & 0xff);
+    bits &= ~0x10;
 
   return writeByte(regoff, bits);
 }
@@ -209,9 +209,9 @@ bool PCA9685::ledFullOff(uint8_t led, bool val)
   uint8_t bits = readByte(regoff);
 
   if (val)
-    bits |= ((1 << 4) & 0xff);
+    bits |= 0x10;
   else
-    bits &= ~((1 << 4) & 0xff);
+    bits &= ~0x10;
 
   return writeByte(regoff, bits);
 }
@@ -240,7 +240,7 @@ bool PCA9685::ledOnTime(uint8_t led, uint16_t time)
     regoff = REG_LED0_ON_L + (led * 4);
 
   // we need to preserve the full ON bit in *_ON_H
-  uint8_t onbit = (readByte(regoff + 1) & 0x40);
+  uint8_t onbit = (readByte(regoff + 1) & 0x10);
 
   time = (time & 0x0fff) | (onbit << 8);
 
@@ -271,7 +271,7 @@ bool PCA9685::ledOffTime(uint8_t led, uint16_t time)
     regoff = REG_LED0_ON_L + (led * 4) + 2;
 
   // we need to preserve the full OFF bit in *_OFF_H
-  uint8_t offbit = (readByte(regoff + 1) & 0x40);
+  uint8_t offbit = (readByte(regoff + 1) & 0x10);
 
   time = (time & 0x0fff) | (offbit << 8);
 


### PR DESCRIPTION
When setting the On or Off times, the FullOn or FullOff control bits
would be improperly masked and therefore not preserved.

Signed-off-by: Jon Trulson <jtrulson@ics.com>