### PR TITLE
java: Enabled directors feature where needed

### DIFF
--- a/src/a110x/javaupm_a110x.i
+++ b/src/a110x/javaupm_a110x.i
@@ -1,4 +1,4 @@
-%module javaupm_a110x
+%module(directors="1") javaupm_a110x
 %include "../upm.i"
 %include "stdint.i"
 %include "typemaps.i"

--- a/src/hcsr04/javaupm_hcsr04.i
+++ b/src/hcsr04/javaupm_hcsr04.i
@@ -1,4 +1,4 @@
-%module javaupm_hcsr04
+%module(directors="1") javaupm_hcsr04
 %include "../upm.i"
 
 %feature("director") IsrCallback;

--- a/src/lsm9ds0/javaupm_lsm9ds0.i
+++ b/src/lsm9ds0/javaupm_lsm9ds0.i
@@ -1,4 +1,4 @@
-%module javaupm_lsm9ds0
+%module(directors="1") javaupm_lsm9ds0
 %include "../upm.i"
 %include "cpointer.i"
 %include "typemaps.i"

--- a/src/mma7660/javaupm_mma7660.i
+++ b/src/mma7660/javaupm_mma7660.i
@@ -1,4 +1,4 @@
-%module javaupm_mma7660
+%module(directors="1") javaupm_mma7660
 %include "../upm.i"
 %include "cpointer.i"
 %include "typemaps.i"

--- a/src/mpu9150/javaupm_mpu9150.i
+++ b/src/mpu9150/javaupm_mpu9150.i
@@ -1,4 +1,4 @@
-%module javaupm_mpu9150
+%module(directors="1") javaupm_mpu9150
 %include "../upm.i"
 %include "typemaps.i"
 %include "arrays_java.i"

--- a/src/nrf24l01/javaupm_nrf24l01.i
+++ b/src/nrf24l01/javaupm_nrf24l01.i
@@ -1,4 +1,4 @@
-%module javaupm_nrf24l01
+%module(directors="1") javaupm_nrf24l01
 %include "../upm.i"
 
 %feature("director") Callback;

--- a/src/pulsensor/javaupm_pulsensor.i
+++ b/src/pulsensor/javaupm_pulsensor.i
@@ -1,4 +1,4 @@
-%module javaupm_pulsensor
+%module(directors="1") javaupm_pulsensor
 %include "../upm.i"
 %include "arrays_java.i"
 

--- a/src/rpr220/javaupm_rpr220.i
+++ b/src/rpr220/javaupm_rpr220.i
@@ -1,4 +1,4 @@
-%module javaupm_rpr220
+%module(directors="1") javaupm_rpr220
 %include "../upm.i"
 
 


### PR DESCRIPTION
Directors feature is disabled by default. Without this commit, the SWIG interfaces containing callbacks that do not have directors="1" will not work.

Signed-off-by: Andrei Vasiliu <andrei.vasiliu@intel.com>