### PR TITLE
tex00: Initial Implementation

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -239,6 +239,7 @@ add_example (hdxxvxta)
 add_example (rhusb)
 add_example (apds9930)
 add_example (kxcjk1013)
+add_example (tex00)
 
 # These are special cases where you specify example binary, source file and module(s)
 include_directories (${PROJECT_SOURCE_DIR}/src)

--- a/examples/c++/tex00.cxx
+++ b/examples/c++/tex00.cxx
@@ -1,0 +1,91 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <signal.h>
+
+#include "tex00.h"
+
+using namespace std;
+
+bool shouldRun = true;
+
+void sig_handler(int signo)
+{
+  if (signo == SIGINT)
+    shouldRun = false;
+}
+
+int main(int argc, char **argv)
+{
+  signal(SIGINT, sig_handler);
+
+//! [Interesting]
+
+  cout << "Initializing..." << endl;
+
+  // Instantiate an TEX00 instance, using A0 for the analog input.  In
+  // this example, we are using a 10K Ohm balance resistor and a TED
+  // (10k type 2) thermistor.
+  upm::TEX00 *sensor = new upm::TEX00(0, 10000, 
+                                      upm::TEX00::STYPE_THERMISTOR_TED);
+
+  cout << "Minimum temperature: " << sensor->getTemperatureRangeMin() 
+       << " C" << endl;
+  cout << "Maximum temperature: " << sensor->getTemperatureRangeMax() 
+       << " C" << endl;
+  cout << endl;
+  
+  // update and print available values every second
+  while (shouldRun)
+    {
+      // update our values from the sensor
+      sensor->update();
+
+      if (sensor->isOutOfRange())
+        {
+          cout << "Temperature out of range" << endl;
+        }
+      else
+        {
+          // we show both C and F for temperature
+          cout << "Temperature: " << sensor->getTemperature()
+               << " C / " << sensor->getTemperature(true) << " F"
+               << endl;
+        }
+
+      cout << endl;
+
+      sleep(1);
+    }
+
+  cout << "Exiting..." << endl;
+
+  delete sensor;
+
+//! [Interesting]
+
+  return 0;
+}

--- a/examples/java/CMakeLists.txt
+++ b/examples/java/CMakeLists.txt
@@ -101,7 +101,7 @@ add_example(WaterLevelSensor waterlevel)
 add_example(WT5001Sample wt5001)
 add_example(YG1006Sample yg1006)
 add_example(ZFM20Sample zfm20)
-
+add_example(TEX00_Example tex00)
 
 add_example_with_path(Jhd1313m1_lcdSample lcd/upm_i2clcd.jar)
 add_example_with_path(Jhd1313m1Sample lcd/upm_i2clcd.jar)

--- a/examples/java/TEX00_Example.java
+++ b/examples/java/TEX00_Example.java
@@ -1,0 +1,71 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import upm_tex00.TEX00;
+
+public class TEX00_Example 
+{
+    public static void main(String[] args) throws InterruptedException
+    {
+// ! [Interesting]
+        System.out.println("Initializing...");
+
+        // Instantiate an TEX00 instance, using A0 for the analog input.  In
+        // this example, we are using a 10K Ohm balance resistor and a TED
+        // (10k type 2) thermistor.
+        TEX00 sensor = new TEX00(0, 10000.0f, 
+                                 TEX00.SENSOR_TYPES_T.STYPE_THERMISTOR_TED);
+
+        System.out.println("Minimum temperature: " 
+                           + sensor.getTemperatureRangeMin());
+        System.out.println("Maximum temperature: " 
+                           + sensor.getTemperatureRangeMax());
+        System.out.println();
+
+        while (true)
+            {
+                // update our values from the sensor
+                sensor.update();
+
+                if (sensor.isOutOfRange())
+                    {
+                        System.out.println("Temperature out of range");
+                    }
+                else
+                    {
+                        // we show both C and F for temperature
+                        System.out.println("Temperature: " 
+                                           + sensor.getTemperature()
+                                           + " C / "
+                                           + sensor.getTemperature(true)
+                                           + " F");
+                    }
+
+                System.out.println();
+                Thread.sleep(1000);
+            }
+
+// ! [Interesting]
+    }
+}

--- a/examples/javascript/tex00.js
+++ b/examples/javascript/tex00.js
@@ -1,0 +1,77 @@
+/*jslint node:true, vars:true, bitwise:true, unparam:true */
+/*jshint unused:true */
+
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+var sensorObj = require('jsupm_tex00');
+
+
+/************** Main code **************/
+
+console.log("Initializing...");
+
+// Instantiate an TEX00 instance, using A0 for the analog input.  In
+// this example, we are using a 10K Ohm balance resistor and a TED
+// (10k type 2) thermistor.
+var sensor = new sensorObj.TEX00(0, 10000, 
+                                 sensorObj.TEX00.STYPE_THERMISTOR_TED);
+
+console.log("Minimum temperature:", sensor.getTemperatureRangeMin(),
+            "C");
+console.log("Maximum temperature:", sensor.getTemperatureRangeMax(),
+            "C");
+console.log("");
+
+// update and print available values every second
+setInterval(function()
+{
+    // update our values from the sensor
+    sensor.update();
+
+    if (sensor.isOutOfRange())
+    {
+        console.log("Temperature out of range");
+    }
+    else
+    {
+        // we show both C and F for temperature
+        console.log("Temperature:", sensor.getTemperature(),
+                    "C /", sensor.getTemperature(true), "F");
+    }
+
+    console.log("");
+
+}, 1000);
+
+
+process.on('SIGINT', function()
+{
+    sensor = null;
+    sensorObj.cleanUp();
+    sensorObj = null;
+    console.log("Exiting...");
+    process.exit(0);
+});

--- a/examples/python/tex00.py
+++ b/examples/python/tex00.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# Author: Jon Trulson <jtrulson@ics.com>
+# Copyright (c) 2016 Intel Corporation.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import time, sys, signal, atexit
+import pyupm_tex00 as sensorObj
+
+## Exit handlers ##
+# This function stops python from printing a stacktrace when you hit control-C
+def SIGINTHandler(signum, frame):
+	raise SystemExit
+
+# This function lets you run code on exit
+def exitHandler():
+	print "Exiting"
+	sys.exit(0)
+
+# Register exit handlers
+atexit.register(exitHandler)
+signal.signal(signal.SIGINT, SIGINTHandler)
+
+print "Initializing..."
+
+# Instantiate an TEX00 instance, using A0 for the analog input.  In
+# this example, we are using a 10K Ohm balance resistor and a TED
+# (10k type 2) thermistor.
+sensor = sensorObj.TEX00(0, 10000, sensorObj.TEX00.STYPE_THERMISTOR_TED)
+
+print "Minimum temperature:", sensor.getTemperatureRangeMin(), "C"
+print "Maximum temperature:", sensor.getTemperatureRangeMax(), "C"
+print
+
+# update and print available values every second
+while (1):
+        # update our values from the sensor
+        sensor.update()
+
+        if (sensor.isOutOfRange()):
+                print "Temperature out of range"
+        else:
+                # we show both C and F for temperature
+                print "Temperature:", sensor.getTemperature(), "C /",
+                print sensor.getTemperature(True), "F"
+
+        print
+	time.sleep(1)

--- a/src/tex00/CMakeLists.txt
+++ b/src/tex00/CMakeLists.txt
@@ -1,0 +1,5 @@
+set (libname "tex00")
+set (libdescription "upm Veris TEX00 Temperature thermistors")
+set (module_src ${libname}.cxx)
+set (module_h ${libname}.h)
+upm_module_init()

--- a/src/tex00/javaupm_tex00.i
+++ b/src/tex00/javaupm_tex00.i
@@ -1,0 +1,19 @@
+%module javaupm_tex00
+%include "../upm.i"
+%include "std_string.i"
+
+%include "tex00.h"
+%{
+    #include "tex00.h"
+%}
+
+%pragma(java) jniclasscode=%{
+    static {
+        try {
+            System.loadLibrary("javaupm_tex00");
+        } catch (UnsatisfiedLinkError e) {
+            System.err.println("Native code library failed to load. \n" + e);
+            System.exit(1);
+        }
+    }
+%}

--- a/src/tex00/jsupm_tex00.i
+++ b/src/tex00/jsupm_tex00.i
@@ -1,0 +1,10 @@
+%module jsupm_tex00
+%include "../upm.i"
+%include "std_string.i"
+
+%{
+    #include "tex00.h"
+%}
+
+%include "tex00.h"
+

--- a/src/tex00/pyupm_tex00.i
+++ b/src/tex00/pyupm_tex00.i
@@ -1,0 +1,13 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
+%module pyupm_tex00
+%include "../upm.i"
+%include "std_string.i"
+
+%feature("autodoc", "3");
+
+%{
+    #include "tex00.h"
+%}
+%include "tex00.h"
+

--- a/src/tex00/tex00.cxx
+++ b/src/tex00/tex00.cxx
@@ -1,0 +1,692 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <iostream>
+#include <math.h>
+#include "tex00.h"
+
+using namespace upm;
+using namespace std;
+
+// we average over several aio reads.
+static const int maxSamples = 10;
+
+// conversion from celcius to fahrenheit
+
+static float c2f(float c)
+{
+  return (c * (9.0 / 5.0) + 32.0);
+}
+
+
+TEX00::TEX00(int tPin, float balanceResistor, SENSOR_TYPES_T stype, 
+             float aref) :
+  m_aioTemp(tPin)
+{
+  m_aResTemp = (1 << m_aioTemp.getBit());
+
+  m_temperature = 0.0;
+  m_outOfRange = false;
+
+  m_aref = aref;
+  m_balanceResistor = balanceResistor;
+
+  // set default to NTC, however per-sensor init functions should set
+  // properly for the relevant sensor
+  m_isNTC = true;
+  
+  switch (stype)
+    {
+    case STYPE_THERMISTOR_TED:
+      initThermistorTED();
+      break;
+
+    case STYPE_THERMISTOR_TEB:
+      initThermistorTEB();
+      break;
+
+    case STYPE_THERMISTOR_TEC:
+      initThermistorTEC();
+      break;
+
+    case STYPE_THERMISTOR_TEI:
+      initThermistorTEI();
+      break;
+
+    case STYPE_THERMISTOR_TEE:
+      initThermistorTEE();
+      break;
+
+    case STYPE_THERMISTOR_TEF:
+      initThermistorTEF();
+      break;
+
+    case STYPE_THERMISTOR_TEH:
+      initThermistorTEH();
+      break;
+
+    case STYPE_THERMISTOR_TEJ:
+      initThermistorTEJ();
+      break;
+
+    case STYPE_THERMISTOR_TES:
+      initThermistorTES();
+      break;
+
+    case STYPE_THERMISTOR_TER:
+      initThermistorTER();
+      break;
+
+    case STYPE_THERMISTOR_TEM:
+      initThermistorTEM();
+      break;
+
+    case STYPE_THERMISTOR_TEU:
+      initThermistorTEU();
+      break;
+
+    case STYPE_THERMISTOR_TET:
+      initThermistorTET();
+      break;
+
+    default:
+      throw std::logic_error(std::string(__FUNCTION__) +
+                             ": internal error: invalid stype");
+    }
+}
+
+TEX00::~TEX00()
+{
+}
+
+void TEX00::update()
+{
+  int val = average(maxSamples);
+
+  // now determine the resistance of the sensor (this is a voltage divider)
+  float resistance = m_balanceResistor / 
+    ((float(m_aResTemp - 1) / float(val)) - 1.0);
+  
+  //  cerr << "Val = " << val << ", resistance = " << resistance << endl;
+
+  m_temperature = thermistor(resistance);
+}
+
+float TEX00::getTemperature(bool fahrenheit)
+{
+  if (fahrenheit)
+    return c2f(m_temperature);
+  else
+    return m_temperature;
+}
+
+int TEX00::average(int samples)
+{
+  if (samples <= 0)
+    samples = 1;
+  
+  int avg = 0;
+  for (int i=0; i<samples; i++)
+    avg += m_aioTemp.read();
+  
+  return (avg / samples);
+}
+
+float TEX00::thermistor(float ohms)
+{
+  // sanity check
+  if (m_tempVector.empty())
+    {
+      throw std::logic_error(std::string(__FUNCTION__) +
+                             ": internal error: temperature table is empty");
+    }
+
+  int found = -1;
+  int next = -1;
+  
+  if (m_isNTC)
+    {
+      // reverse search
+      for (int i=m_tempVector.size() - 1; i>=0; i--)
+        if (ohms < m_tempVector[i].ohms)
+          {
+            found = i;
+            next = found + 1;
+            break;
+          }
+    }
+  else
+    {
+      // PTC
+      for (int i=0; i<m_tempVector.size(); i++)
+        if (ohms < m_tempVector[i].ohms)
+          {
+            found = i;
+            next = found - 1;
+            break;
+          }
+    }
+
+  if (found < 0 || next < 0 || 
+      found >= m_tempVector.size() || next >= m_tempVector.size())
+    {
+      m_outOfRange = true;
+      // return last measured temperature
+      return m_temperature;
+    }
+  else
+    m_outOfRange = false;
+  
+  // calculate the percentages of ohms and temp
+  float diffO = m_tempVector[found].ohms - m_tempVector[next].ohms;
+  ohms -= m_tempVector[next].ohms;
+  
+  diffO = ohms / diffO;
+  
+  float diffT;
+  if (m_isNTC)
+    diffT = m_tempVector[next].temp - m_tempVector[found].temp;
+  else
+    diffT = m_tempVector[found].temp - m_tempVector[next].temp;
+
+  // compute offset
+  float tempOffset = fabs(diffT * diffO);
+
+  // apply according to NTC or PTC
+  if (m_isNTC)
+    return m_tempVector[next].temp - tempOffset;
+  else
+    return m_tempVector[next].temp + tempOffset;
+}
+
+float TEX00::getTemperatureRangeMin()
+{
+  if (m_tempVector.empty())
+    {
+      throw std::logic_error(std::string(__FUNCTION__) +
+                             ": internal error: temperature table is empty");
+    }
+
+  return m_tempVector[0].temp;
+}
+
+float TEX00::getTemperatureRangeMax()
+{
+  if (m_tempVector.empty())
+    {
+      throw std::logic_error(std::string(__FUNCTION__) +
+                             ": internal error: temperature table is empty");
+    }
+
+  return m_tempVector[m_tempVector.size() - 1].temp;
+}
+
+
+void TEX00::initThermistorTED()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "D" (10K type 2) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms      temperature (C)
+  m_tempVector.push_back(tempEntry(692700,   -50));
+  m_tempVector.push_back(tempEntry(344700,   -40));
+  m_tempVector.push_back(tempEntry(180100,   -30));
+  m_tempVector.push_back(tempEntry(98320,    -20));
+  m_tempVector.push_back(tempEntry(55790,    -10));
+  m_tempVector.push_back(tempEntry(32770,    0));
+  m_tempVector.push_back(tempEntry(19930,    10));
+  m_tempVector.push_back(tempEntry(12500,    20));
+  m_tempVector.push_back(tempEntry(10000,    25));
+  m_tempVector.push_back(tempEntry(8055,     30));
+  m_tempVector.push_back(tempEntry(5323,     40));
+  m_tempVector.push_back(tempEntry(3599,     50));
+  m_tempVector.push_back(tempEntry(2486,     60));
+  m_tempVector.push_back(tempEntry(1753,     70));
+  m_tempVector.push_back(tempEntry(1258,     80));
+  m_tempVector.push_back(tempEntry(919,      90));
+  m_tempVector.push_back(tempEntry(682,      100));
+  m_tempVector.push_back(tempEntry(513,      110));
+  m_tempVector.push_back(tempEntry(392,      120));
+  m_tempVector.push_back(tempEntry(303,      130));
+}
+
+void TEX00::initThermistorTEB()
+{
+  // this is a PTC type thermistor
+  m_isNTC = false;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "B" (100 Ohm) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(80.306,     -50));
+  m_tempVector.push_back(tempEntry(84.271,     -40));
+  m_tempVector.push_back(tempEntry(88.222,     -30));
+  m_tempVector.push_back(tempEntry(92.160,     -20));
+  m_tempVector.push_back(tempEntry(96.086,     -10));
+  m_tempVector.push_back(tempEntry(100,        0));
+  m_tempVector.push_back(tempEntry(103.903,    10));
+  m_tempVector.push_back(tempEntry(107.794,    20));
+  m_tempVector.push_back(tempEntry(109.735,    25));
+  m_tempVector.push_back(tempEntry(111.673,    30));
+  m_tempVector.push_back(tempEntry(115.541,    40));
+  m_tempVector.push_back(tempEntry(119.397,    50));
+  m_tempVector.push_back(tempEntry(123.242,    60));
+  m_tempVector.push_back(tempEntry(127.075,    70));
+  m_tempVector.push_back(tempEntry(130.897,    80));
+  m_tempVector.push_back(tempEntry(134.707,    90));
+  m_tempVector.push_back(tempEntry(138.506,    100));
+  m_tempVector.push_back(tempEntry(142.293,    110));
+  m_tempVector.push_back(tempEntry(146.068,    120));
+  m_tempVector.push_back(tempEntry(149.332,    130));
+}
+
+void TEX00::initThermistorTEC()
+{
+  // this is a PTC type thermistor
+  m_isNTC = false;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "C" (1000 Ohm) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(803.06,     -50));
+  m_tempVector.push_back(tempEntry(842.71,     -40));
+  m_tempVector.push_back(tempEntry(882.22,     -30));
+  m_tempVector.push_back(tempEntry(921.60,     -20));
+  m_tempVector.push_back(tempEntry(960.86,     -10));
+  m_tempVector.push_back(tempEntry(1000,       0));
+  m_tempVector.push_back(tempEntry(1039.03,    10));
+  m_tempVector.push_back(tempEntry(1077.94,    20));
+  m_tempVector.push_back(tempEntry(1097.35,    25));
+  m_tempVector.push_back(tempEntry(1116.73,    30));
+  m_tempVector.push_back(tempEntry(1155.41,    40));
+  m_tempVector.push_back(tempEntry(1193.97,    50));
+  m_tempVector.push_back(tempEntry(1232.42,    60));
+  m_tempVector.push_back(tempEntry(1270.75,    70));
+  m_tempVector.push_back(tempEntry(1308.97,    80));
+  m_tempVector.push_back(tempEntry(1347.07,    90));
+  m_tempVector.push_back(tempEntry(1385.06,    100));
+  m_tempVector.push_back(tempEntry(1422.93,    110));
+  m_tempVector.push_back(tempEntry(1460.68,    120));
+  m_tempVector.push_back(tempEntry(1493.32,    130));
+}
+
+void TEX00::initThermistorTEI()
+{
+  // this is a PTC type thermistor
+  m_isNTC = false;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "I" (1000 Ohm) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(740.46,     -50));
+  m_tempVector.push_back(tempEntry(773.99,     -40));
+  m_tempVector.push_back(tempEntry(806.02,     -30));
+  m_tempVector.push_back(tempEntry(841,        -20));
+  m_tempVector.push_back(tempEntry(877.76,     -10));
+  m_tempVector.push_back(tempEntry(913.66,     0));
+  m_tempVector.push_back(tempEntry(952.25,     10));
+  m_tempVector.push_back(tempEntry(991.82,     20));
+  m_tempVector.push_back(tempEntry(1013.50,    25));
+  m_tempVector.push_back(tempEntry(1035.18,    30));
+  m_tempVector.push_back(tempEntry(1077.68,    40));
+  m_tempVector.push_back(tempEntry(1120.52,    50));
+  m_tempVector.push_back(tempEntry(1166.13,    60));
+  m_tempVector.push_back(tempEntry(1210.75,    70));
+  m_tempVector.push_back(tempEntry(1254.55,    80));
+  m_tempVector.push_back(tempEntry(1301.17,    90));
+  m_tempVector.push_back(tempEntry(1348.38,    100));
+  m_tempVector.push_back(tempEntry(1397.13,    110));
+  m_tempVector.push_back(tempEntry(1447.44,    120));
+  m_tempVector.push_back(tempEntry(1496.28,    130));
+}
+
+void TEX00::initThermistorTEE()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "E" (2.2k Ohm) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(154464,     -50));
+  m_tempVector.push_back(tempEntry(77081,      -40));
+  m_tempVector.push_back(tempEntry(40330,      -30));
+  m_tempVector.push_back(tempEntry(22032,      -20));
+  m_tempVector.push_back(tempEntry(12519,      -10));
+  m_tempVector.push_back(tempEntry(7373,       0));
+  m_tempVector.push_back(tempEntry(4487,       10));
+  m_tempVector.push_back(tempEntry(2814,       20));
+  m_tempVector.push_back(tempEntry(2252,       25));
+  m_tempVector.push_back(tempEntry(1814,       30));
+  m_tempVector.push_back(tempEntry(1199,       40));
+  m_tempVector.push_back(tempEntry(811.5,      50));
+  m_tempVector.push_back(tempEntry(561,        60));
+  m_tempVector.push_back(tempEntry(395.5,      70));
+  m_tempVector.push_back(tempEntry(284,        80));
+  m_tempVector.push_back(tempEntry(207.4,      90));
+  m_tempVector.push_back(tempEntry(153.8,      100));
+  m_tempVector.push_back(tempEntry(115.8,      110));
+  m_tempVector.push_back(tempEntry(88.3,       120));
+  m_tempVector.push_back(tempEntry(68.3,       130));
+}
+
+void TEX00::initThermistorTEF()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "F" (3k Ohm) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(205800,     -50));
+  m_tempVector.push_back(tempEntry(102690,     -40));
+  m_tempVector.push_back(tempEntry(53730,      -30));
+  m_tempVector.push_back(tempEntry(29346,      -20));
+  m_tempVector.push_back(tempEntry(16674,      -10));
+  m_tempVector.push_back(tempEntry(9822,       0));
+  m_tempVector.push_back(tempEntry(5976,       10));
+  m_tempVector.push_back(tempEntry(3750,       20));
+  m_tempVector.push_back(tempEntry(3000,       25));
+  m_tempVector.push_back(tempEntry(2417,       30));
+  m_tempVector.push_back(tempEntry(1598,       40));
+  m_tempVector.push_back(tempEntry(1081,       50));
+  m_tempVector.push_back(tempEntry(747,        60));
+  m_tempVector.push_back(tempEntry(527,        70));
+  m_tempVector.push_back(tempEntry(378,        80));
+}
+
+void TEX00::initThermistorTEH()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "H" (10k Type 3) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(454910,     -50));
+  m_tempVector.push_back(tempEntry(245089,     -40));
+  m_tempVector.push_back(tempEntry(137307,     -30));
+  m_tempVector.push_back(tempEntry(79729,      -20));
+  m_tempVector.push_back(tempEntry(47843,      -10));
+  m_tempVector.push_back(tempEntry(29588,      0));
+  m_tempVector.push_back(tempEntry(18813,      10));
+  m_tempVector.push_back(tempEntry(12272,      20));
+  m_tempVector.push_back(tempEntry(10000,      25));
+  m_tempVector.push_back(tempEntry(8195,       30));
+  m_tempVector.push_back(tempEntry(5593,       40));
+  m_tempVector.push_back(tempEntry(3894,       50));
+  m_tempVector.push_back(tempEntry(2763,       60));
+  m_tempVector.push_back(tempEntry(1994,       70));
+  m_tempVector.push_back(tempEntry(1462,       80));
+  m_tempVector.push_back(tempEntry(1088,       90));
+  m_tempVector.push_back(tempEntry(821,        100));
+  m_tempVector.push_back(tempEntry(628,        110));
+  m_tempVector.push_back(tempEntry(486,        120));
+  m_tempVector.push_back(tempEntry(380,        130));
+}
+
+void TEX00::initThermistorTEJ()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "J" (10k Dale) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(672300,     -50));
+  m_tempVector.push_back(tempEntry(337200,     -40));
+  m_tempVector.push_back(tempEntry(177200,     -30));
+  m_tempVector.push_back(tempEntry(97130,      -20));
+  m_tempVector.push_back(tempEntry(55340,      -10));
+  m_tempVector.push_back(tempEntry(32660,      0));
+  m_tempVector.push_back(tempEntry(19900,      10));
+  m_tempVector.push_back(tempEntry(12490,      20));
+  m_tempVector.push_back(tempEntry(10000,      25));
+  m_tempVector.push_back(tempEntry(8056,       30));
+  m_tempVector.push_back(tempEntry(5326,       40));
+  m_tempVector.push_back(tempEntry(3602,       50));
+  m_tempVector.push_back(tempEntry(2489,       60));
+  m_tempVector.push_back(tempEntry(1753,       70));
+  m_tempVector.push_back(tempEntry(1258,       80));
+  m_tempVector.push_back(tempEntry(917,        90));
+  m_tempVector.push_back(tempEntry(679,        100));
+  m_tempVector.push_back(tempEntry(511,        110));
+  m_tempVector.push_back(tempEntry(389,        120));
+  m_tempVector.push_back(tempEntry(301,        130));
+}
+
+void TEX00::initThermistorTES()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "S" (10k 3A221) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(333562,     -40));
+  m_tempVector.push_back(tempEntry(176081,     -30));
+  m_tempVector.push_back(tempEntry(96807,      -20));
+  m_tempVector.push_back(tempEntry(55252,      -10));
+  m_tempVector.push_back(tempEntry(32639,      0));
+  m_tempVector.push_back(tempEntry(19901,      10));
+  m_tempVector.push_back(tempEntry(12493,      20));
+  m_tempVector.push_back(tempEntry(10000,      25));
+  m_tempVector.push_back(tempEntry(8055,       30));
+  m_tempVector.push_back(tempEntry(5324,       40));
+  m_tempVector.push_back(tempEntry(3600,       50));
+  m_tempVector.push_back(tempEntry(2486,       60));
+  m_tempVector.push_back(tempEntry(1751,       70));
+  m_tempVector.push_back(tempEntry(1255,       80));
+  m_tempVector.push_back(tempEntry(915,        90));
+  m_tempVector.push_back(tempEntry(678,        100));
+  m_tempVector.push_back(tempEntry(509,        110));
+  m_tempVector.push_back(tempEntry(388,        120));
+  m_tempVector.push_back(tempEntry(299,        130));
+}
+
+void TEX00::initThermistorTER()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "R" (10k "G" US) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(441200,     -50));
+  m_tempVector.push_back(tempEntry(239700,     -40));
+  m_tempVector.push_back(tempEntry(135300,     -30));
+  m_tempVector.push_back(tempEntry(78910,      -20));
+  m_tempVector.push_back(tempEntry(47540,      -10));
+  m_tempVector.push_back(tempEntry(29490,      0));
+  m_tempVector.push_back(tempEntry(18780,      10));
+  m_tempVector.push_back(tempEntry(12260,      20));
+  m_tempVector.push_back(tempEntry(10000,      25));
+  m_tempVector.push_back(tempEntry(8194,       30));
+  m_tempVector.push_back(tempEntry(5592,       40));
+  m_tempVector.push_back(tempEntry(3893,       50));
+  m_tempVector.push_back(tempEntry(2760,       60));
+  m_tempVector.push_back(tempEntry(1990,       70));
+  m_tempVector.push_back(tempEntry(1458,       80));
+  m_tempVector.push_back(tempEntry(1084,       90));
+  m_tempVector.push_back(tempEntry(816.8,      100));
+  m_tempVector.push_back(tempEntry(623.6,      110));
+  m_tempVector.push_back(tempEntry(481.8,      120));
+  m_tempVector.push_back(tempEntry(376.4,      130));
+}
+
+void TEX00::initThermistorTEM()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "M" (20k NTC) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(1267600,    -50));
+  m_tempVector.push_back(tempEntry(643800,     -40));
+  m_tempVector.push_back(tempEntry(342000,     -30));
+  m_tempVector.push_back(tempEntry(189080,     -20));
+  m_tempVector.push_back(tempEntry(108380,     -10));
+  m_tempVector.push_back(tempEntry(64160,      0));
+  m_tempVector.push_back(tempEntry(38440,      10));
+  m_tempVector.push_back(tempEntry(24920,      20));
+  m_tempVector.push_back(tempEntry(20000,      25));
+  m_tempVector.push_back(tempEntry(16144,      30));
+  m_tempVector.push_back(tempEntry(10696,      40));
+  m_tempVector.push_back(tempEntry(7234,       50));
+  m_tempVector.push_back(tempEntry(4992,       60));
+  m_tempVector.push_back(tempEntry(3512,       70));
+  m_tempVector.push_back(tempEntry(2516,       80));
+  m_tempVector.push_back(tempEntry(1833,       90));
+  m_tempVector.push_back(tempEntry(1356,       100));
+  m_tempVector.push_back(tempEntry(1016,       110));
+  m_tempVector.push_back(tempEntry(770,        120));
+  m_tempVector.push_back(tempEntry(591,        130));
+}
+
+void TEX00::initThermistorTEU()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "U" (20k "D") column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(803200,     -40));
+  m_tempVector.push_back(tempEntry(412800,     -30));
+  m_tempVector.push_back(tempEntry(220600,     -20));
+  m_tempVector.push_back(tempEntry(112400,     -10));
+  m_tempVector.push_back(tempEntry(70200,      0));
+  m_tempVector.push_back(tempEntry(41600,      10));
+  m_tempVector.push_back(tempEntry(25340,      20));
+  m_tempVector.push_back(tempEntry(20000,      25));
+  m_tempVector.push_back(tempEntry(15884,      30));
+  m_tempVector.push_back(tempEntry(10210,      40));
+  m_tempVector.push_back(tempEntry(6718,       50));
+  m_tempVector.push_back(tempEntry(4518,       60));
+  m_tempVector.push_back(tempEntry(3100,       70));
+  m_tempVector.push_back(tempEntry(2168,       80));
+  m_tempVector.push_back(tempEntry(1542,       90));
+  m_tempVector.push_back(tempEntry(1134,       100));
+  m_tempVector.push_back(tempEntry(816,        110));
+  m_tempVector.push_back(tempEntry(606,        120));
+  m_tempVector.push_back(tempEntry(456,        130));
+}
+
+void TEX00::initThermistorTET()
+{
+  // this is an NTC type thermistor
+  m_isNTC = true;
+
+  // This data comes from the Veris TW_TE_d0116.pdf datasheet for the
+  // "T" (100k) column
+
+  // clear and initialize the vector, ordered from lowest to highest
+  // temperature
+  m_tempVector.clear();
+
+  //                               ohms        temperature (C)
+  m_tempVector.push_back(tempEntry(3366000,    -40));
+  m_tempVector.push_back(tempEntry(1770000,    -30));
+  m_tempVector.push_back(tempEntry(971200,     -20));
+  m_tempVector.push_back(tempEntry(553400,     -10));
+  m_tempVector.push_back(tempEntry(326600,     0));
+  m_tempVector.push_back(tempEntry(199000,     10));
+  m_tempVector.push_back(tempEntry(124900,     20));
+  m_tempVector.push_back(tempEntry(100000,     25));
+  m_tempVector.push_back(tempEntry(80580,      30));
+  m_tempVector.push_back(tempEntry(53260,      40));
+  m_tempVector.push_back(tempEntry(36020,      50));
+  m_tempVector.push_back(tempEntry(24880,      60));
+  m_tempVector.push_back(tempEntry(17510,      70));
+  m_tempVector.push_back(tempEntry(12560,      80));
+  m_tempVector.push_back(tempEntry(9164,       90));
+  m_tempVector.push_back(tempEntry(6792,       100));
+  m_tempVector.push_back(tempEntry(5108,       110));
+  m_tempVector.push_back(tempEntry(3894,       120));
+  m_tempVector.push_back(tempEntry(3006,       130));
+}
+

--- a/src/tex00/tex00.h
+++ b/src/tex00/tex00.h
@@ -1,0 +1,216 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include <iostream>
+#include <vector>
+
+#include <mraa/aio.hpp>
+
+#define TEX00_DEFAULT_AREF 5.0
+
+namespace upm {
+    /**
+     * @brief Veris TEX00 Temperature Sensor
+     * @defgroup tex00 libupm-tex00
+     * @ingroup veris ainput temp 
+     */
+
+    /**
+     * @library tex00
+     * @sensor tex00
+     * @comname Veris TEX00 Temperature Sensor
+     * @type temp
+     * @man veris
+     * @con ainput
+     * @web http://www.veris.com/Item/TED00.aspx
+     *
+     * @brief API for the Veris TEX00 Temperature Sensor
+     *
+     * The Veris TEX00 temperature sensor family is made up of a
+     * series of RTD thermistors in wall mount packaging.  
+     * 
+     * This driver was developed using the TED00, which utilizes a 10K
+     * Ohm Type 2 thermistor.  However, this driver can support the
+     * other 12 variants of the TE series as well by providing the
+     * correct sensor type to the class constructor.  These other
+     * sensor types have not been tested.  Only the TED00 was tested
+     * with this driver.
+     *
+     * This sensor must be connected as part of a voltage divider,
+     * with the balancing resistor ideally matched to the sensor's 25C
+     * detection range.  For the TED00 (10kt2), a 10K Ohm (1%
+     * tolerance) resistor was used in a circuit like the following:
+     *
+     * GND o----|TED00(10k2)|----o----|balanceResistor(10K)|----o VCC (+5vdc)
+     *                           |
+     *                           |
+     *                           |----o A0 (analog input to MCU)
+     *
+     * A 3.3vdc voltage can be used as well if desired.
+     *
+     * @snippet tex00.cxx Interesting
+     */
+
+  class TEX00 {
+  public:
+
+    typedef enum {
+      STYPE_THERMISTOR_TED               = 0, // 10k type 2
+      STYPE_THERMISTOR_TEB,                   // 100 Ohm
+      STYPE_THERMISTOR_TEC,                   // 1000 Ohm
+      STYPE_THERMISTOR_TEI,                   // 1000 Ohm
+      STYPE_THERMISTOR_TEE,                   // 2.2k
+      STYPE_THERMISTOR_TEF,                   // 3k
+      STYPE_THERMISTOR_TEH,                   // 10k type 3
+      STYPE_THERMISTOR_TEJ,                   // 10k Dale
+      STYPE_THERMISTOR_TES,                   // 10k 3A221
+      STYPE_THERMISTOR_TER,                   // 10k "G" US
+      STYPE_THERMISTOR_TEM,                   // 20k NTC
+      STYPE_THERMISTOR_TEU,                   // 20k "D"
+      STYPE_THERMISTOR_TET                    // 100k
+    } SENSOR_TYPES_T;
+
+    /**
+     * TEX00 object constructor
+     *
+     * @param tPin Analog pin to use for temperature.
+     * @param balanceResistor Resistance (in Ohms) of the balance
+     * resistor used in your voltage divider.
+     * @param stype The sensor type.  One of the SENSOR_TYPES_T values.
+     * @param aref The analog reference voltage, default 5.0
+     */
+    TEX00(int tPin, float balanceResistor, SENSOR_TYPES_T stype,
+          float aref=TEX00_DEFAULT_AREF);
+
+    /**
+     * TEX00 object destructor
+     */
+    ~TEX00();
+
+    /**
+     * Read current values from the sensor and update internal stored
+     * values.  This method must be called prior to querying any
+     * values, such as temperature.
+     */
+    void update();
+
+    /**
+     * Get the current temperature.  update() must have been called
+     * prior to calling this method.
+     *
+     * @param fahrenheit true to return the temperature in degrees
+     * fahrenheit, false to return the temperature in degrees celcius.
+     * The default is false (degrees Celcius).
+     * @return The last temperature reading in Celcius or Fahrenheit
+     */
+    float getTemperature(bool fahrenheit=false);
+
+    /**
+     * Return the smallest temperature that can be measured by the
+     * current sensor.
+     *
+     * @return The smallest detectable temperature this sensor can
+     * measure, in C.
+     */
+    float getTemperatureRangeMin();
+
+    /**
+     * Return the largest temperature that can be measured by the
+     * current sensor.  
+     *
+     * @return The largest detectable temperature this sensor can
+     * measure, in C.
+     */
+    float getTemperatureRangeMax();
+
+    /**
+     * Detect whether the last measurement exceeded the sensors
+     * detection range.  update() must have been called prior to
+     * calling this method.
+     *
+     * @return true if the last measurement was out of range, false
+     * otherwise.
+     */
+    bool isOutOfRange()
+    {
+      return m_outOfRange;
+    }
+
+  protected:
+    mraa::Aio m_aioTemp;
+
+    // compute the temperature based on the resistance of the thermistor
+    float thermistor(float ohms);
+
+  private:
+    float m_aref;
+    int m_aResTemp;
+
+    // in Celcius
+    float m_temperature;
+    // temp reading out of range
+    bool m_outOfRange;
+
+    // resistance of the other half of our voltage divider
+    float m_balanceResistor;
+
+    int average(int samples);
+
+    // Negative Temperature Coefficient (NTC) or Positive Temperature
+    // Coefficient (PTC)
+    bool m_isNTC;
+
+    // This may generate a SWIG warning.  It can be safely ignored
+    // since this structure is never exposed outside the class.
+    struct tempEntry
+    {
+      tempEntry(float o, float t) : ohms(o), temp(t) {};
+      
+      float ohms;
+      float temp; // in C
+    };
+
+    // ohms/temperature table store
+    std::vector<tempEntry> m_tempVector;
+
+    // table temperature init functions
+    void initThermistorTED();
+    void initThermistorTEB();
+    void initThermistorTEC();
+    void initThermistorTEI();
+    void initThermistorTEE();
+    void initThermistorTEF();
+    void initThermistorTEH();
+    void initThermistorTEJ();
+    void initThermistorTES();
+    void initThermistorTER();
+    void initThermistorTEM();
+    void initThermistorTEU();
+    void initThermistorTET();
+  };
+}
+
+


### PR DESCRIPTION
The Veris TEX00 temperature sensor family is made up of a series of
RTD thermistors in wall mount packaging.

This driver was developed using the TED00, which utilizes a 10K Ohm
Type 2 thermistor.  However, this driver can support the other 12
variants of the TE series as well by providing the correct sensor type
to the class constructor.  These other sensor types have not been
tested.  Only the TED00 hardware was tested with this driver.

This sensor must be connected as part of a voltage divider, with the
balancing resistor ideally matched to the sensor's 25C detection
range.  For the TED00 (10kt2), a 10K Ohm (1% tolerance) resistor was
used in a circuit like the following:

GND o----|TED00(10k2)|----o----|balanceResistor(10K)|----o VCC (+5vdc)
                          |
                          |
                          |----o A0 (analog input to MCU)

A 3.3vdc voltage can be used as well if desired.

Signed-off-by: Jon Trulson <jtrulson@ics.com>