### PR TITLE
hmtrp, wt5001: (swig) rename funcs that caused overload errors in python

### DIFF
--- a/src/hmtrp/pyupm_hmtrp.i
+++ b/src/hmtrp/pyupm_hmtrp.i
@@ -24,6 +24,9 @@
   $1 = reinterpret_cast< uint32_t * >(argp);
 }
 
+%rename("getModSignalStrengthNoParam")  getModSignalStrength();
+%rename("getRFSignalStrengthNoParam") getRFSignalStrength();
+
 %feature("autodoc", "3");
 
 %include "hmtrp.h"

--- a/src/wt5001/pyupm_wt5001.i
+++ b/src/wt5001/pyupm_wt5001.i
@@ -15,6 +15,11 @@
   $1 = reinterpret_cast< uint16_t * >(argp);
 }
 
+%rename("getVolumeNoParam")  getVolume();
+%rename("getPlayStateNoParam") getPlayState();
+%rename("getNumFilesOneParam")  getNumFiles(WT5001_PLAYSOURCE_T psrc);
+%rename("getCurrentFileNoParam") getCurrentFile();
+
 %feature("autodoc", "3");
 
 %{


### PR DESCRIPTION
Signed-off-by: Zion Orent <zorent@ics.com>
Signed-off-by: Jon Trulson <jtrulson@ics.com>