### PR TITLE
Fix Java IsrCallback crash: the director now uses a GlobalRef instead of a WeakRef to the IsrCallback object

### DIFF
--- a/src/a110x/javaupm_a110x.i
+++ b/src/a110x/javaupm_a110x.i
@@ -4,7 +4,7 @@
 %include "typemaps.i"
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 

--- a/src/bma220/javaupm_bma220.i
+++ b/src/bma220/javaupm_bma220.i
@@ -6,7 +6,7 @@
 %include "../java_buffer.i"
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 

--- a/src/grove/javaupm_grove.i
+++ b/src/grove/javaupm_grove.i
@@ -3,7 +3,7 @@
 %include "../upm.i"
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 

--- a/src/lsm9ds0/javaupm_lsm9ds0.i
+++ b/src/lsm9ds0/javaupm_lsm9ds0.i
@@ -6,7 +6,7 @@
 %include "../java_buffer.i"
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 

--- a/src/mma7660/javaupm_mma7660.i
+++ b/src/mma7660/javaupm_mma7660.i
@@ -4,7 +4,7 @@
 %include "typemaps.i"
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 

--- a/src/mpu9150/javaupm_mpu9150.i
+++ b/src/mpu9150/javaupm_mpu9150.i
@@ -5,7 +5,7 @@
 %include "../java_buffer.i"
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 

--- a/src/nrf24l01/javaupm_nrf24l01.i
+++ b/src/nrf24l01/javaupm_nrf24l01.i
@@ -2,6 +2,7 @@
 %include "../upm.i"
 
 %feature("director") Callback;
+SWIG_DIRECTOR_OWNED(Callback)
 
 %include "arrays_java.i";
 %apply signed char[] {uint8_t *};

--- a/src/pulsensor/javaupm_pulsensor.i
+++ b/src/pulsensor/javaupm_pulsensor.i
@@ -3,6 +3,7 @@
 %include "arrays_java.i"
 
 %feature("director") Callback;
+SWIG_DIRECTOR_OWNED(Callback)
 
 %ignore sample_thread;
 %ignore pin_ctx;

--- a/src/rpr220/javaupm_rpr220.i
+++ b/src/rpr220/javaupm_rpr220.i
@@ -3,7 +3,7 @@
 
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 

--- a/src/ttp223/javaupm_ttp223.i
+++ b/src/ttp223/javaupm_ttp223.i
@@ -3,7 +3,7 @@
 %include "../upm.i"
 
 %feature("director") IsrCallback;
-
+SWIG_DIRECTOR_OWNED(IsrCallback)
 %ignore generic_callback_isr;
 %include "../IsrCallback.h"
 


### PR DESCRIPTION
Fix Java IsrCallback crash: the director now uses a GlobalRef instead of a WeakRef to the IsrCallback object. Fix for https://github.com/intel-iot-devkit/upm/issues/308

Signed-off-by: Petre Eftime <petre.p.eftime@intel.com>