### PR TITLE
swig typechecks: ensure that all uint*_t passed in have the correct t…

### DIFF
--- a/src/carrays_uint16_t.i
+++ b/src/carrays_uint16_t.i
@@ -6,3 +6,30 @@
 %include "stdint.i"
 %include "carrays.i"
 %array_class(uint16_t, uint16Array);
+
+// Adding these typemaps because SWIG is converting uint8, uint16, and uint32 into a short by default
+// This forces SWIG to convert it correctly
+
+#if (SWIG_JAVASCRIPT_V8)
+%typemap(in) uint16_t * {
+  void *argp = 0 ;
+  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
+  if (!SWIG_IsOK(res)) {
+    SWIG_exception_fail(SWIG_ArgError(res), "failed to convert input to uint16");
+  }
+  $1 = (uint16_t *)(argp);
+}
+#endif
+
+#if (SWIGPYTHON)
+%typemap(in) uint16_t * {
+  void *argp = 0 ;
+  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
+  if (!SWIG_IsOK(res)) {
+    SWIG_exception_fail(SWIG_ArgError(res), "failed to convert input to uint16");
+  }
+  $1 = reinterpret_cast< uint16_t * >(argp);
+}
+#endif
+
+//#elsif (SWIGJAVA)

--- a/src/carrays_uint32_t.i
+++ b/src/carrays_uint32_t.i
@@ -6,3 +6,51 @@
 %include "stdint.i"
 %include "carrays.i"
 %array_class(uint32_t, uint32Array);
+
+// Adding these typemaps because SWIG is converting uint8, uint16, and uint32 into a short by default
+// This forces SWIG to convert it correctly
+
+#if (SWIG_JAVASCRIPT_V8)
+%typemap(in) uint32_t * {
+  void *argp = 0 ;
+  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint32Array, 0 |  0 );
+  if (!SWIG_IsOK(res)) {
+    SWIG_exception_fail(SWIG_ArgError(res), "failed to convert input to uint32 *");
+  }
+  $1 = (uint32_t *)(argp);
+}
+
+/*$input (non-pointer) is a v8::object, which inherits from v8::value */
+%typemap(in) uint32_t {
+  int ecode2 = 0 ;
+  if (($input)->IsInt32())
+    $1 = ($input)->Uint32Value();
+  else
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "failed to convert uint32");
+}
+#endif
+
+#if (SWIGPYTHON)
+%typemap(in) uint32_t * {
+  void *argp = 0 ;
+  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint32Array, 0 |  0 );
+  if (!SWIG_IsOK(res)) {
+    SWIG_exception_fail(SWIG_ArgError(res), "failed to convert input to uint32 *");
+  }
+  $1 = reinterpret_cast< uint32_t * >(argp);
+}
+
+/*$input (non-pointer) */
+%typemap(in) uint32_t {
+  long v;
+  int res = SWIG_AsVal_long ($input, &v);
+  if (SWIG_IsOK(res)) {
+    $1 = PyInt_AsLong($input);
+  }
+  else {
+    SWIG_exception_fail(SWIG_ArgError(res), "failed to convert uint32");
+  }
+}
+#endif
+
+//#elsif (SWIGJAVA)

--- a/src/carrays_uint8_t.i
+++ b/src/carrays_uint8_t.i
@@ -6,3 +6,30 @@
 %include "stdint.i"
 %include "carrays.i"
 %array_class(uint8_t, uint8Array);
+
+// Adding these typemaps because SWIG is converting uint8, uint16, and uint32 into a short by default
+// This forces SWIG to convert it correctly
+
+#if (SWIG_JAVASCRIPT_V8)
+%typemap(in) uint8_t * {
+  void *argp = 0 ;
+  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint8Array, 0 |  0 );
+  if (!SWIG_IsOK(res)) {
+    SWIG_exception_fail(SWIG_ArgError(res), "failed to convert input to uint8");
+  }
+  $1 = (uint8_t *)(argp);
+}
+#endif
+
+#if (SWIGPYTHON)
+%typemap(in) uint8_t * {
+  void *argp = 0 ;
+  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint8Array, 0 |  0 );
+  if (!SWIG_IsOK(res)) {
+    SWIG_exception_fail(SWIG_ArgError(res), "failed to convert input to uint8");
+  }
+  $1 = reinterpret_cast< uint8_t * >(argp);
+}
+#endif
+
+//#elsif (SWIGJAVA)

--- a/src/gas/jsupm_gas.i
+++ b/src/gas/jsupm_gas.i
@@ -2,12 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint16_t.i"
 
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = (uint16_t *)(argp);
-}
-
 %include "gas.h"
 %{
     #include "gas.h"

--- a/src/gas/pyupm_gas.i
+++ b/src/gas/pyupm_gas.i
@@ -2,12 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint16_t.i"
 
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = reinterpret_cast< uint16_t * >(argp);
-}
-
 %feature("autodoc", "3");
 
 %include "gas.h"

--- a/src/hmtrp/jsupm_hmtrp.i
+++ b/src/hmtrp/jsupm_hmtrp.i
@@ -4,26 +4,6 @@
 %include "../carrays_uint16_t.i"
 %include "../carrays_uint32_t.i"
 
-// Adding this typemap because SWIG is converting uint8, uint16, and uint32 into a short by default
-// This forces SWIG to convert it correctly
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = (uint8_t *)(argp);
-}
-
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = (uint16_t *)(argp);
-}
-
-%typemap(in) uint32_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint32Array, 0 |  0 );
-  $1 = (uint32_t *)(argp);
-}
-
 %{
     #include "hmtrp.h"
     speed_t int_B9600 = B9600;

--- a/src/hmtrp/pyupm_hmtrp.i
+++ b/src/hmtrp/pyupm_hmtrp.i
@@ -4,26 +4,6 @@
 %include "../carrays_uint16_t.i"
 %include "../carrays_uint32_t.i"
 
-// Adding this typemap because SWIG is converting uint8, uint16, and uint32 into a short by default
-// This forces SWIG to convert it correctly
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = reinterpret_cast< uint8_t * >(argp);
-}
-
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = reinterpret_cast< uint16_t * >(argp);
-}
-
-%typemap(in) uint32_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint32Array, 0 |  0 );
-  $1 = reinterpret_cast< uint32_t * >(argp);
-}
-
 %feature("autodoc", "3");
 
 %include "hmtrp.h"

--- a/src/lcd/jsupm_i2clcd.i
+++ b/src/lcd/jsupm_i2clcd.i
@@ -2,12 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint8_t.i"
 
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = (uint8_t *)(argp);
-}
-
 %include "ssd.h"
 %include "lcd.h"
 %{

--- a/src/lcd/pyupm_i2clcd.i
+++ b/src/lcd/pyupm_i2clcd.i
@@ -2,13 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint8_t.i"
 
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = reinterpret_cast< uint8_t * >(argp);
-}
-
-
 %feature("autodoc", "3");
 
 %include "ssd.h"

--- a/src/mic/jsupm_mic.i
+++ b/src/mic/jsupm_mic.i
@@ -2,12 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint16_t.i"
 
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = (uint16_t *)(argp);
-}
-
 %{
     #include "mic.h"
 %}

--- a/src/mic/pyupm_mic.i
+++ b/src/mic/pyupm_mic.i
@@ -2,12 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint16_t.i"
 
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = reinterpret_cast< uint16_t * >(argp);
-}
-
 %{
     #include "mic.h"
 %}

--- a/src/pn532/jsupm_pn532.i
+++ b/src/pn532/jsupm_pn532.i
@@ -2,14 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint8_t.i"
 
-// Adding this typemap because SWIG is converting uint8 into a short by default
-// This forces SWIG to convert it correctly
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = (uint8_t *)(argp);
-}
-
 %{
     #include "pn532.h"
 %}

--- a/src/pn532/pyupm_pn532.i
+++ b/src/pn532/pyupm_pn532.i
@@ -2,14 +2,6 @@
 %include "../upm.i"
 %include "../carrays_uint8_t.i"
 
-// Adding this typemap because SWIG is converting uint8, uint16, and uint32 into a short by default
-// This forces SWIG to convert it correctly
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = reinterpret_cast< uint8_t * >(argp);
-}
-
 %feature("autodoc", "3");
 
 #ifdef DOXYGEN

--- a/src/tm1637/jsupm_tm1637.i
+++ b/src/tm1637/jsupm_tm1637.i
@@ -7,12 +7,6 @@
 %rename("writeArray")  write(uint8_t *digits);
 %rename("writeString") write(std::string digits);
 
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp, SWIGTYPE_p_uint8Array, 0 | 0);
-  $1 = (uint8_t *)(argp);
-}
-
 %{
     #include "tm1637.h"
 %}

--- a/src/tm1637/pyupm_tm1637.i
+++ b/src/tm1637/pyupm_tm1637.i
@@ -4,12 +4,6 @@
 
 %varargs(4, int digit = 0) write;
 
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = reinterpret_cast< uint8_t * >(argp);
-}
-
 %{
     #include "tm1637.h"
 %}

--- a/src/wt5001/jsupm_wt5001.i
+++ b/src/wt5001/jsupm_wt5001.i
@@ -3,19 +3,6 @@
 %include "../carrays_uint8_t.i"
 %include "../carrays_uint16_t.i"
 
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = (uint8_t *)(argp);
-}
-
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = (uint16_t *)(argp);
-}
-
-
 %{
     #include "wt5001.h"
     speed_t int_B9600 = B9600;

--- a/src/wt5001/pyupm_wt5001.i
+++ b/src/wt5001/pyupm_wt5001.i
@@ -3,18 +3,6 @@
 %include "../carrays_uint8_t.i"
 %include "../carrays_uint16_t.i"
 
-%typemap(in) uint8_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint8Array, 0 |  0 );
-  $1 = reinterpret_cast< uint8_t * >(argp);
-}
-
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = reinterpret_cast< uint16_t * >(argp);
-}
-
 %feature("autodoc", "3");
 
 %{

--- a/src/zfm20/jsupm_zfm20.i
+++ b/src/zfm20/jsupm_zfm20.i
@@ -4,17 +4,6 @@
 %include "../carrays_uint32_t.i"
 %include "cpointer.i"
 
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = (uint16_t *)(argp);
-}
-
-/*$input is a v8::object, which inherits from v8::value */
-%typemap(in) uint32_t {
-   $1 = ($input)->Uint32Value();
-}
-
 /* Send "int *" to JavaScript as intp */
 %pointer_functions(int, intp);
 %{

--- a/src/zfm20/pyupm_zfm20.i
+++ b/src/zfm20/pyupm_zfm20.i
@@ -6,16 +6,6 @@
 
 %feature("autodoc", "3");
 
-%typemap(in) uint16_t * {
-  void *argp = 0 ;
-  int res = SWIG_ConvertPtr($input, &argp,SWIGTYPE_p_uint16Array, 0 |  0 );
-  $1 = reinterpret_cast< uint16_t * >(argp);
-}
-
-%typemap(in) uint32_t {
-   $1 = PyInt_AsLong($input);
-}
-
 /* Send "int *" to python as intp */
 %pointer_functions(int, intp);
 %{


### PR DESCRIPTION
…ype.

Otherwise, we generate an exception.  This should fix Issue #172:

https://github.com/intel-iot-devkit/upm/issues/172

Signed-off-by: Zion Orent <zorent@ics.com>
Signed-off-by: Jon Trulson <jtrulson@ics.com>