### PR TITLE
Implement CurieIMU sensor for MRAA Firmata client

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -240,6 +240,7 @@ add_example (rhusb)
 add_example (apds9930)
 add_example (kxcjk1013)
 add_example (ssd1351)
+add_example (curieimu)
 
 # These are special cases where you specify example binary, source file and module(s)
 include_directories (${PROJECT_SOURCE_DIR}/src)

--- a/examples/c++/curieimu.cxx
+++ b/examples/c++/curieimu.cxx
@@ -40,6 +40,10 @@ main(int argc, char **argv)
 
     std::cout << "temperature is: " << (sensor->getTemperature() * pow(0.5, 9) + 23) << std::endl;
 
+    int x, y, z;
+    sensor->readAccelerometer(&x, &y, &z);
+    printf("accelerometer is: %d, %d, %d\n", x, y, z);
+
     delete sensor;
 
     return 0;

--- a/examples/c++/curieimu.cxx
+++ b/examples/c++/curieimu.cxx
@@ -1,0 +1,40 @@
+/*
+ * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include "curieimu.hpp"
+
+int
+main(int argc, char **argv)
+{
+    //! [Interesting]
+    upm::CurieImu* sensor = new upm::CurieImu();
+
+    std::cout << "temperature is: " << sensor->getTemperature() << std::endl;
+
+    delete sensor;
+
+    return 0;
+}

--- a/examples/c++/curieimu.cxx
+++ b/examples/c++/curieimu.cxx
@@ -52,6 +52,16 @@ main(int argc, char **argv)
     sensor->readMotion(&m, &n, &o, &p, &q, &r);
     printf("motion is: %d, %d, %d, %d, %d, %d\n", m, n, o, p, q, r);
 
+    int axis, direction;
+    sensor->enableShockDetection(true);
+    for(int i=0; i<300; i++) {
+      if (sensor->isShockDetected()) {
+        sensor->getShockDetectData(&axis, &direction);
+        printf("shock data is: %d, %d\n", axis, direction);
+      }
+      usleep(10000);
+    }
+
     delete sensor;
 
     return 0;

--- a/examples/c++/curieimu.cxx
+++ b/examples/c++/curieimu.cxx
@@ -1,5 +1,7 @@
 /*
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Author: Ron Evans (@deadprogram)
+ * Author: Justin Zemlyansky (@JustInDevelopment) 
  * Copyright (c) 2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/examples/c++/curieimu.cxx
+++ b/examples/c++/curieimu.cxx
@@ -44,6 +44,14 @@ main(int argc, char **argv)
     sensor->readAccelerometer(&x, &y, &z);
     printf("accelerometer is: %d, %d, %d\n", x, y, z);
 
+    int a, b, c;
+    sensor->readGyro(&a, &b, &c);
+    printf("gyroscope is: %d, %d, %d\n", a, b, c);
+
+    int m, n, o, p, q, r;
+    sensor->readMotion(&m, &n, &o, &p, &q, &r);
+    printf("motion is: %d, %d, %d, %d, %d, %d\n", m, n, o, p, q, r);
+
     delete sensor;
 
     return 0;

--- a/examples/c++/curieimu.cxx
+++ b/examples/c++/curieimu.cxx
@@ -48,10 +48,6 @@ main(int argc, char **argv)
     sensor->readGyro(&a, &b, &c);
     printf("gyroscope is: %d, %d, %d\n", a, b, c);
 
-    int m, n, o, p, q, r;
-    sensor->readMotion(&m, &n, &o, &p, &q, &r);
-    printf("motion is: %d, %d, %d, %d, %d, %d\n", m, n, o, p, q, r);
-
     int axis, direction;
     sensor->enableShockDetection(true);
     for(int i=0; i<300; i++) {
@@ -61,6 +57,10 @@ main(int argc, char **argv)
       }
       usleep(10000);
     }
+
+    int m, n, o, p, q, r;
+    sensor->readMotion(&m, &n, &o, &p, &q, &r);
+    printf("motion is: %d, %d, %d, %d, %d, %d\n", m, n, o, p, q, r);
 
     delete sensor;
 

--- a/examples/c++/curieimu.cxx
+++ b/examples/c++/curieimu.cxx
@@ -25,14 +25,20 @@
 #include <unistd.h>
 #include <iostream>
 #include "curieimu.hpp"
+#include "mraa.h"
+#include "mraa/firmata.h"
+#include <math.h>
 
 int
 main(int argc, char **argv)
 {
     //! [Interesting]
+    mraa_init();
+    mraa_add_subplatform(MRAA_GENERIC_FIRMATA, "/dev/ttyACM0");
+
     upm::CurieImu* sensor = new upm::CurieImu();
 
-    std::cout << "temperature is: " << sensor->getTemperature() << std::endl;
+    std::cout << "temperature is: " << (sensor->getTemperature() * pow(0.5, 9) + 23) << std::endl;
 
     delete sensor;
 

--- a/src/curieimu/CMakeLists.txt
+++ b/src/curieimu/CMakeLists.txt
@@ -1,0 +1,5 @@
+set (libname "curieimu")
+set (libdescription "upm Curie IMU via Firmata")
+set (module_src ${libname}.cpp)
+set (module_h ${libname}.hpp)
+upm_module_init()

--- a/src/curieimu/curieimu.cpp
+++ b/src/curieimu/curieimu.cpp
@@ -35,7 +35,9 @@
 using namespace upm;
 
 static CurieImu* awaitingReponse;
-
+/*
+* Instantiates a CurieImu object
+*/
 CurieImu::CurieImu (int subplatformoffset)
 {
     m_firmata = mraa_firmata_init(FIRMATA_CURIE_IMU);
@@ -57,13 +59,17 @@ CurieImu::CurieImu (int subplatformoffset)
         return;
     }
 }
-
+/*
+*Destructor for CurieImu object
+*/
 CurieImu::~CurieImu()
 {
     pthread_mutex_destroy(&m_responseLock);
     pthread_cond_destroy(&m_responseCond);
 }
-
+/*
+*response handlers
+*/
 void
 CurieImu::lock()
 {
@@ -95,21 +101,28 @@ CurieImu::setResults(uint8_t* buf, int length)
     m_results = new char(length);
     memcpy((void*)m_results, (void*)buf, length);
 }
-
+/*
+*handles syncronus response
+*/
 static void
 handleSyncResponse(uint8_t* buf, int length)
 {
     awaitingReponse->setResults(buf, length);
     awaitingReponse->proceed();
 }
-
+/*
+*handles A-syncronus response
+*/
 static void
 handleAsyncResponses(uint8_t* buf, int length)
 {
     awaitingReponse->setResults(buf, length);
     awaitingReponse->processResponse();
 }
-
+/**
+* Read accelerometer 
+*X,Y, and Z axis 
+*/
 void
 CurieImu::readAccelerometer(int *xVal, int *yVal, int *zVal)
 {
@@ -136,7 +149,10 @@ CurieImu::readAccelerometer(int *xVal, int *yVal, int *zVal)
 
   return;
 }
-
+/**
+* Read gyroscope 
+*X,Y, and Z axis
+*/
 void
 CurieImu::readGyro(int *xVal, int *yVal, int *zVal)
 {
@@ -163,7 +179,9 @@ CurieImu::readGyro(int *xVal, int *yVal, int *zVal)
 
   return;
 }
-
+/*
+*reads the temperature
+*/
 int16_t
 CurieImu::getTemperature()
 {
@@ -190,7 +208,10 @@ CurieImu::getTemperature()
 
     return result;
 }
-
+/*
+*reads the X,Y, and Z axis of both
+*the gyroscope and the accelerometer
+*/
 void
 CurieImu::readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG)
 {
@@ -224,6 +245,9 @@ CurieImu::readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG)
 void
 CurieImu::processResponse()
 {
+    /*
+    *response if shock is detected
+    */
   switch(m_results[2]) {
     case FIRMATA_CURIE_IMU_SHOCK_DETECT:
     {
@@ -233,12 +257,18 @@ CurieImu::processResponse()
         m_shockData.push(item);
         break;
     }
+    /*
+    *response for steps counted 
+    */
     case FIRMATA_CURIE_IMU_STEP_COUNTER:
     {
         int count = ((m_results[3] & 0x7f) | ((m_results[4] & 0x7f) << 7));
         m_stepData.push(count);
         break;
     }
+    /*
+    *response if tap is detected
+    */
     case FIRMATA_CURIE_IMU_TAP_DETECT:
     {
         IMUDataItem* item = new IMUDataItem();
@@ -251,7 +281,9 @@ CurieImu::processResponse()
 
   return;
 }
-
+/*
+*turns shock detection on
+*/
 void
 CurieImu::enableShockDetection(bool enable)
 {
@@ -291,7 +323,9 @@ CurieImu::getShockDetectData(int *axis, int *direction)
     delete item;
   }
 }
-
+/*
+*turns step counter on
+*/
 void
 CurieImu::enableStepCounter(bool enable)
 {
@@ -328,7 +362,9 @@ CurieImu::getStepCount(int *count)
     m_stepData.pop();
   }
 }
-
+/*
+*turns tap detection on
+*/
 void
 CurieImu::enableTapDetection(bool enable)
 {

--- a/src/curieimu/curieimu.cpp
+++ b/src/curieimu/curieimu.cpp
@@ -65,7 +65,7 @@ CurieImu::~CurieImu()
 }
 
 static void
-handleResponses(uint8_t* buf, int length)
+handleSyncResponse(uint8_t* buf, int length)
 {
     awaitingReponse->m_results = new char(length);
     memcpy((void*)awaitingReponse->m_results, (void*)buf, length);
@@ -84,7 +84,7 @@ CurieImu::readAccelerometer(int *xVal, int *yVal, int *zVal)
   pthread_mutex_lock(&m_responseLock);
 
   mraa_firmata_response_stop(m_firmata);
-  mraa_firmata_response(m_firmata, handleResponses);
+  mraa_firmata_response(m_firmata, handleSyncResponse);
   mraa_firmata_write_sysex(m_firmata, &message[0], 4);
 
   awaitingReponse = this;
@@ -112,7 +112,7 @@ CurieImu::readGyro(int *xVal, int *yVal, int *zVal)
   pthread_mutex_lock(&m_responseLock);
 
   mraa_firmata_response_stop(m_firmata);
-  mraa_firmata_response(m_firmata, handleResponses);
+  mraa_firmata_response(m_firmata, handleSyncResponse);
   mraa_firmata_write_sysex(m_firmata, &message[0], 4);
 
   awaitingReponse = this;
@@ -140,7 +140,7 @@ CurieImu::getTemperature()
     pthread_mutex_lock(&m_responseLock);
 
     mraa_firmata_response_stop(m_firmata);
-    mraa_firmata_response(m_firmata, handleResponses);
+    mraa_firmata_response(m_firmata, handleSyncResponse);
     mraa_firmata_write_sysex(m_firmata, &message[0], 4);
 
     awaitingReponse = this;
@@ -168,7 +168,7 @@ CurieImu::readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG)
   pthread_mutex_lock(&m_responseLock);
 
   mraa_firmata_response_stop(m_firmata);
-  mraa_firmata_response(m_firmata, handleResponses);
+  mraa_firmata_response(m_firmata, handleSyncResponse);
   mraa_firmata_write_sysex(m_firmata, &message[0], 4);
 
   awaitingReponse = this;

--- a/src/curieimu/curieimu.cpp
+++ b/src/curieimu/curieimu.cpp
@@ -1,5 +1,7 @@
 /*
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Author: Ron Evans (@deadprogram)
+ * Author: Justin Zemlyansky (@JustInDevelopment)
  * Copyright (c) 2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -35,9 +37,10 @@
 using namespace upm;
 
 static CurieImu* awaitingReponse;
+
 /*
 * Instantiates a CurieImu object
-*@param subplatform_offset Subplatform offset
+* @param subplatform_offset Subplatform offset
 */
 CurieImu::CurieImu (int subplatformoffset)
 {
@@ -60,16 +63,18 @@ CurieImu::CurieImu (int subplatformoffset)
         return;
     }
 }
+
 /*
-*Destructor for CurieImu object
+* Destructor for CurieImu object
 */
 CurieImu::~CurieImu()
 {
     pthread_mutex_destroy(&m_responseLock);
     pthread_cond_destroy(&m_responseCond);
 }
+
 /*
-*response handlers
+* response handlers
 */
 void
 CurieImu::lock()
@@ -95,10 +100,11 @@ CurieImu::proceed()
 {
     pthread_cond_broadcast(&m_responseCond);
 }
+
 /*
-*set results 
-*@param buf is the buffer
-*@param length is the lenghth of results
+* set results
+* @param buf is the buffer
+* @param length is the lenghth of results
 */
 void
 CurieImu::setResults(uint8_t* buf, int length)
@@ -106,10 +112,11 @@ CurieImu::setResults(uint8_t* buf, int length)
     m_results = new char(length);
     memcpy((void*)m_results, (void*)buf, length);
 }
+
 /*
-*handles syncronus response
-*@param buffer
-*@param length
+* handles syncronous response
+* @param buffer
+* @param length
 */
 static void
 handleSyncResponse(uint8_t* buf, int length)
@@ -117,10 +124,11 @@ handleSyncResponse(uint8_t* buf, int length)
     awaitingReponse->setResults(buf, length);
     awaitingReponse->proceed();
 }
+
 /*
-*handles A-syncronus response
-*@param buffer
-*@param length
+* handles asyncronous response
+* @param buffer
+* @param length
 */
 static void
 handleAsyncResponses(uint8_t* buf, int length)
@@ -128,9 +136,9 @@ handleAsyncResponses(uint8_t* buf, int length)
     awaitingReponse->setResults(buf, length);
     awaitingReponse->processResponse();
 }
+
 /**
-* Read accelerometer 
-*X,Y, and Z axis 
+* Read accelerometer X, Y, and Z axis
 * @param xVal Pointer to returned X-axis value
 * @param yVal Pointer to returned Y-axis value
 * @param zVal Pointer to returned Z-axis value
@@ -161,9 +169,10 @@ CurieImu::readAccelerometer(int *xVal, int *yVal, int *zVal)
 
   return;
 }
+
 /**
-* Read gyroscope 
-*X,Y, and Z axis
+* Read gyroscope
+* X, Y, and Z axis
 * @param xVal Pointer to returned X-axis value
 * @param yVal Pointer to returned Y-axis value
 * @param zVal Pointer to returned Z-axis value
@@ -194,8 +203,9 @@ CurieImu::readGyro(int *xVal, int *yVal, int *zVal)
 
   return;
 }
+
 /*
-*reads the temperature
+* reads the temperature
 */
 int16_t
 CurieImu::getTemperature()
@@ -224,8 +234,8 @@ CurieImu::getTemperature()
     return result;
 }
 /*
-*reads the X,Y, and Z axis of both
-*the gyroscope and the accelerometer
+* reads the X, sY, and Z axis of both
+* the gyroscope and the accelerometer
 * @param xA Pointer to returned X-axis value of accelerometer
 * @param yA Pointer to returned Y-axis value of accelerometer
 * @param zA Pointer to returned Z-axis value of accelerometer
@@ -267,7 +277,7 @@ void
 CurieImu::processResponse()
 {
     /*
-    *response if shock is detected
+    * response if shock is detected
     */
   switch(m_results[2]) {
     case FIRMATA_CURIE_IMU_SHOCK_DETECT:
@@ -279,7 +289,7 @@ CurieImu::processResponse()
         break;
     }
     /*
-    *response for steps counted 
+    * response for steps counted
     */
     case FIRMATA_CURIE_IMU_STEP_COUNTER:
     {
@@ -288,7 +298,7 @@ CurieImu::processResponse()
         break;
     }
     /*
-    *response if tap is detected
+    * response if tap is detected
     */
     case FIRMATA_CURIE_IMU_TAP_DETECT:
     {
@@ -302,9 +312,10 @@ CurieImu::processResponse()
 
   return;
 }
+
 /*
-*turns shock detection on
-*@param enable
+* turns shock detection on
+* @param enable
 */
 void
 CurieImu::enableShockDetection(bool enable)
@@ -333,10 +344,11 @@ CurieImu::isShockDetected()
 {
   return (m_shockData.size() > 0);
 }
+
 /*
-*gets shock detect data
-*@param axis gets axis data
-*@param direction gets direction data
+* gets shock detect data
+* @param axis gets axis data
+* @param direction gets direction data
 */
 void
 CurieImu::getShockDetectData(int *axis, int *direction)
@@ -349,9 +361,10 @@ CurieImu::getShockDetectData(int *axis, int *direction)
     delete item;
   }
 }
+
 /*
-*turns step counter on
-*param enable
+* turns step counter on
+* @param enable
 */
 void
 CurieImu::enableStepCounter(bool enable)
@@ -375,13 +388,17 @@ CurieImu::enableStepCounter(bool enable)
   return;
 }
 
+/*
+* has there been a step detected?
+*/
 bool
 CurieImu::isStepDetected()
 {
   return (m_stepData.size() > 0);
 }
+
 /*
-*@param count pointer to current step count
+* @param count pointer to current step count
 */
 void
 CurieImu::getStepCount(int *count)
@@ -391,9 +408,10 @@ CurieImu::getStepCount(int *count)
     m_stepData.pop();
   }
 }
+
 /*
-*turns tap detection on
-*param enable
+* turns tap detection on
+* @param enable
 */
 void
 CurieImu::enableTapDetection(bool enable)
@@ -417,15 +435,19 @@ CurieImu::enableTapDetection(bool enable)
   return;
 }
 
+/*
+* has there been a tap detected?
+*/
 bool
 CurieImu::isTapDetected()
 {
   return (m_tapData.size() > 0);
 }
+
 /*
-*gets tap detect data
-*@param axis gets axis data
-*@param direction gets direction data
+* gets tap detect data
+* @param axis gets axis data
+* @param direction gets direction data
 */
 void
 CurieImu::getTapDetectData(int *axis, int *direction)

--- a/src/curieimu/curieimu.cpp
+++ b/src/curieimu/curieimu.cpp
@@ -1,0 +1,52 @@
+/*
+ * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include "curieimu.hpp"
+
+using namespace upm;
+
+CurieImu::CurieImu (int subplatformoffset)
+{
+    m_firmata = mraa_firmata_init(0x11);
+    if (m_firmata == NULL) {
+        throw std::invalid_argument(std::string(__FUNCTION__) +
+                                    ": mraa_firmata_init() failed");
+        return;
+    }
+}
+
+int16_t
+CurieImu::getTemperature()
+{
+    char message[8];
+    mraa_firmata_write_sysex(m_firmata, &message[0], 8);
+    // needs to block on mraa_firmata_response
+    return 0;
+}

--- a/src/curieimu/curieimu.cpp
+++ b/src/curieimu/curieimu.cpp
@@ -37,6 +37,7 @@ using namespace upm;
 static CurieImu* awaitingReponse;
 /*
 * Instantiates a CurieImu object
+*@param subplatform_offset Subplatform offset
 */
 CurieImu::CurieImu (int subplatformoffset)
 {
@@ -94,7 +95,11 @@ CurieImu::proceed()
 {
     pthread_cond_broadcast(&m_responseCond);
 }
-
+/*
+*set results 
+*@param buf is the buffer
+*@param length is the lenghth of results
+*/
 void
 CurieImu::setResults(uint8_t* buf, int length)
 {
@@ -103,6 +108,8 @@ CurieImu::setResults(uint8_t* buf, int length)
 }
 /*
 *handles syncronus response
+*@param buffer
+*@param length
 */
 static void
 handleSyncResponse(uint8_t* buf, int length)
@@ -112,6 +119,8 @@ handleSyncResponse(uint8_t* buf, int length)
 }
 /*
 *handles A-syncronus response
+*@param buffer
+*@param length
 */
 static void
 handleAsyncResponses(uint8_t* buf, int length)
@@ -122,6 +131,9 @@ handleAsyncResponses(uint8_t* buf, int length)
 /**
 * Read accelerometer 
 *X,Y, and Z axis 
+* @param xVal Pointer to returned X-axis value
+* @param yVal Pointer to returned Y-axis value
+* @param zVal Pointer to returned Z-axis value
 */
 void
 CurieImu::readAccelerometer(int *xVal, int *yVal, int *zVal)
@@ -152,6 +164,9 @@ CurieImu::readAccelerometer(int *xVal, int *yVal, int *zVal)
 /**
 * Read gyroscope 
 *X,Y, and Z axis
+* @param xVal Pointer to returned X-axis value
+* @param yVal Pointer to returned Y-axis value
+* @param zVal Pointer to returned Z-axis value
 */
 void
 CurieImu::readGyro(int *xVal, int *yVal, int *zVal)
@@ -211,6 +226,12 @@ CurieImu::getTemperature()
 /*
 *reads the X,Y, and Z axis of both
 *the gyroscope and the accelerometer
+* @param xA Pointer to returned X-axis value of accelerometer
+* @param yA Pointer to returned Y-axis value of accelerometer
+* @param zA Pointer to returned Z-axis value of accelerometer
+* @param xG Pointer to returned X-axis value of Gyroscope
+* @param yG Pointer to returned Y-axis value of Gyroscope
+* @param zG Pointer to returned Z-axis value of Gyroscope
 */
 void
 CurieImu::readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG)
@@ -283,6 +304,7 @@ CurieImu::processResponse()
 }
 /*
 *turns shock detection on
+*@param enable
 */
 void
 CurieImu::enableShockDetection(bool enable)
@@ -311,7 +333,11 @@ CurieImu::isShockDetected()
 {
   return (m_shockData.size() > 0);
 }
-
+/*
+*gets shock detect data
+*@param axis gets axis data
+*@param direction gets direction data
+*/
 void
 CurieImu::getShockDetectData(int *axis, int *direction)
 {
@@ -325,6 +351,7 @@ CurieImu::getShockDetectData(int *axis, int *direction)
 }
 /*
 *turns step counter on
+*param enable
 */
 void
 CurieImu::enableStepCounter(bool enable)
@@ -353,7 +380,9 @@ CurieImu::isStepDetected()
 {
   return (m_stepData.size() > 0);
 }
-
+/*
+*@param count pointer to current step count
+*/
 void
 CurieImu::getStepCount(int *count)
 {
@@ -364,6 +393,7 @@ CurieImu::getStepCount(int *count)
 }
 /*
 *turns tap detection on
+*param enable
 */
 void
 CurieImu::enableTapDetection(bool enable)
@@ -392,7 +422,11 @@ CurieImu::isTapDetected()
 {
   return (m_tapData.size() > 0);
 }
-
+/*
+*gets tap detect data
+*@param axis gets axis data
+*@param direction gets direction data
+*/
 void
 CurieImu::getTapDetectData(int *axis, int *direction)
 {

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -63,7 +63,7 @@ namespace upm {
 #define FIRMATA_CURIE_IMU_TAP_DETECT        0x05
 #define FIRMATA_CURIE_IMU_READ_MOTION       0x06
 
-struct ShockDataItem {
+struct IMUDataItem {
     int axis;
     int direction;
 };
@@ -102,9 +102,26 @@ class CurieImu {
          */
         void readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG);
 
+        /**
+         * Shock detection
+         */
         void enableShockDetection(bool enable);
         bool isShockDetected();
         void getShockDetectData(int *axis, int *direction);
+
+        /**
+         * Step counter
+         */
+        void enableStepCounter(bool enable);
+        bool isStepDetected();
+        void getStepCount(int *count);
+
+        /**
+         * Tap detection
+         */
+        void enableTapDetection(bool enable);
+        bool isTapDetected();
+        void getTapDetectData(int *axis, int *direction);
 
         /**
          * Used for response handling
@@ -122,7 +139,9 @@ class CurieImu {
         pthread_cond_t m_responseCond;
         char* m_results;
 
-        std::queue<ShockDataItem*> m_shockData;
+        std::queue<IMUDataItem*> m_shockData;
+        std::queue<int> m_stepData;
+        std::queue<IMUDataItem*> m_tapData;
 };
 
 }

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -1,5 +1,7 @@
 /*
  * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Author: Ron Evans (@deadprogram)
+ * Author: Justin Zemlyansky (@JustInDevelopment)
  * Copyright (c) 2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -77,10 +77,19 @@ class CurieImu {
         ~CurieImu();
 
         /**
-         * Returns the Temperature
+         * Read accelerometer
+         */
+        void readAccelerometer(int *xVal, int *yVal, int *zVal);
+
+        /**
+         * Returns the temperature
          */
         int16_t getTemperature();
 
+
+        /**
+         * Used for response handling
+         */
         pthread_mutex_t m_responseLock;
         pthread_cond_t m_responseCond;
         char* m_results;

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -72,68 +72,154 @@ struct IMUDataItem {
 
 class CurieImu {
     public:
-        /**
-         * Instantiates a CurieImu object
-         *
-         * @param subplatform_offset Subplatform offset, default 512
-         */
-        CurieImu (int subplatform_offset=512);
 
-        /**
-         * Destructor for a CurieImu object
-         */
-        ~CurieImu();
+      /**
+      * Instantiates a CurieImu object
+      *
+      * @param subplatformoffset Subplatform offset
+      */
+      CurieImu (int subplatform_offset=512);
 
-        /**
-         * Read accelerometer
-         */
-        void readAccelerometer(int *xVal, int *yVal, int *zVal);
+      /**
+      * Destructor for CurieImu object
+      */
+      ~CurieImu();
 
-        /**
-         * Read gyroscope
-         */
-        void readGyro(int *xVal, int *yVal, int *zVal);
+      /**
+       * Read accelerometer X, Y, and Z axis
+       *
+       * @param xVal Pointer to returned X-axis value
+       * @param yVal Pointer to returned Y-axis value
+       * @param zVal Pointer to returned Z-axis value
+       */
+      void readAccelerometer(int *xVal, int *yVal, int *zVal);
 
-        /**
-         * Returns the temperature
-         */
-        int16_t getTemperature();
+      /**
+       * Read gyroscope X, Y, and Z axis
+       *
+       * @param xVal Pointer to returned X-axis value
+       * @param yVal Pointer to returned Y-axis value
+       * @param zVal Pointer to returned Z-axis value
+       */
+      void readGyro(int *xVal, int *yVal, int *zVal);
 
-        /**
-         * Read motion aka both accelerometer and gyroscope
-         */
-        void readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG);
+      /**
+       * Reads the internal temperature
+       *
+       * @return 16-bit integer containing the scaled temperature reading
+       */
+      int16_t getTemperature();
 
-        /**
-         * Shock detection
-         */
-        void enableShockDetection(bool enable);
-        bool isShockDetected();
-        void getShockDetectData(int *axis, int *direction);
+      /**
+       * Reads the X, Y, and Z axis of both gyroscope and accelerometer
+       *
+       * @param xA Pointer to returned X-axis value of accelerometer
+       * @param yA Pointer to returned Y-axis value of accelerometer
+       * @param zA Pointer to returned Z-axis value of accelerometer
+       * @param xG Pointer to returned X-axis value of Gyroscope
+       * @param yG Pointer to returned Y-axis value of Gyroscope
+       * @param zG Pointer to returned Z-axis value of Gyroscope
+       */
+      void readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG);
 
-        /**
-         * Step counter
-         */
-        void enableStepCounter(bool enable);
-        bool isStepDetected();
-        void getStepCount(int *count);
+      /**
+       * Turns shock detection notifications on/off
+       *
+       * @param enable enables/disables notifications
+       */
+      void enableShockDetection(bool enable);
 
-        /**
-         * Tap detection
-         */
-        void enableTapDetection(bool enable);
-        bool isTapDetected();
-        void getTapDetectData(int *axis, int *direction);
+      /**
+       * Has there been a shock detected?
+       *
+       * @return true if any unprocessed shock notifications are in the queue
+       */
+      bool isShockDetected();
 
-        /**
-         * Used for response handling
-         */
-        void lock();
-        void unlock();
-        void wait();
-        void proceed();
-        void setResults(uint8_t* buf, int length);
-        void processResponse();
+      /**
+       * Gets shock detect data from queue
+       *
+       * @param axis gets axis data
+       * @param direction gets direction data
+       */
+      void getShockDetectData(int *axis, int *direction);
+
+      /**
+       * Turns step counter notifications on/off
+       *
+       * @param enable enables/disables notifications
+       */
+      void enableStepCounter(bool enable);
+
+      /**
+       * Has there been a step detected?
+       *
+       * @return true if any unprocessed step notifications are in the queue
+       */
+      bool isStepDetected();
+
+      /**
+       * Gets step count data from queue
+       *
+       * @param count the total number of steps taken
+       */
+      void getStepCount(int *count);
+
+      /**
+       * Turns tap detection notifications on/off
+       *
+       * @param enable enables/disables notifications
+       */
+      void enableTapDetection(bool enable);
+
+      /**
+       * Has there been a tap detected?
+       *
+       * @return true if any unprocessed tap notifications are in the queue
+       */
+      bool isTapDetected();
+
+      /**
+       * Gets tap detect data from queue
+       *
+       * @param axis gets axis data
+       * @param direction gets direction data
+       */
+      void getTapDetectData(int *axis, int *direction);
+
+      /**
+       * Locks responses from Firmata
+       */
+      void lock();
+
+      /**
+       * Unlocks responses from Firmata
+       */
+      void unlock();
+
+      /**
+       * Wait for a response from Firmata before proceeding
+       */
+      void wait();
+
+      /**
+       * Proceed with original function call now that response
+       * from Firmata has been received
+       */
+      void proceed();
+
+      /**
+       * Set results being returned from Firmata for processing
+       *
+       * @param buf is the buffer
+       * @param length is the length of results buffer
+       */
+      void setResults(uint8_t* buf, int length);
+
+      /**
+       * Processes asyncronous responses returned from Firmata
+       */
+      void processResponse();
 
     private:
         mraa_firmata_context m_firmata;

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -82,9 +82,19 @@ class CurieImu {
         void readAccelerometer(int *xVal, int *yVal, int *zVal);
 
         /**
+         * Read gyroscope
+         */
+        void readGyro(int *xVal, int *yVal, int *zVal);
+
+        /**
          * Returns the temperature
          */
         int16_t getTemperature();
+
+        /**
+         * Read motion aka both accelerometer and gyroscope
+         */
+        void readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG);
 
 
         /**

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -51,6 +51,17 @@ namespace upm {
  * @snippet curieimu.cxx Interesting
  */
 
+#define FIRMATA_START_SYSEX                 0xF0
+#define FIRMATA_END_SYSEX                   0xF7
+#define FIRMATA_CURIE_IMU                   0x11
+#define FIRMATA_CURIE_IMU_READ_ACCEL        0x00
+#define FIRMATA_CURIE_IMU_READ_GYRO         0x01
+#define FIRMATA_CURIE_IMU_READ_TEMP         0x02
+#define FIRMATA_CURIE_IMU_SHOCK_DETECT      0x03
+#define FIRMATA_CURIE_IMU_STEP_COUNTER      0x04
+#define FIRMATA_CURIE_IMU_TAP_DETECT        0x05
+#define FIRMATA_CURIE_IMU_READ_MOTION       0x06
+
 class CurieImu {
     public:
         /**
@@ -61,9 +72,18 @@ class CurieImu {
         CurieImu (int subplatform_offset=512);
 
         /**
+         * Destructor for a CurieImu object
+         */
+        ~CurieImu();
+
+        /**
          * Returns the Temperature
          */
         int16_t getTemperature();
+
+        pthread_mutex_t m_responseLock;
+        pthread_cond_t m_responseCond;
+        char* m_results;
 
     private:
         mraa_firmata_context m_firmata;

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <mraa/firmata.h>
+#include <queue>
 
 namespace upm {
 
@@ -62,6 +63,11 @@ namespace upm {
 #define FIRMATA_CURIE_IMU_TAP_DETECT        0x05
 #define FIRMATA_CURIE_IMU_READ_MOTION       0x06
 
+struct ShockDataItem {
+    int axis;
+    int direction;
+};
+
 class CurieImu {
     public:
         /**
@@ -96,16 +102,27 @@ class CurieImu {
          */
         void readMotion(int *xA, int *yA, int *zA, int *xG, int *yG, int *zG);
 
+        void enableShockDetection(bool enable);
+        bool isShockDetected();
+        void getShockDetectData(int *axis, int *direction);
 
         /**
          * Used for response handling
          */
+        void lock();
+        void unlock();
+        void wait();
+        void proceed();
+        void setResults(uint8_t* buf, int length);
+        void processResponse();
+
+    private:
+        mraa_firmata_context m_firmata;
         pthread_mutex_t m_responseLock;
         pthread_cond_t m_responseCond;
         char* m_results;
 
-    private:
-        mraa_firmata_context m_firmata;
+        std::queue<ShockDataItem*> m_shockData;
 };
 
 }

--- a/src/curieimu/curieimu.hpp
+++ b/src/curieimu/curieimu.hpp
@@ -1,0 +1,72 @@
+/*
+ * Author: Brendan Le Foll <brendan.le.foll@intel.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <mraa/firmata.h>
+
+namespace upm {
+
+/**
+ * @brief CurieIMU sensor for Genuino 101 running Firmata
+ * @defgroup curieimu libupm-curieimu
+ * @ingroup firmata
+ */
+
+/**
+ * @library curieimu
+ * @sensor curieimu
+ * @comname Curie IMU sensor over Genuino 101 running Firmata
+ * @altname Curie Firmata IMU
+ * @type firmata
+ * @man firmata imu genuino
+ * @con firmata
+ *
+ * @brief API for the Curie IMU via Firmata
+ *
+ * Curie IMU is a 6-axxis acclerometer
+ *
+ * This module has been tested on an Genuino 101 running ConfigurableFirmata with CurieIMU
+ *
+ * @snippet curieimu.cxx Interesting
+ */
+
+class CurieImu {
+    public:
+        /**
+         * Instantiates a CurieImu object
+         *
+         * @param subplatform_offset Subplatform offset, default 512
+         */
+        CurieImu (int subplatform_offset=512);
+
+        /**
+         * Returns the Temperature
+         */
+        int16_t getTemperature();
+
+    private:
+        mraa_firmata_context m_firmata;
+};
+
+}

--- a/src/curieimu/javaupm_curieimu.i
+++ b/src/curieimu/javaupm_curieimu.i
@@ -2,10 +2,10 @@
 %include "../upm.i"
 
 %{
-    #include "curieimu.h"
+    #include "curieimu.hpp"
 %}
 
-%include "curieimu.h"
+%include "curieimu.hpp"
 
 %pragma(java) jniclasscode=%{
     static {

--- a/src/curieimu/javaupm_curieimu.i
+++ b/src/curieimu/javaupm_curieimu.i
@@ -1,0 +1,19 @@
+%module javaupm_curieimu
+%include "../upm.i"
+
+%{
+    #include "curieimu.h"
+%}
+
+%include "curieimu.h"
+
+%pragma(java) jniclasscode=%{
+    static {
+        try {
+            System.loadLibrary("javaupm_curieimu");
+        } catch (UnsatisfiedLinkError e) {
+            System.err.println("Native code library failed to load. \n" + e);
+            System.exit(1);
+        }
+    }
+%}

--- a/src/curieimu/jsupm_curieimu.i
+++ b/src/curieimu/jsupm_curieimu.i
@@ -1,0 +1,8 @@
+%module jsupm_curieimu
+%include "../upm.i"
+
+%{
+    #include "curieimu.h"
+%}
+
+%include "curieimu.h"

--- a/src/curieimu/jsupm_curieimu.i
+++ b/src/curieimu/jsupm_curieimu.i
@@ -2,7 +2,7 @@
 %include "../upm.i"
 
 %{
-    #include "curieimu.h"
+    #include "curieimu.hpp"
 %}
 
-%include "curieimu.h"
+%include "curieimu.hpp"

--- a/src/curieimu/pyupm_curieimu.i
+++ b/src/curieimu/pyupm_curieimu.i
@@ -5,8 +5,7 @@
 
 %include "stdint.i"
 
-%include "curieimu.h"
+%include "curieimu.hpp"
 %{
-    #include "curieimu.h"
+    #include "curieimu.hpp"
 %}
-

--- a/src/curieimu/pyupm_curieimu.i
+++ b/src/curieimu/pyupm_curieimu.i
@@ -1,0 +1,12 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
+%module pyupm_curieimu
+%include "../upm.i"
+
+%include "stdint.i"
+
+%include "curieimu.h"
+%{
+    #include "curieimu.h"
+%}
+


### PR DESCRIPTION
This PR implements a sensor to communicate with the built-in devices that are in the Arduino101/Genuino101. It uses MRAA acting as a Firmata client. 

This sensor requires that the FirmataCurieIMU plugin to ConfigurableFirmata be compiled and installed on a Arduino101/Genuino101 board.

Here is a very simple example of how it can be used:

```c
#include <unistd.h>
#include "curieimu.hpp"
#include "mraa.h"
#include "mraa/firmata.h"

int
main(int argc, char **argv)
{
    mraa_init();
    mraa_add_subplatform(MRAA_GENERIC_FIRMATA, "/dev/ttyACM0");

    upm::CurieImu* sensor = new upm::CurieImu();

    int x, y, z;
    sensor->readAccelerometer(&x, &y, &z);
    printf("accelerometer is: %d, %d, %d\n", x, y, z);

   delete sensor;
}
```