### PR TITLE
Cleaned up code.

### DIFF
--- a/examples/javascript/micsv89.js
+++ b/examples/javascript/micsv89.js
@@ -16,7 +16,7 @@ var mics = new upmMICSV89.MICSV89(6);
 
 while(1)
 {
-    mics.start(); 
+    mics.update(); 
     while(!mics.valid());
     console.log("co2: " + mics.co2equ()); 
     console.log("short: " + mics.vocshort()); 

--- a/src/micsv89/micsv89.cxx
+++ b/src/micsv89/micsv89.cxx
@@ -31,6 +31,10 @@ MICSV89::MICSV89 (int bus, uint8_t address) {
     m_valid = false;
     m_address = address;
     i2c = new mraa::I2c(bus);
+     if(i2c->address(m_address) != mraa::SUCCESS){
+      throw std::invalid_argument(std::string(__FUNCTION__) + ": I2c.address() failed");
+      return;
+    }
     if(i2c->frequency(mraa::I2C_STD) != mraa::SUCCESS){
       throw std::invalid_argument(std::string(__FUNCTION__) + ": I2c.frequency(I2C_STD) failed");
       return;
@@ -41,20 +45,12 @@ MICSV89::MICSV89 (int bus, uint8_t address) {
 }
 
 void MICSV89::update() {
-    m_valid = false;
-    if(i2c->address(m_address) != mraa::SUCCESS){
-      throw std::invalid_argument(std::string(__FUNCTION__) + ": I2c.address() failed");
-      return;
-    }
+    m_valid = false;   
     if(i2c->write(tx_buf, 3) != mraa::SUCCESS){
       throw std::invalid_argument(std::string(__FUNCTION__) + ": I2c.write() failed");
       return;
     }
     sleep(1); //Give the device time to make the measurement.
-    if(i2c->address(m_address) != mraa::SUCCESS){
-      throw std::invalid_argument(std::string(__FUNCTION__) + ": I2c.address() failed");
-      return;
-    }
     if(i2c->read(rx_buf, 6) != 6){
       throw std::invalid_argument(std::string(__FUNCTION__) + ": I2c.read() failed");
       return;


### PR DESCRIPTION
Removed some unneeded calls in update function. Changed call in
micsv89.js sample file to use update instead of start.

Tested with UPM. 4.0. The micsv89 is sensitive to other devices pulling
the I2c bus up, so it is not likely to work on the Arduino breakout.
I2c 1 on mini breakout works fine.

—Signed-off-by Marc Graham <marc@m2ag.net>