### PR TITLE
Pass reference to current object to ISR.

### DIFF
--- a/examples/c++/hcsr04.cxx
+++ b/examples/c++/hcsr04.cxx
@@ -24,7 +24,7 @@
 
 #include <unistd.h>
 #include <iostream>
-#include <upm/hcsr04.h>
+#include "hcsr04.h"
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/examples/c++/hcsr04.cxx
+++ b/examples/c++/hcsr04.cxx
@@ -24,12 +24,10 @@
 
 #include <unistd.h>
 #include <iostream>
-#include "hcsr04.h"
+#include <upm/hcsr04.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/time.h>
-
-upm::HCSR04 *sonar = NULL;
 
 void
 sig_handler(int signo)
@@ -37,20 +35,20 @@ sig_handler(int signo)
     printf("got signal\n");
     if (signo == SIGINT) {
         printf("exiting application\n");
-        sonar->m_doWork = 1;
     }
 }
 
 //! [Interesting]
 void
 interrupt (void * args) {
+    upm::HCSR04 * sonar = (upm::HCSR04 *) args;
     sonar->ackEdgeDetected ();
 }
 
 int
 main(int argc, char **argv)
 {
-    sonar = new upm::HCSR04(5, 6, &interrupt);
+    upm::HCSR04 * sonar = new upm::HCSR04(5, 6, &interrupt);
     signal(SIGINT, sig_handler);
 
     sleep(1);

--- a/src/hcsr04/hcsr04.cxx
+++ b/src/hcsr04/hcsr04.cxx
@@ -63,7 +63,7 @@ HCSR04::HCSR04 (uint8_t triggerPin, uint8_t echoPin, void (*fptr)(void *)) {
     }
 
     mraa_gpio_dir(m_echoPinCtx, MRAA_GPIO_IN);
-    mraa_gpio_isr(m_echoPinCtx, MRAA_GPIO_EDGE_BOTH, fptr, NULL);
+    mraa_gpio_isr(m_echoPinCtx, MRAA_GPIO_EDGE_BOTH, fptr, (void*)this);
 }
 
 HCSR04::~HCSR04 () {


### PR DESCRIPTION
This will allow users to call ackEdgeDetected() on the object passed into the function pointer, instead of requiring them to have a global reference to the object.