### PR TITLE
lsm303: Fixing an incorrect accelerometer address

### DIFF
--- a/src/lsm303/lsm303.h
+++ b/src/lsm303/lsm303.h
@@ -33,8 +33,8 @@
 namespace upm {
 
 /* LSM303 Address definitions */
-#define LSM303_MAG 0x1E // assuming SA0 grounded
-#define LSM303_ACC 0x18 // assuming SA0 grounded
+#define LSM303_MAG 0x1E
+#define LSM303_ACC 0x19
 
 /* LSM303 Register definitions */
 #define CTRL_REG1_A 0x20


### PR DESCRIPTION
Signed-off-by: Eugene Bolshakov <pub@relvarsoft.com>

I2C address was incorrect.
It shall be 0x19, as descibed in a datasheet: http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00027543.pdf