### PR TITLE
cmake: added doxygen doc content to python sensor modules

### DIFF
--- a/doxy/README.cpp.md
+++ b/doxy/README.cpp.md
@@ -30,7 +30,7 @@ Multi-sensor samples for the starter and specialized kits can be found in the
 
 Supported [sensor list](http://iotdk.intel.com/docs/master/upm/modules.html) from API documentation.
 
-You can also refer to the [Intel® IoT Developer Zone](https://software.intel.com/iot/sensors).
+You can also refer to the [Intel IoT Developer Zone](https://software.intel.com/iot/sensors).
 
 ### IDE Compatibility
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ endmacro (upm_CREATE_INSTALL_PKGCONFIG)
 macro(upm_SWIG_PYTHON)
   if (BUILDSWIGPYTHON AND BUILDSWIG)
     set_source_files_properties (pyupm_${libname}.i PROPERTIES CPLUSPLUS ON)
+    set_source_files_properties (pyupm_${libname}.i PROPERTIES SWIG_FLAGS "-I${CMAKE_CURRENT_BINARY_DIR}/..")
     swig_add_module (pyupm_${libname} python pyupm_${libname}.i ${module_src})
     swig_link_libraries (pyupm_${libname} ${PYTHON_LIBRARIES} ${MRAA_LIBRARIES})
     target_include_directories ( ${SWIG_MODULE_pyupm_${libname}_REAL_NAME}
@@ -120,16 +121,8 @@ macro(upm_doxygen)
       set (classname ${libname})
     endif()
     set (CMAKE_SWIG_FLAGS -DDOXYGEN=${DOXYGEN_FOUND})
-    add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${libname}_doc.i
-      COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../doxy2swig.py -n
-        ${CMAKE_BINARY_DIR}/xml/${classname}_8h.xml
-        ${CMAKE_CURRENT_BINARY_DIR}/${libname}_doc.i
-        DEPENDS ${CMAKE_BINARY_DIR}/xml/${classname}_8h.xml
-    )
-    add_custom_target (${libname}doc_i DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${libname}_doc.i)
-    add_dependencies (${libname}doc_i doc)
     if (BUILDSWIG)
-      add_dependencies (_pyupm_${libname} ${libname}doc_i)
+      add_dependencies (_pyupm_${libname} pyupm_doxy2swig)
       add_dependencies (pydoc _pyupm_${libname})
     else ()
       add_dependencies (${libname} doc)
@@ -201,6 +194,24 @@ macro(upm_module_init)
     set(CPACK_COMPONENT_${libname}_DESCRIPTION "${libdescription}")
   endif()
 endmacro(upm_module_init)
+
+# Generate python module documentation from doxygen collateral
+if (BUILDDOC AND BUILDSWIGPYTHON AND SWIG_FOUND)
+  # doxy2swig the doxygen output
+  add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pyupm_doxy2swig.i
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/doxy2swig.py
+      ${CMAKE_BINARY_DIR}/xml/index.xml
+      ${CMAKE_CURRENT_BINARY_DIR}/pyupm_doxy2swig.i
+    DEPENDS ${CMAKE_BINARY_DIR}/xml/index.xml
+  )
+  add_custom_target (pyupm_doxy2swig DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/pyupm_doxy2swig.i)
+  add_dependencies (pyupm_doxy2swig doc)
+# BUILDDOC not set but still building python modules, generate an empty
+# pyupm_doxy2swig.i file (overwriting if necessary)
+elseif (BUILDSWIGPYTHON AND SWIG_FOUND)
+  message (INFO " Generating empty ${CMAKE_CURRENT_BINARY_DIR}/pyupm_doxy2swig.i")
+  file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/pyupm_doxy2swig.i "// Empty doxy2swig stub")
+endif (BUILDDOC AND BUILDSWIGPYTHON AND SWIG_FOUND)
 
 if (MODULE_LIST)
   set(SUBDIRS ${MODULE_LIST})

--- a/src/a110x/pyupm_a110x.i
+++ b/src/a110x/pyupm_a110x.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_a110x
 %include "../upm.i"
 

--- a/src/ad8232/pyupm_ad8232.i
+++ b/src/ad8232/pyupm_ad8232.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ad8232
 %include "../upm.i"
 

--- a/src/adafruitms1438/pyupm_adafruitms1438.i
+++ b/src/adafruitms1438/pyupm_adafruitms1438.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_adafruitms1438
 %include "../upm.i"
 

--- a/src/adafruitss/pyupm_adafruitss.i
+++ b/src/adafruitss/pyupm_adafruitss.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_adafruitss
 %include "../upm.i"
 

--- a/src/adc121c021/pyupm_adc121c021.i
+++ b/src/adc121c021/pyupm_adc121c021.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_adc121c021
 %include "../upm.i"
 

--- a/src/adis16448/pyupm_adis16448.i
+++ b/src/adis16448/pyupm_adis16448.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_adis16448
 %include "../upm.i"
 

--- a/src/adxl335/pyupm_adxl335.i
+++ b/src/adxl335/pyupm_adxl335.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_adxl335
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/adxl345/pyupm_adxl345.i
+++ b/src/adxl345/pyupm_adxl345.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_adxl345
 %include "../upm.i"
 %include "../carrays_int16_t.i"

--- a/src/adxrs610/pyupm_adxrs610.i
+++ b/src/adxrs610/pyupm_adxrs610.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_adxrs610
 %include "../upm.i"
 

--- a/src/am2315/pyupm_am2315.i
+++ b/src/am2315/pyupm_am2315.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_am2315
 %include "../upm.i"
 

--- a/src/apds9002/pyupm_apds9002.i
+++ b/src/apds9002/pyupm_apds9002.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_apds9002
 %include "../upm.i"
 

--- a/src/at42qt1070/pyupm_at42qt1070.i
+++ b/src/at42qt1070/pyupm_at42qt1070.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_at42qt1070
 %include "../upm.i"
 

--- a/src/biss0001/pyupm_biss0001.i
+++ b/src/biss0001/pyupm_biss0001.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_biss0001
 %include "../upm.i"
 

--- a/src/bma220/pyupm_bma220.i
+++ b/src/bma220/pyupm_bma220.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_bma220
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/bmpx8x/pyupm_bmpx8x.i
+++ b/src/bmpx8x/pyupm_bmpx8x.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_bmpx8x
 %include "../upm.i"
 

--- a/src/buzzer/pyupm_buzzer.i
+++ b/src/buzzer/pyupm_buzzer.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_buzzer
 %include "../upm.i"
 

--- a/src/cjq4435/pyupm_cjq4435.i
+++ b/src/cjq4435/pyupm_cjq4435.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_cjq4435
 %include "../upm.i"
 

--- a/src/dfrph/pyupm_dfrph.i
+++ b/src/dfrph/pyupm_dfrph.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_dfrph
 %include "../upm.i"
 

--- a/src/ds1307/pyupm_ds1307.i
+++ b/src/ds1307/pyupm_ds1307.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ds1307
 %include "../upm.i"
 

--- a/src/ecs1030/pyupm_ecs1030.i
+++ b/src/ecs1030/pyupm_ecs1030.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ecs1030
 %include "../upm.i"
 

--- a/src/enc03r/pyupm_enc03r.i
+++ b/src/enc03r/pyupm_enc03r.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_enc03r
 %include "../upm.i"
 

--- a/src/flex/pyupm_flex.i
+++ b/src/flex/pyupm_flex.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_flex
 %include "../upm.i"
 

--- a/src/gas/pyupm_gas.i
+++ b/src/gas/pyupm_gas.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_gas
 %include "../upm.i"
 %include "../carrays_uint16_t.i"

--- a/src/gp2y0a/pyupm_gp2y0a.i
+++ b/src/gp2y0a/pyupm_gp2y0a.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_gp2y0a
 %include "../upm.i"
 

--- a/src/grove/pyupm_grove.i
+++ b/src/grove/pyupm_grove.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grove
 %include "../upm.i"
 

--- a/src/grovecircularled/pyupm_grovecircularled.i
+++ b/src/grovecircularled/pyupm_grovecircularled.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovecircularled
 %include "../upm.i"
 

--- a/src/grovecollision/pyupm_grovecollision.i
+++ b/src/grovecollision/pyupm_grovecollision.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovecollision
 %include "../upm.i"
 

--- a/src/groveehr/pyupm_groveehr.i
+++ b/src/groveehr/pyupm_groveehr.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_groveehr
 %include "../upm.i"
 

--- a/src/groveeldriver/pyupm_groveeldriver.i
+++ b/src/groveeldriver/pyupm_groveeldriver.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_groveeldriver
 %include "../upm.i"
 

--- a/src/groveelectromagnet/pyupm_groveelectromagnet.i
+++ b/src/groveelectromagnet/pyupm_groveelectromagnet.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_groveelectromagnet
 %include "../upm.i"
 

--- a/src/groveemg/pyupm_groveemg.i
+++ b/src/groveemg/pyupm_groveemg.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_groveemg
 %include "../upm.i"
 

--- a/src/grovegprs/pyupm_grovegprs.i
+++ b/src/grovegprs/pyupm_grovegprs.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovegprs
 %include "../upm.i"
 %include "carrays.i"

--- a/src/grovegsr/pyupm_grovegsr.i
+++ b/src/grovegsr/pyupm_grovegsr.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovegsr
 %include "../upm.i"
 

--- a/src/grovelinefinder/pyupm_grovelinefinder.i
+++ b/src/grovelinefinder/pyupm_grovelinefinder.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovelinefinder
 %include "../upm.i"
 

--- a/src/grovemd/pyupm_grovemd.i
+++ b/src/grovemd/pyupm_grovemd.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovemd
 %include "../upm.i"
 

--- a/src/grovemoisture/pyupm_grovemoisture.i
+++ b/src/grovemoisture/pyupm_grovemoisture.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovemoisture
 %include "../upm.i"
 

--- a/src/groveo2/pyupm_groveo2.i
+++ b/src/groveo2/pyupm_groveo2.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_groveo2
 %include "../upm.i"
 

--- a/src/grovescam/pyupm_grovescam.i
+++ b/src/grovescam/pyupm_grovescam.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovescam
 %include "../upm.i"
 

--- a/src/grovespeaker/pyupm_grovespeaker.i
+++ b/src/grovespeaker/pyupm_grovespeaker.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovespeaker
 %include "../upm.i"
 

--- a/src/groveultrasonic/pyupm_groveultrasonic.i
+++ b/src/groveultrasonic/pyupm_groveultrasonic.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_groveultrasonic
 %include "../upm.i"
 

--- a/src/grovevdiv/pyupm_grovevdiv.i
+++ b/src/grovevdiv/pyupm_grovevdiv.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovevdiv
 %include "../upm.i"
 

--- a/src/grovewater/pyupm_grovewater.i
+++ b/src/grovewater/pyupm_grovewater.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovewater
 %include "../upm.i"
 

--- a/src/grovewfs/pyupm_grovewfs.i
+++ b/src/grovewfs/pyupm_grovewfs.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_grovewfs
 %include "../upm.i"
 

--- a/src/guvas12d/pyupm_guvas12d.i
+++ b/src/guvas12d/pyupm_guvas12d.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_guvas12d
 %include "../upm.i"
 

--- a/src/h3lis331dl/pyupm_h3lis331dl.i
+++ b/src/h3lis331dl/pyupm_h3lis331dl.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_h3lis331dl
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/hcsr04/pyupm_hcsr04.i
+++ b/src/hcsr04/pyupm_hcsr04.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_hcsr04
 %include "../upm.i"
 

--- a/src/hm11/pyupm_hm11.i
+++ b/src/hm11/pyupm_hm11.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_hm11
 %include "../upm.i"
 %include "carrays.i"

--- a/src/hmc5883l/pyupm_hmc5883l.i
+++ b/src/hmc5883l/pyupm_hmc5883l.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_hmc5883l
 %include "../upm.i"
 %include "../carrays_int16_t.i"

--- a/src/hmtrp/pyupm_hmtrp.i
+++ b/src/hmtrp/pyupm_hmtrp.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_hmtrp
 %include "../upm.i"
 %include "../carrays_uint8_t.i"

--- a/src/hp20x/pyupm_hp20x.i
+++ b/src/hp20x/pyupm_hp20x.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_hp20x
 %include "../upm.i"
 

--- a/src/ht9170/pyupm_ht9170.i
+++ b/src/ht9170/pyupm_ht9170.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ht9170
 %include "../upm.i"
 

--- a/src/htu21d/pyupm_htu21d.i
+++ b/src/htu21d/pyupm_htu21d.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_htu21d
 %include "../upm.i"
 

--- a/src/hx711/pyupm_hx711.i
+++ b/src/hx711/pyupm_hx711.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_hx711
 %include "../upm.i"
 %include "stdint.i"

--- a/src/ina132/pyupm_ina132.i
+++ b/src/ina132/pyupm_ina132.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ina132
 %include "../upm.i"
 

--- a/src/isd1820/pyupm_isd1820.i
+++ b/src/isd1820/pyupm_isd1820.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_isd1820
 %include "../upm.i"
 

--- a/src/itg3200/pyupm_itg3200.i
+++ b/src/itg3200/pyupm_itg3200.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_itg3200
 %include "../upm.i"
 %include "../carrays_int16_t.i"

--- a/src/joystick12/pyupm_joystick12.i
+++ b/src/joystick12/pyupm_joystick12.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_joystick12
 %include "../upm.i"
 

--- a/src/l298/pyupm_l298.i
+++ b/src/l298/pyupm_l298.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_l298
 %include "../upm.i"
 

--- a/src/lcd/pyupm_i2clcd.i
+++ b/src/lcd/pyupm_i2clcd.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_i2clcd
 %include "../upm.i"
 %include "../carrays_uint8_t.i"

--- a/src/ldt0028/pyupm_ldt0028.i
+++ b/src/ldt0028/pyupm_ldt0028.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ldt0028
 %include "../upm.i"
 

--- a/src/lm35/pyupm_lm35.i
+++ b/src/lm35/pyupm_lm35.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_lm35
 %include "../upm.i"
 

--- a/src/lol/pyupm_lol.i
+++ b/src/lol/pyupm_lol.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_lol
 %include "../upm.i"
 

--- a/src/loudness/pyupm_loudness.i
+++ b/src/loudness/pyupm_loudness.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_loudness
 %include "../upm.i"
 

--- a/src/lpd8806/pyupm_lpd8806.i
+++ b/src/lpd8806/pyupm_lpd8806.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_lpd8806
 %include "../upm.i"
 

--- a/src/lsm303/pyupm_lsm303.i
+++ b/src/lsm303/pyupm_lsm303.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_lsm303
 %include "../upm.i"
 %include "../carrays_int16_t.i"

--- a/src/lsm9ds0/pyupm_lsm9ds0.i
+++ b/src/lsm9ds0/pyupm_lsm9ds0.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_lsm9ds0
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/m24lr64e/pyupm_m24lr64e.i
+++ b/src/m24lr64e/pyupm_m24lr64e.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_m24lr64e
 %include "../upm.i"
 

--- a/src/max31723/pyupm_max31723.i
+++ b/src/max31723/pyupm_max31723.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_max31723
 %include "../upm.i"
 

--- a/src/max31855/pyupm_max31855.i
+++ b/src/max31855/pyupm_max31855.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_max31855
 %include "../upm.i"
 

--- a/src/max44000/pyupm_max44000.i
+++ b/src/max44000/pyupm_max44000.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_max44000
 %include "../upm.i"
 

--- a/src/max5487/pyupm_max5487.i
+++ b/src/max5487/pyupm_max5487.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_max5487
 %include "../upm.i"
 

--- a/src/maxds3231m/pyupm_maxds3231m.i
+++ b/src/maxds3231m/pyupm_maxds3231m.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_maxds3231m
 %include "../upm.i"
 

--- a/src/maxsonarez/pyupm_maxsonarez.i
+++ b/src/maxsonarez/pyupm_maxsonarez.i
@@ -1,3 +1,7 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_maxsonarez
 %include "../upm.i"
 

--- a/src/mcp9808/pyupm_mcp9808.i
+++ b/src/mcp9808/pyupm_mcp9808.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mcp9808
 %include "../upm.i"
 

--- a/src/mg811/pyupm_mg811.i
+++ b/src/mg811/pyupm_mg811.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mg811
 %include "../upm.i"
 

--- a/src/mhz16/pyupm_mhz16.i
+++ b/src/mhz16/pyupm_mhz16.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mhz16
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/mic/pyupm_mic.i
+++ b/src/mic/pyupm_mic.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mic
 %include "../upm.i"
 %include "../carrays_uint16_t.i"

--- a/src/micsv89/pyupm_micsv89.i
+++ b/src/micsv89/pyupm_micsv89.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_micsv89
 %include "../upm.i"
 

--- a/src/mlx90614/pyupm_mlx90614.i
+++ b/src/mlx90614/pyupm_mlx90614.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mlx90614
 %include "../upm.i"
 

--- a/src/mma7455/pyupm_mma7455.i
+++ b/src/mma7455/pyupm_mma7455.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mma7455
 %include "../upm.i"
 

--- a/src/mma7660/pyupm_mma7660.i
+++ b/src/mma7660/pyupm_mma7660.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mma7660
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/mpl3115a2/pyupm_mpl3115a2.i
+++ b/src/mpl3115a2/pyupm_mpl3115a2.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mpl3115a2
 %include "../upm.i"
 

--- a/src/mpr121/pyupm_mpr121.i
+++ b/src/mpr121/pyupm_mpr121.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mpr121
 %include "../upm.i"
 

--- a/src/mpu9150/pyupm_mpu9150.i
+++ b/src/mpu9150/pyupm_mpu9150.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mpu9150
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/mq303a/pyupm_mq303a.i
+++ b/src/mq303a/pyupm_mq303a.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_mq303a
 %include "../upm.i"
 

--- a/src/my9221/pyupm_my9221.i
+++ b/src/my9221/pyupm_my9221.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_my9221
 %include "../upm.i"
 

--- a/src/nrf24l01/pyupm_nrf24l01.i
+++ b/src/nrf24l01/pyupm_nrf24l01.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_nrf24l01
 %include "../upm.i"
 

--- a/src/nrf8001/pyupm_nrf8001.i
+++ b/src/nrf8001/pyupm_nrf8001.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_nrf8001
 %include "../upm.i"
 

--- a/src/nunchuck/pyupm_nunchuck.i
+++ b/src/nunchuck/pyupm_nunchuck.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_nunchuck
 %include "../upm.i"
 

--- a/src/otp538u/pyupm_otp538u.i
+++ b/src/otp538u/pyupm_otp538u.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_otp538u
 %include "../upm.i"
 

--- a/src/ozw/pyupm_ozw.i
+++ b/src/ozw/pyupm_ozw.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ozw
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/pca9685/pyupm_pca9685.i
+++ b/src/pca9685/pyupm_pca9685.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_pca9685
 %include "../upm.i"
 

--- a/src/pn532/pyupm_pn532.i
+++ b/src/pn532/pyupm_pn532.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_pn532
 %include "../upm.i"
 %include "../carrays_uint8_t.i"

--- a/src/ppd42ns/pyupm_ppd42ns.i
+++ b/src/ppd42ns/pyupm_ppd42ns.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ppd42ns
 %include "../upm.i"
 

--- a/src/pulsensor/pyupm_pulsensor.i
+++ b/src/pulsensor/pyupm_pulsensor.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_pulsensor
 %include "../upm.i"
 

--- a/src/rfr359f/pyupm_rfr359f.i
+++ b/src/rfr359f/pyupm_rfr359f.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_rfr359f
 %include "../upm.i"
 

--- a/src/rgbringcoder/pyupm_rgbringcoder.i
+++ b/src/rgbringcoder/pyupm_rgbringcoder.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_rgbringcoder
 %include "../upm.i"
 

--- a/src/rotaryencoder/pyupm_rotaryencoder.i
+++ b/src/rotaryencoder/pyupm_rotaryencoder.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_rotaryencoder
 %include "../upm.i"
 

--- a/src/rpr220/pyupm_rpr220.i
+++ b/src/rpr220/pyupm_rpr220.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_rpr220
 %include "../upm.i"
 

--- a/src/servo/pyupm_servo.i
+++ b/src/servo/pyupm_servo.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_servo
 %include "../upm.i"
 

--- a/src/si114x/pyupm_si114x.i
+++ b/src/si114x/pyupm_si114x.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_si114x
 %include "../upm.i"
 

--- a/src/sm130/pyupm_sm130.i
+++ b/src/sm130/pyupm_sm130.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_sm130
 %include "../upm.i"
 

--- a/src/st7735/pyupm_st7735.i
+++ b/src/st7735/pyupm_st7735.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_st7735
 %include "../upm.i"
 

--- a/src/stepmotor/pyupm_stepmotor.i
+++ b/src/stepmotor/pyupm_stepmotor.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_stepmotor
 %include "../upm.i"
 

--- a/src/sx1276/pyupm_sx1276.i
+++ b/src/sx1276/pyupm_sx1276.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_sx1276
 %include "../upm.i"
 %include "cpointer.i"

--- a/src/sx6119/pyupm_sx6119.i
+++ b/src/sx6119/pyupm_sx6119.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_sx6119
 %include "../upm.i"
 

--- a/src/ta12200/pyupm_ta12200.i
+++ b/src/ta12200/pyupm_ta12200.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ta12200
 %include "../upm.i"
 

--- a/src/tcs3414cs/pyupm_tcs3414cs.i
+++ b/src/tcs3414cs/pyupm_tcs3414cs.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_tcs3414cs
 %include "../upm.i"
 

--- a/src/th02/pyupm_th02.i
+++ b/src/th02/pyupm_th02.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_th02
 %include "../upm.i"
 

--- a/src/tm1637/pyupm_tm1637.i
+++ b/src/tm1637/pyupm_tm1637.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_tm1637
 %include "../upm.i"
 %include "../carrays_uint8_t.i"

--- a/src/tsl2561/pyupm_tsl2561.i
+++ b/src/tsl2561/pyupm_tsl2561.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_tsl2561
 %include "../upm.i"
 

--- a/src/ttp223/pyupm_ttp223.i
+++ b/src/ttp223/pyupm_ttp223.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ttp223
 %include "../upm.i"
 

--- a/src/ublox6/pyupm_ublox6.i
+++ b/src/ublox6/pyupm_ublox6.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_ublox6
 %include "../upm.i"
 %include "stdint.i"

--- a/src/uln200xa/pyupm_uln200xa.i
+++ b/src/uln200xa/pyupm_uln200xa.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_uln200xa
 %include "../upm.i"
 

--- a/src/urm37/pyupm_urm37.i
+++ b/src/urm37/pyupm_urm37.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_urm37
 %include "../upm.i"
 %include "std_string.i"

--- a/src/waterlevel/pyupm_waterlevel.i
+++ b/src/waterlevel/pyupm_waterlevel.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_waterlevel
 %include "../upm.i"
 

--- a/src/wheelencoder/pyupm_wheelencoder.i
+++ b/src/wheelencoder/pyupm_wheelencoder.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_wheelencoder
 %include "../upm.i"
 

--- a/src/wt5001/pyupm_wt5001.i
+++ b/src/wt5001/pyupm_wt5001.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_wt5001
 %include "../upm.i"
 %include "../carrays_uint8_t.i"

--- a/src/xbee/pyupm_xbee.i
+++ b/src/xbee/pyupm_xbee.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_xbee
 %include "../upm.i"
 %include "carrays.i"

--- a/src/yg1006/pyupm_yg1006.i
+++ b/src/yg1006/pyupm_yg1006.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_yg1006
 %include "../upm.i"
 

--- a/src/zfm20/pyupm_zfm20.i
+++ b/src/zfm20/pyupm_zfm20.i
@@ -1,3 +1,5 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
 %module pyupm_zfm20
 %include "../upm.i"
 %include "../carrays_uint16_t.i"


### PR DESCRIPTION
Include doxygen documentation collateral in python sensor modules.  This runs
when BUILDDOC and BUILDSWIGPYTHON are set.  The general flow is:

    doxygen -> index.xml -> doxy2swig.py -> pyupm_doxy2swig.i -> swig

    * Removed registered trademark symbol from README.ccp.md since this
    does not agree with the include version of doxy2swig.py.

    * Removed per-sensor target run of doxy2swig.py.  pyupm_XXX targets now
    depend on the output of doxy2swig.

    * Added custom command to build pyupm_doxy2swig.i from index.xml.  If
    BUILDDOC=OFF, an empty stub pyupm_doxy2swig.i is used.  A single output
    .i file is generated which is used by ALL pyupm_XXX sensor targets.

    * Added %include pyupm_doxy2swig.i per pyupm_XXX sensor target.

    * Added swig source file property which includes build directory.
