### PR TITLE
hdxxvxta: Initial implementation

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -232,6 +232,7 @@ if (OPENZWAVE_FOUND)
 endif()
 add_example (nlgpio16)
 add_example (ads1x15)
+add_example (hdxxvxta)
 
 # These are special cases where you specify example binary, source file and module(s)
 include_directories (${PROJECT_SOURCE_DIR}/src)

--- a/examples/c++/hdxxvxta.cxx
+++ b/examples/c++/hdxxvxta.cxx
@@ -1,0 +1,79 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <signal.h>
+
+#include "hdxxvxta.h"
+
+using namespace std;
+
+bool shouldRun = true;
+
+void sig_handler(int signo)
+{
+  if (signo == SIGINT)
+    shouldRun = false;
+}
+
+int main(int argc, char **argv)
+{
+  signal(SIGINT, sig_handler);
+
+//! [Interesting]
+
+  cout << "Initializing..." << endl;
+
+  // Instantiate an HDXXVXTA instance, using A1 for humidity and A0
+  // for temperature
+  upm::HDXXVXTA *sensor = new upm::HDXXVXTA(1, 0);
+
+  // update and print available values every second
+  while (shouldRun)
+    {
+      // update our values from the sensor
+      sensor->update();
+
+      // we show both C and F for temperature
+      cout << "Temperature: " << sensor->getTemperature()
+           << " C / " << sensor->getTemperature(true) << " F"
+           << endl;
+
+      cout << "Humidity: " << sensor->getHumidity()
+           << " %" << endl;
+
+      cout << endl;
+
+      sleep(1);
+    }
+
+  cout << "Exiting..." << endl;
+
+  delete sensor;
+
+//! [Interesting]
+
+  return 0;
+}

--- a/examples/javascript/hdxxvxta.js
+++ b/examples/javascript/hdxxvxta.js
@@ -1,0 +1,64 @@
+/*jslint node:true, vars:true, bitwise:true, unparam:true */
+/*jshint unused:true */
+
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+var sensorObj = require('jsupm_hdxxvxta');
+
+
+/************** Main code **************/
+
+console.log("Initializing...");
+
+// Instantiate an HDXXVXTA instance, using A1 for humidity and A0
+// for temperature
+var sensor = new sensorObj.HDXXVXTA(1, 0);
+
+// update and print available values every second
+setInterval(function()
+{
+    // update our values from the sensor
+    sensor.update();
+
+    // we show both C and F for temperature
+    console.log("Temperature:", sensor.getTemperature(),
+                "C /", sensor.getTemperature(true), "F");
+
+    console.log("Humidity:", sensor.getHumidity(), "%");
+
+    console.log("");
+
+}, 1000);
+
+
+process.on('SIGINT', function()
+{
+    sensor = null;
+    sensorObj.cleanUp();
+    sensorObj = null;
+    console.log("Exiting...");
+    process.exit(0);
+});

--- a/examples/python/hdxxvxta.py
+++ b/examples/python/hdxxvxta.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# Author: Jon Trulson <jtrulson@ics.com>
+# Copyright (c) 2016 Intel Corporation.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import time, sys, signal, atexit
+import pyupm_hdxxvxta as sensorObj
+
+## Exit handlers ##
+# This function stops python from printing a stacktrace when you hit control-C
+def SIGINTHandler(signum, frame):
+	raise SystemExit
+
+# This function lets you run code on exit
+def exitHandler():
+	print "Exiting"
+	sys.exit(0)
+
+# Register exit handlers
+atexit.register(exitHandler)
+signal.signal(signal.SIGINT, SIGINTHandler)
+
+print "Initializing..."
+
+# Instantiate an HDXXVXTA instance, using A1 for humidity and A0
+# for temperature
+sensor = sensorObj.HDXXVXTA(1, 0)
+
+# update and print available values every second
+while (1):
+        # update our values from the sensor
+        sensor.update()
+
+        # we show both C and F for temperature
+        print "Temperature:", sensor.getTemperature(), "C /",
+        print sensor.getTemperature(True), "F"
+
+        print "Humidity:", sensor.getHumidity(), "%"
+
+        print
+	time.sleep(1)

--- a/src/hdxxvxta/CMakeLists.txt
+++ b/src/hdxxvxta/CMakeLists.txt
@@ -1,0 +1,5 @@
+set (libname "hdxxvxta")
+set (libdescription "upm Veris HDXXVXTA Temperature/Humidity transmitter")
+set (module_src ${libname}.cxx)
+set (module_h ${libname}.h)
+upm_module_init()

--- a/src/hdxxvxta/hdxxvxta.cxx
+++ b/src/hdxxvxta/hdxxvxta.cxx
@@ -1,0 +1,122 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <iostream>
+
+#include "hdxxvxta.h"
+
+using namespace upm;
+using namespace std;
+
+// conversion from celcius to fahrenheit
+
+static float c2f(float c)
+{
+  return (c * (9.0 / 5.0) + 32.0);
+}
+
+
+HDXXVXTA::HDXXVXTA(int hPin, int tPin, float aref) :
+  m_aioHum(hPin), m_aioTemp(0)
+{
+  if (tPin >= 0)
+    m_hasTemp = true;
+  else
+    m_hasTemp = false;
+
+  m_temperature = 0.0;
+  m_humidity = 0.0;
+
+  if (m_hasTemp)
+    {
+      m_aioTemp = new mraa::Aio(tPin);
+      m_aResTemp = (1 << m_aioTemp->getBit());
+    }
+  else
+    m_aResTemp = 0;
+
+  m_aResHum = (1 << m_aioHum.getBit());
+  m_aref = aref;
+
+  // set the default temperature range to the A1 series (-40C-50C),
+  // regardless of whether temperature measuring is enabled
+  setRange(RANGE_MINUS40_50);
+}
+
+HDXXVXTA::~HDXXVXTA()
+{
+  if (m_aioTemp)
+    delete m_aioTemp;
+}
+
+void HDXXVXTA::update()
+{
+  // temperature
+  int val;
+  float volts;
+
+  if (m_hasTemp)
+    {
+      val = m_aioTemp->read();
+      volts = (float(val) * (m_aref / m_aResTemp));
+
+      switch (m_range)
+        {
+        case RANGE_MINUS40_50:
+          // valid range is 50 + abs(-40) = 90
+          m_temperature = ((volts / m_aref) * 90.0) - 40.0;
+          break;
+          
+        case RANGE_0_50:
+          // valid range is 50
+          m_temperature = ((volts / m_aref) * 50.0);
+          break;
+          
+        default:
+          // shouldn't happen, but...
+          throw std::out_of_range(std::string(__FUNCTION__) +
+                                  ": internal error, invalid range value");
+          break;
+        }
+    }
+
+  // humidity
+  val = m_aioHum.read();
+  volts = (float(val) * (m_aref / m_aResHum));
+  m_humidity = ((volts / m_aref) * 100.0);
+}
+
+float HDXXVXTA::getTemperature(bool fahrenheit)
+{
+  if (fahrenheit)
+    return c2f(m_temperature);
+  else
+    return m_temperature;
+}
+
+float HDXXVXTA::getHumidity()
+{
+  return m_humidity;
+}
+

--- a/src/hdxxvxta/hdxxvxta.h
+++ b/src/hdxxvxta/hdxxvxta.h
@@ -1,0 +1,166 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include <iostream>
+
+#include <mraa/aio.hpp>
+
+// Unlikey to be changable without external circuitry (voltage divider)
+#define HDXXVXTA_DEFAULT_AREF 5.0
+
+namespace upm {
+    /**
+     * @brief Veris HDXXVXTA Humidity Transmitter
+     * @defgroup hdxxvxta libupm-hdxxvxta
+     * @ingroup veris ainput temp
+     */
+
+    /**
+     * @library hdxxvxta
+     * @sensor hdxxvxta
+     * @comname Veris HDXXVXTA Humidity Transmitter family
+     * @type temp
+     * @man veris
+     * @con ainput
+     * @web http://www.veris.com/Item/HD2NVSTA1.aspx
+     *
+     * @brief API for the Veris HDXXVXTA Humidity Transmitter
+     *
+     * The driver was developed using the HD2NVSTA1 humidity
+     * transmitter.  The 'T' variant supports a temperature
+     * transmitter as well.  Both signals are provided by the device
+     * as analog 0-5Vdc or 0-10Vdc outputs.  The A1 variant supports a
+     * temperature range of -40C-50C, while the A2 variant supports a
+     * range of 0C-50C.  Humidity ranges for all devices in this
+     * device family range from 0% to 100% (non-condensing).
+     *
+     * This driver used the 5Vdc outputs for obvious reasons.  Your
+     * MCU must be configured for 5V operation.  Using any other
+     * analog reference voltage will require the appropriate external
+     * circuitry (such as a voltage divider) in order to interface
+     * safely with your MCU.
+     *
+     * For devices which do not support temperature, use '-1' as the
+     * temperature pin number in the object constructor.  If
+     * temperature measurement is disabled, getTemperature() will always
+     * return 0C/32F.
+     *
+     * @snippet hdxxvxta.cxx Interesting
+     */
+
+  class HDXXVXTA {
+  public:
+
+    typedef enum {
+      // *A1 series (-40C-50C)
+      RANGE_MINUS40_50                      = 1,
+      // *A2 series (0C-50C)
+      RANGE_0_50                            = 2
+    } RANGE_T;
+
+    /**
+     * HDXXVXTA object constructor
+     *
+     * @param hPin Analog pin to use for the humidity measurement
+     * @param tPin Analog pin to use for temperature.  If your device
+     * does not support temperature, use -1 as the value so that
+     * temperature will not be queried and an analog pin won't be
+     * wasted.
+     * @param aref The analog reference voltage, default 5.0
+     */
+    HDXXVXTA(int hPin, int tPin, float aref=HDXXVXTA_DEFAULT_AREF);
+
+    /**
+     * HDXXVXTA object destructor
+     */
+    ~HDXXVXTA();
+
+    /**
+     * Set the temperature range of the sensor.  HD*A1 sensors support
+     * a range of -40C-50C, while HD*A2 devices support a temperature
+     * range of 0C-50C.  The constructor sets a default of
+     * RANGE_MINUS40_50.
+     *
+     * @param One of the RANGE_T values, default is RANGE_MINUS40_50
+     */
+    void setRange(RANGE_T range=RANGE_MINUS40_50)
+    {
+      m_range = range;
+    };
+
+    /**
+     * Read current values from the sensor and update internal stored
+     * values.  This method must be called prior to querying any
+     * values, such as temperature or humidity.
+     */
+    void update();
+
+    /**
+     * Get the current temperature.  update() must have been called
+     * prior to calling this method.  If temperature measurement was
+     * disabled (by passing -1 as the temperature pin in the
+     * constructor) then this function will always return 0C/32F.
+     *
+     * @param fahrenheit true to return the temperature in degrees
+     * fahrenheit, false to return the temperature in degrees celcius.
+     * The default is false (degrees Celcius).
+     * @return The last temperature reading in Celcius or Fahrenheit
+     */
+    float getTemperature(bool fahrenheit=false);
+
+    /**
+     * Get the current relative humidity.  update() must have been called
+     * prior to calling this method.
+     *
+     * @return The last humidity reading
+     */
+    float getHumidity();
+
+
+  protected:
+    // temperature is an optional feature of the humidity transmitter
+    mraa::Aio *m_aioTemp;
+
+    mraa::Aio m_aioHum;
+
+  private:
+    float m_aref;
+    int m_aResTemp;
+    int m_aResHum;
+
+    // does this sensor support temperature reporting?
+    bool m_hasTemp;
+
+    // in Celcius
+    float m_temperature;
+
+    float m_humidity;
+
+    RANGE_T m_range;
+  };
+}
+
+

--- a/src/hdxxvxta/javaupm_hdxxvxta.i
+++ b/src/hdxxvxta/javaupm_hdxxvxta.i
@@ -1,0 +1,21 @@
+%module javaupm_hdxxvxta
+%include "../upm.i"
+%include "std_string.i"
+
+%{
+    #include "hdxxvxta.h"
+%}
+
+%include "hdxxvxta.h"
+
+
+%pragma(java) jniclasscode=%{
+    static {
+        try {
+            System.loadLibrary("javaupm_hdxxvxta");
+        } catch (UnsatisfiedLinkError e) {
+            System.err.println("Native code library failed to load. \n" + e);
+            System.exit(1);
+        }
+    }
+%}

--- a/src/hdxxvxta/jsupm_hdxxvxta.i
+++ b/src/hdxxvxta/jsupm_hdxxvxta.i
@@ -1,0 +1,10 @@
+%module jsupm_hdxxvxta
+%include "../upm.i"
+%include "std_string.i"
+
+%{
+    #include "hdxxvxta.h"
+%}
+
+%include "hdxxvxta.h"
+

--- a/src/hdxxvxta/pyupm_hdxxvxta.i
+++ b/src/hdxxvxta/pyupm_hdxxvxta.i
@@ -1,0 +1,13 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
+%module pyupm_hdxxvxta
+%include "../upm.i"
+%include "std_string.i"
+
+%feature("autodoc", "3");
+
+%{
+    #include "hdxxvxta.h"
+%}
+%include "hdxxvxta.h"
+

--- a/src/upm.h
+++ b/src/upm.h
@@ -338,6 +338,12 @@
  * @ingroup byman
  */
 
+/**
+ * @brief Veris Industries
+ * @defgroup veris Veris Industries
+ * @ingroup byman
+ */
+
 ////////////////////////////////////////////////////////////////// @cond KIT
 /// Groups for the various Starter Kits.
 ////////////////////////////////////////////////////////////////// @endcond KIT


### PR DESCRIPTION
This driver was developed using the Veris HD2NVSTA1 humidity
transmitter.  The 'T' variant supports a temperature transmitter as
well.  Both signals are provided by the device as analog 0-5Vdc or
0-10Vdc outputs.

The A1 variant supports a temperature range of -40C-50C, while the A2
variant supports a range of 0C-50C.  Humidity ranges for all devices
in this device family range from 0% to 100% (non-condensing).

Temperature measurement can be disabled by passing -1 as the
temperature analog pin to the constructor.

Signed-off-by: Jon Trulson <jtrulson@ics.com>