### PR TITLE
cmake: Enable C++11 standards support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ option (BUILDSWIGJAVA "Build swig java modules" OFF)
 option (IPK "Generate IPK using CPack" OFF)
 option (RPM "Generate RPM using CPack" OFF)
 option (BUILDTESTS "Generate check-ups for upm" OFF)
+option (ENABLECXX11 "Enable C++11 standards support" ON)
 
 # Find swig
 if (BUILDSWIG)
@@ -75,6 +76,27 @@ endif ()
 include (TargetArch)
 target_architecture (DETECTED_ARCH)
 message( INFO " - Target arch is ${DETECTED_ARCH}")
+
+# enable c++11 standards support
+if (ENABLECXX11)
+  include(CheckCXXCompilerFlag)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+    if (COMPILER_SUPPORTS_CXX11)
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    elseif (COMPILER_SUPPORTS_CXX0X)
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    else()
+      message(WARNING "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please update your C++ compiler.")
+    endif()
+  else()
+    # 3.1+ uses this generic method to enable c++11
+    set (CMAKE_CXX_STANDARD 11)
+  endif()
+else()
+  message(WARNING "Some modules require C++11 support, and may not build without it.")
+endif()
 
 if (BUILDDOC)
   # Add a target to generate API documentation with Doxygen


### PR DESCRIPTION
This patch checks for, and enables C++11 support for building UPM.
This should work for all cmake versions currently supported by UPM
(2.8.11+), and any compiler (clang/gcc) that was released in this
decade.

Support can be specifically disabled by passing '-DENABLECXX11=OFF' to
cmake, though modules requiring this support will not build.

C++11 support is enabled by default.

Signed-off-by: Jon Trulson <jtrulson@ics.com>