### PR TITLE
cmake: Use include/lib paths from MRAA pkgconfig for cmake

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -5,12 +5,10 @@ UPM uses cmake in order to make compilation relatively painless. Cmake runs
 build out of tree so the recommended way is to clone from git and make a build/
 directory.
 
-This project depends on libmraa, so that needs to be installed first. Use the
-following environment variables to configure the paths:
+This project depends on libmraa, so that needs to be installed first. Append
+the install location of mraa pkgconfig to the following environment variable:
 
     PKG_CONFIG_PATH=$PKG_CONFIG_PATH:.../mraa/build/lib/pkgconfig
-    CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:.../mraa/build/include
-    LIBRARY_PATH=$LIBRARY_PATH:.../mraa/build/lib
 
 UPM will attempt to build all directories inside src/ and they must contain
 individual CMakeLists.txt files.

--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -74,6 +74,10 @@ endmacro()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples)
 
+# Set the mraa include and link directories prior to adding examples
+include_directories (${MRAA_INCLUDE_DIRS})
+link_directories (${MRAA_LIBDIR})
+
 # If your sample source file matches the name of the module it tests, add it here
 # Exceptions are as follows:
 #  string after first '-' is ignored (e.g. nrf24l01-transmitter maps to nrf24l01)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,9 +49,9 @@ macro(upm_SWIG_NODE)
     )
     if (${V8_VERSION_MAJOR} GREATER 3)
       if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
-	    message(FATAL_ERROR " **ERROR** GCC 4.7 or above is required to compile jsupm_${libname} ")
-	  endif()
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
+          message(FATAL_ERROR " **ERROR** GCC 4.7 or above is required to compile jsupm_${libname} ")
+        endif()
       endif()
       set_property (TARGET jsupm_${libname} PROPERTY CXX_STANDARD 11)
       set_property (TARGET jsupm_${libname} PROPERTY CXX_STANDARD_REQUIRED ON)
@@ -88,10 +88,10 @@ macro(upm_SWIG_JAVA)
       SUFFIX ".so"
     )
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/libjavaupm_${libname}.so
-	DESTINATION lib/java
+        DESTINATION lib/java
     )
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/upm_${libname}.jar
-	DESTINATION lib/java
+        DESTINATION lib/java
     )
 
     if (NOT DEFINED $ENV{JAVA_HOME_NATIVE})
@@ -168,15 +168,16 @@ if (SWIG_FOUND)
 #  if(BUILDSWIGJAVA)
 #    add_subdirectory (java)
 #  endif(BUILDSWIGJAVA)
-    
+
 endif()
 
 macro(upm_module_init)
+  link_directories (${MRAA_LIBDIR})
   add_library (${libname} SHARED ${module_src})
   foreach (linkflag ${ARGN})
     target_link_libraries (${libname} ${linkflag})
   endforeach ()
-  include_directories (${MRAA_INCLUDE_DIR} .)
+  include_directories (${MRAA_INCLUDE_DIRS} .)
   target_link_libraries (${libname} ${MRAA_LIBRARIES})
   set_target_properties(
     ${libname}


### PR DESCRIPTION
If successful, the MRAA pkgconfig sets MRAA_INCLUDE_DIRS and MRAA_LIBDIR.
These can be used by dependent cmake files.

    * Updated src CMakeLists.txt to use MRAA pkgconfig locations in
      upm_module_init
    * Updated c++ example CMakeLists.txt to use MRAA pkgconfig locations
    * Updated UPM building.md to reflect the change (removed the need to set
      CPLUS_INCLUDE_PATH and LIBRARY_PATH
