### PR TITLE
Pull remove setttyfd compiler warnings

### DIFF
--- a/src/grovescam/grovescam.h
+++ b/src/grovescam/grovescam.h
@@ -181,7 +181,6 @@ namespace upm {
 
   protected:
     int ttyFd() { return m_ttyFd; };
-    int setTtyFd(int fd) { m_ttyFd = fd; };
 
   private:
     mraa_uart_context m_uart;

--- a/src/hm11/hm11.h
+++ b/src/hm11/hm11.h
@@ -134,7 +134,6 @@ namespace upm {
 
   protected:
     int ttyFd() { return m_ttyFd; };
-    int setTtyFd(int fd) { m_ttyFd = fd; };
 
   private:
     mraa_uart_context m_uart;

--- a/src/mhz16/mhz16.h
+++ b/src/mhz16/mhz16.h
@@ -152,7 +152,6 @@ namespace upm {
 
   protected:
     int ttyFd() { return m_ttyFd; };
-    int setTtyFd(int fd) { m_ttyFd = fd; };
 
   private:
     mraa_uart_context m_uart;

--- a/src/ublox6/ublox6.h
+++ b/src/ublox6/ublox6.h
@@ -120,7 +120,6 @@ namespace upm {
 
   protected:
     int ttyFd() { return m_ttyFd; };
-    int setTtyFd(int fd) { m_ttyFd = fd; };
 
   private:
     mraa_uart_context m_uart;

--- a/src/wt5001/wt5001.h
+++ b/src/wt5001/wt5001.h
@@ -340,7 +340,6 @@ namespace upm {
 
   protected:
     int ttyFd() { return m_ttyFd; };
-    int setTtyFd(int fd) { m_ttyFd = fd; };
 
   private:
     mraa_uart_context m_uart;

--- a/src/zfm20/zfm20.h
+++ b/src/zfm20/zfm20.h
@@ -366,7 +366,6 @@ namespace upm {
 
   protected:
     int ttyFd() { return m_ttyFd; };
-    int setTtyFd(int fd) { m_ttyFd = fd; };
 
   private:
     mraa_uart_context m_uart;


### PR DESCRIPTION
These commits remove an unused setTtyFd() method in the older UART based UPM sensors that caused compiler warnings.