### PR TITLE
Enable C++11 standards support, and fix narrowing conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ option (BUILDSWIGJAVA "Build swig java modules" OFF)
 option (IPK "Generate IPK using CPack" OFF)
 option (RPM "Generate RPM using CPack" OFF)
 option (BUILDTESTS "Generate check-ups for upm" OFF)
+option (ENABLECXX11 "Enable C++11 standards support" ON)
 
 # Find swig
 if (BUILDSWIG)
@@ -75,6 +76,27 @@ endif ()
 include (TargetArch)
 target_architecture (DETECTED_ARCH)
 message( INFO " - Target arch is ${DETECTED_ARCH}")
+
+# enable c++11 standards support
+if (ENABLECXX11)
+  include(CheckCXXCompilerFlag)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+    if (COMPILER_SUPPORTS_CXX11)
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    elseif (COMPILER_SUPPORTS_CXX0X)
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+    else()
+      message(WARNING "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please update your C++ compiler.")
+    endif()
+  else()
+    # 3.1+ uses this generic method to enable c++11
+    set (CMAKE_CXX_STANDARD 11)
+  endif()
+else()
+  message(WARNING "Some modules require C++11 support, and may not build without it.")
+endif()
 
 if (BUILDDOC)
   # Add a target to generate API documentation with Doxygen

--- a/src/am2315/am2315.cpp
+++ b/src/am2315/am2315.cpp
@@ -233,7 +233,8 @@ AM2315::i2cWriteReg(uint8_t reg, uint8_t* data, uint8_t ilen)
 uint8_t
 AM2315::i2cReadReg(int reg, uint8_t* data, int ilen)
 {
-    uint8_t tdata[16] = { AM2315_READ, reg, ilen };
+  uint8_t tdata[16] = { AM2315_READ, static_cast<uint8_t>(reg),
+                        static_cast<uint8_t>(ilen) };
 
     mraa_result_t ret = mraa_i2c_address(m_i2ControlCtx, m_controlAddr);
     int iLoops = 5;

--- a/src/grovescam/grovescam.cxx
+++ b/src/grovescam/grovescam.cxx
@@ -194,7 +194,8 @@ void GROVESCAM::drainInput()
 bool GROVESCAM::init()
 {
   const unsigned int pktLen = 6;
-  uint8_t cmd[pktLen] = {0xaa, 0x0d|m_camAddr, 0x00, 0x00, 0x00, 0x00};
+  uint8_t cmd[pktLen] = {0xaa, static_cast<uint8_t>(0x0d|m_camAddr), 0x00,
+                         0x00, 0x00, 0x00};
   uint8_t resp[pktLen];
   int retries = 0;
 
@@ -246,7 +247,8 @@ bool GROVESCAM::init()
 bool GROVESCAM::preCapture(PIC_FORMATS_T fmt)
 {
   const unsigned int pktLen = 6;
-  uint8_t cmd[pktLen] = { 0xaa, 0x01 | m_camAddr, 0x00, 0x07, 0x00, fmt };
+  uint8_t cmd[pktLen] = { 0xaa, static_cast<uint8_t>(0x01 | m_camAddr), 0x00,
+                          0x07, 0x00, fmt };
   uint8_t resp[pktLen];
   int retries = 0;
 
@@ -282,7 +284,8 @@ bool GROVESCAM::preCapture(PIC_FORMATS_T fmt)
 bool GROVESCAM::doCapture()
 {
   const unsigned int pktLen = 6;
-  uint8_t cmd[pktLen] = { 0xaa, 0x06 | m_camAddr, 0x08, MAX_PKT_LEN & 0xff, 
+  uint8_t cmd[pktLen] = { 0xaa, static_cast<uint8_t>(0x06 | m_camAddr), 0x08,
+                          MAX_PKT_LEN & 0xff,
                           (MAX_PKT_LEN >> 8) & 0xff, 0};
   uint8_t resp[pktLen];
   int retries = 0;
@@ -422,7 +425,8 @@ bool GROVESCAM::storeImage(const char *fname)
   if ((m_picTotalLen % (MAX_PKT_LEN-6)) != 0) 
     pktCnt += 1;
   
-  uint8_t cmd[pktLen] = { 0xaa, 0x0e | m_camAddr, 0x00, 0x00, 0x00, 0x00 };
+  uint8_t cmd[pktLen] = { 0xaa, static_cast<uint8_t>(0x0e | m_camAddr), 0x00,
+                          0x00, 0x00, 0x00 };
   uint8_t pkt[MAX_PKT_LEN];
   int retries = 0;
   

--- a/src/grovescam/grovescam.cxx
+++ b/src/grovescam/grovescam.cxx
@@ -248,7 +248,7 @@ bool GROVESCAM::preCapture(PIC_FORMATS_T fmt)
 {
   const unsigned int pktLen = 6;
   uint8_t cmd[pktLen] = { 0xaa, static_cast<uint8_t>(0x01 | m_camAddr), 0x00,
-                          0x07, 0x00, fmt };
+                          0x07, 0x00, static_cast<uint8_t>(fmt) };
   uint8_t resp[pktLen];
   int retries = 0;
 
@@ -285,8 +285,8 @@ bool GROVESCAM::doCapture()
 {
   const unsigned int pktLen = 6;
   uint8_t cmd[pktLen] = { 0xaa, static_cast<uint8_t>(0x06 | m_camAddr), 0x08,
-                          MAX_PKT_LEN & 0xff,
-                          (MAX_PKT_LEN >> 8) & 0xff, 0};
+                          static_cast<uint8_t>(MAX_PKT_LEN & 0xff),
+                          static_cast<uint8_t>((MAX_PKT_LEN >> 8)) & 0xff, 0};
   uint8_t resp[pktLen];
   int retries = 0;
   

--- a/src/pn532/pn532.cxx
+++ b/src/pn532/pn532.cxx
@@ -993,7 +993,8 @@ bool PN532::mifareclassic_WriteNDEFURI (uint8_t sectorNumber,
   // in NDEF records
     
   // Setup the sector buffer (w/pre-formatted TLV wrapper and NDEF message)
-  uint8_t sectorbuffer1[16] = {0x00, 0x00, 0x03, len+5, 0xD1, 0x01, len+1, 
+  uint8_t sectorbuffer1[16] = {0x00, 0x00, 0x03, static_cast<uint8_t>(len+5),
+                               0xD1, 0x01, static_cast<uint8_t>(len+1),
                                0x55, uriIdentifier, 0x00, 0x00, 0x00, 0x00, 
                                0x00, 0x00, 0x00};
   uint8_t sectorbuffer2[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
@@ -1330,11 +1331,11 @@ bool PN532::ntag2xx_WriteNDEFURI (NDEF_URI_T uriIdentifier, char * url,
                        each lock bit can lock (4 bit + 4 bits) */
       /* NDEF Message TLV - URI Record */
       0x03,         /* Tag Field (0x03 = NDEF Message) */
-      len+5,        /* Payload Length (not including 0xFE trailer) */
+      static_cast<uint8_t>(len+5), /* Payload Length (not including 0xFE trailer) */
       0xD1,         /* NDEF Record Header (TNF=0x1:Well known record +
                        SR + ME + MB) */
       0x01,         /* Type Length for the record type indicator */
-      len+1,        /* Payload len */
+      static_cast<uint8_t>(len+1),        /* Payload len */
       0x55,         /* Record Type Indicator (0x55 or 'U' = URI Record) */
       uriIdentifier /* URI Prefix (ex. 0x01 = "http://www.") */
     };

--- a/src/pn532/pn532.cxx
+++ b/src/pn532/pn532.cxx
@@ -995,7 +995,8 @@ bool PN532::mifareclassic_WriteNDEFURI (uint8_t sectorNumber,
   // Setup the sector buffer (w/pre-formatted TLV wrapper and NDEF message)
   uint8_t sectorbuffer1[16] = {0x00, 0x00, 0x03, static_cast<uint8_t>(len+5),
                                0xD1, 0x01, static_cast<uint8_t>(len+1),
-                               0x55, uriIdentifier, 0x00, 0x00, 0x00, 0x00, 
+                               0x55, static_cast<uint8_t>(uriIdentifier), 
+                               0x00, 0x00, 0x00, 0x00, 
                                0x00, 0x00, 0x00};
   uint8_t sectorbuffer2[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
@@ -1337,7 +1338,7 @@ bool PN532::ntag2xx_WriteNDEFURI (NDEF_URI_T uriIdentifier, char * url,
       0x01,         /* Type Length for the record type indicator */
       static_cast<uint8_t>(len+1),        /* Payload len */
       0x55,         /* Record Type Indicator (0x55 or 'U' = URI Record) */
-      uriIdentifier /* URI Prefix (ex. 0x01 = "http://www.") */
+      static_cast<uint8_t>(uriIdentifier) /* URI Prefix (ex. 0x01 = "http://www.") */
     };
   
   // Write 12 byte header (three pages of data starting at page 4)

--- a/src/sx1276/sx1276.cxx
+++ b/src/sx1276/sx1276.cxx
@@ -167,7 +167,7 @@ SX1276::~SX1276()
 
 uint8_t SX1276::readReg(uint8_t reg)
 {
-  uint8_t pkt[2] = {(reg & 0x7f), 0};
+  uint8_t pkt[2] = {static_cast<uint8_t>(reg & 0x7f), 0};
 
   csOn();
   if (m_spi.transfer(pkt, pkt, 2))
@@ -184,7 +184,7 @@ uint8_t SX1276::readReg(uint8_t reg)
 
 bool SX1276::writeReg(uint8_t reg, uint8_t val)
 {
-  uint8_t pkt[2] = {reg | m_writeMode, val};
+  uint8_t pkt[2] = {static_cast<uint8_t>(reg | m_writeMode), val};
 
   csOn();
   if (m_spi.transfer(pkt, NULL, 2))

--- a/src/zfm20/zfm20.cxx
+++ b/src/zfm20/zfm20.cxx
@@ -323,10 +323,10 @@ bool ZFM20::verifyPassword()
 {
   const int pktLen = 5;
   uint8_t pkt[pktLen] = {CMD_VERIFY_PASSWORD, 
-                         (m_password >> 24) & 0xff,
-                         (m_password >> 16) & 0xff,
-                         (m_password >> 8) & 0xff,
-                         m_password & 0xff };
+                         static_cast<uint8_t>((m_password >> 24) & 0xff),
+                         static_cast<uint8_t>((m_password >> 16) & 0xff),
+                         static_cast<uint8_t>((m_password >> 8) & 0xff),
+                         static_cast<uint8_t>(m_password & 0xff) };
 
   writeCmdPacket(pkt, pktLen);
 
@@ -368,10 +368,10 @@ bool ZFM20::setNewPassword(uint32_t pwd)
 {
   const int pktLen = 5;
   uint8_t pkt[pktLen] = {CMD_SET_PASSWORD, 
-                         (pwd >> 24) & 0xff,
-                         (pwd >> 16) & 0xff,
-                         (pwd >> 8) & 0xff,
-                         pwd & 0xff };
+                         static_cast<uint8_t>((pwd >> 24) & 0xff),
+                         static_cast<uint8_t>((pwd >> 16) & 0xff),
+                         static_cast<uint8_t>((pwd >> 8) & 0xff),
+                         static_cast<uint8_t>(pwd & 0xff) };
 
   writeCmdPacket(pkt, pktLen);
 
@@ -398,10 +398,10 @@ bool ZFM20::setNewAddress(uint32_t addr)
 {
   const int pktLen = 5;
   uint8_t pkt[pktLen] = {CMD_SET_ADDRESS, 
-                         (addr >> 24) & 0xff,
-                         (addr >> 16) & 0xff,
-                         (addr >> 8) & 0xff,
-                         addr & 0xff };
+                         static_cast<uint8_t>((addr >> 24) & 0xff),
+                         static_cast<uint8_t>((addr >> 16) & 0xff),
+                         static_cast<uint8_t>((addr >> 8) & 0xff),
+                         static_cast<uint8_t>(addr & 0xff) };
 
   writeCmdPacket(pkt, pktLen);
 
@@ -451,7 +451,7 @@ uint8_t ZFM20::image2Tz(int slot)
 
   const int pktLen = 2;
   uint8_t pkt[pktLen] = {CMD_IMG2TZ,
-                         (slot & 0xff)};
+                         static_cast<uint8_t>(slot & 0xff)};
 
   writeCmdPacket(pkt, pktLen);
 
@@ -491,9 +491,9 @@ uint8_t ZFM20::storeModel(int slot, uint16_t id)
 
   const int pktLen = 4;
   uint8_t pkt[pktLen] = {CMD_STORE,
-                         (slot & 0xff),
-                         (id >> 8) & 0xff,
-                         id & 0xff};
+                         static_cast<uint8_t>(slot & 0xff),
+                         static_cast<uint8_t>((id >> 8) & 0xff),
+                         static_cast<uint8_t>(id & 0xff)};
 
   writeCmdPacket(pkt, pktLen);
 
@@ -510,8 +510,8 @@ uint8_t ZFM20::deleteModel(uint16_t id)
 {
   const int pktLen = 5;
   uint8_t pkt[pktLen] = {CMD_DELETE_TMPL,
-                         (id >> 8) & 0xff,
-                         id & 0xff,
+                         static_cast<uint8_t>((id >> 8) & 0xff),
+                         static_cast<uint8_t>(id & 0xff),
                          0x00,
                          0x01};
 
@@ -557,7 +557,7 @@ uint8_t ZFM20::search(int slot, uint16_t *id, uint16_t *score)
   // search from page 0x0000 to page 0x00a3
   const int pktLen = 6;
   uint8_t pkt[pktLen] = {CMD_SEARCH,
-                         (slot & 0xff),
+                         static_cast<uint8_t>(slot & 0xff),
                          0x00,
                          0x00,
                          0x00,


### PR DESCRIPTION
The first patch modifies the main CMakeLists.txt file so that it checks for, and enables C++11 support for building UPM.

This should work for all cmake versions currently supported by UPM
(2.8.11+), and any compiler (clang/gcc) that was released in this
decade.
    
Support can be specifically disabled by passing '-DENABLECXX11=OFF' to
cmake, though modules requiring this support will not build.
    
C++11 support is enabled by default.

The other patches in this PR fix narrowing conversions that were tolerated in pre-C++11, but are warnings or errors in C++11.  These fixes are still valid even if not building with C++11 support.