### PR TITLE
Character LCD modules - support for various configurations

### DIFF
--- a/examples/c++/lcd-parallel.cxx
+++ b/examples/c++/lcd-parallel.cxx
@@ -1,0 +1,54 @@
+/*
+ * Author: Sergey Kiselev <sergey.kiselev@intel.com>
+ * Author: Yevgeniy Kiveish <yevgeniy.kiveisha@intel.com>
+ * Copyright (c) 2014 - 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <upm/lcm1602.h>
+
+int
+main(int argc, char **argv)
+{
+//! [Interesting]
+    // LCD connection:
+    // LCD RS pin to digital pin 8
+    // LCD Enable pin to digital pin 13
+    // LCD D4 pin to digital pin 2
+    // LCD D5 pin to digital pin 3
+    // LCD D6 pin to digital pin 4
+    // LCD D7 pin to digital pin 5
+    // LCD R/W pin to ground
+    // 10K trimmer potentiometer:
+    //   ends to +5V and ground
+    //   wiper to LCD VO pin (pin 3)
+    upm::Lcm1602 *lcd = new upm::Lcm1602(8, 13, 2, 3, 4, 5, 20, 2);
+    lcd->setCursor(0,0);
+    lcd->write("Hello World");
+    lcd->setCursor(1,2);
+    lcd->write("Hello World");
+
+    printf("Sleeping for 5 seconds\n");
+    sleep(5);
+    delete lcd;
+//! [Interesting]
+    return 0;
+}

--- a/src/lcd/lcm1602.cxx
+++ b/src/lcd/lcm1602.cxx
@@ -213,7 +213,7 @@ Lcm1602::setCursor(int row, int column)
             if (m_numColumns > 8)
             {
                 offset = (column % (m_numColumns / 2)) +
-                         (column / (m_numColumns / 2)) * 0x40;
+                         (column / (m_numColumns / 2) * 0x40;
             }
             break;
         case 2:

--- a/src/lcd/lcm1602.cxx
+++ b/src/lcd/lcm1602.cxx
@@ -213,7 +213,7 @@ Lcm1602::setCursor(int row, int column)
             if (m_numColumns > 8)
             {
                 offset = (column % (m_numColumns / 2)) +
-                         (column / (m_numColumns / 2) * 0x40;
+                         (column / (m_numColumns / 2)) * 0x40;
             }
             break;
         case 2:

--- a/src/lcd/lcm1602.cxx
+++ b/src/lcd/lcm1602.cxx
@@ -212,14 +212,14 @@ Lcm1602::setCursor(int row, int column)
             offset = (column % 8) + (column / 8) * 0x40;
             break;
         case 2:
-            // this should work for 40x2, 20x2, and 16x2 displays
+            // this should work for any display with two rows
             // DDRAM mapping:
-            // 00 .. 0F .. 13 .. 27
-            // 40 .. 4F .. 53 .. 67
+            // 00 .. 27
+            // 40 .. 67
             offset += row * 0x40;
             break;
         case 4:
-            if (m_numRows == 16)
+            if (m_numColumns == 16)
             {
                  // 16x4 display
                  // DDRAM mapping:

--- a/src/lcd/lcm1602.cxx
+++ b/src/lcd/lcm1602.cxx
@@ -206,10 +206,15 @@ Lcm1602::setCursor(int row, int column)
     switch (m_numRows)
     {
         case 1:
-            // assume 16x1 display (8x1 should work as well)
-            // DDRAM mapping:
+            // Single row displays with more than 8 columns usually have their
+            // DDRAM split in two halves. The first half starts at address 00.
+            // The second half starts at address 40. E.g. 16x2 DDRAM mapping:
             // 00 01 02 03 04 05 06 07 40 41 42 43 44 45 46 47
-            offset = (column % 8) + (column / 8) * 0x40;
+            if (m_numColumns > 8)
+            {
+                offset = (column % (m_numColumns / 2)) +
+                         (column / (m_numColumns / 2) * 0x40;
+            }
             break;
         case 2:
             // this should work for any display with two rows

--- a/src/lcd/lcm1602.h
+++ b/src/lcd/lcm1602.h
@@ -72,7 +72,8 @@ class Lcm1602 : public LCD
      * @param isExpander True if we are dealing with an I2C expander,
      * false otherwise.  Default is true.
      */
-  Lcm1602(int bus, int address, bool isExpander=true);
+  Lcm1602(int bus, int address, bool isExpander=true,
+          uint8_t numColumns = 16, uint8_t numRows = 4);
 
     /**
      * Lcm1602 alternate constructor, used for GPIO based hd44780
@@ -87,7 +88,8 @@ class Lcm1602 : public LCD
      * @param d3 Data 3 pin
      */
     Lcm1602(uint8_t rs,  uint8_t enable,
-            uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3);
+            uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+            uint8_t numColumns = 16, uint8_t numRows = 4);
 
     /**
      * Lcm1602 destructor
@@ -224,6 +226,10 @@ class Lcm1602 : public LCD
 
     uint8_t m_displayControl;
     uint8_t m_entryDisplayMode;
+
+    // Display size
+    uint8_t m_numColumns;
+    uint8_t m_numRows;
 
     // Add a command() and data() virtual member functions, with a
     // default implementation in lcm1602.  This is expected to be


### PR DESCRIPTION
It appears that currently UPM (lcm1602) supports only 20x4 modules. This patch adds support for other LCD configurations 8x1, 16x1, 16x2, 20x2, 40x2, 16x4, 20x4.
It also adds an example for using an LCD with parallel interface.

As a side note lcm1602 is not an obvious name for character LCD modules. Consider renaming it. hd44780 or just 'lcd' are probably some better choices.