### PR TITLE
JS/Python examples for CurieIMU sensor for MRAA Firmata client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: cpp
-compiler:
-  - gcc
-  - clang
+env:
+  - CC=gcc CXX=gcc
+  - CC=clang CXX=clang++
+  - NODE4=true
+  - NODE5=true
+  - NODE012=true
 install:
+  - if [ "${NODE4}" ]; then export CC=gcc-4.8 CXX=g++-4.8; fi
   - sudo add-apt-repository --yes ppa:kalakris/cmake
   - sudo add-apt-repository --yes ppa:fenics-packages/fenics-exp/swig
   - sudo apt-get update -qq
@@ -12,10 +16,14 @@ install:
 before_script:
   - if [ "$CC" = "gcc" ]; then export BUILDJAVA=ON; else export BUILDJAVA=OFF; fi
   - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+  - export NODE_ROOT_DIR="/home/travis/.nvm/v0.10.36"
+  - if [ "${NODE4}" ]; then nvm install 4.1; export CC=gcc-4.8; export CXX=g++-4.8; export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; fi
+  - if [ "${NODE5}" ]; then nvm install 5; export CC=gcc-4.8; export CXX=g++-4.8; export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; fi
+  - if [ "${NODE012}" ]; then nvm install 0.12; export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; fi
 script:
   - git clone --branch=master https://github.com/intel-iot-devkit/mraa.git
-  - cd mraa && mkdir build && cd build && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DENABLEEXAMPLES=OFF -DCMAKE_INSTALL_PREFIX:PATH=. -DNODE_ROOT_DIR:PATH=/home/travis/.nvm/v0.10.36/include .. && make && make install
+  - cd mraa && mkdir build && cd build && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DFIRMATA=ON -DENABLEEXAMPLES=OFF -DCMAKE_INSTALL_PREFIX:PATH=. .. && make && make install
   - export PKG_CONFIG_PATH=$PWD/lib/pkgconfig:$PWD/lib/x86_64-linux-gnu/pkgconfig
   - export CPLUS_INCLUDE_PATH=$PWD/include
   - export LIBRARY_PATH=$PWD/lib:$PWD/lib/x86_64-linux-gnu
-  - cd ../.. && mkdir build && cd build && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DNODE_ROOT_DIR:PATH=/home/travis/.nvm/v0.10.36/include -DBUILDEXAMPLES=ON -DBUILDJAVAEXAMPLES=$BUILDJAVA .. && make
+  - cd ../.. && mkdir build && cd build && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DBUILDEXAMPLES=ON -DBUILDJAVAEXAMPLES=$BUILDJAVA .. && make

--- a/examples/javascript/curieimu.js
+++ b/examples/javascript/curieimu.js
@@ -27,7 +27,7 @@
 var mraa = require('mraa');
 console.log('MRAA Version: ' + mraa.getVersion());
 
-// open connection to firmata
+// open connection to Firmata
 mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0");
 
 var curieImu = require('jsupm_curieimu');
@@ -36,7 +36,6 @@ var myCurie = new curieImu.CurieImu();
 var outputStr;
 var myInterval = setInterval(function()
 {
-	// get accelerometer readings
 	myCurie.updateAccel();
 	outputStr = "accel: x " + myCurie.getAccelX()
 				+ " - y " + myCurie.getAccelY()

--- a/examples/javascript/curieimu.js
+++ b/examples/javascript/curieimu.js
@@ -42,7 +42,6 @@ var myInterval = setInterval(function()
 				+ " - y " + myCurie.getAccelY()
 				+ " - z " + myCurie.getAccelZ();
 	console.log(outputStr);
-	console.log(" ");
 }, 500);
 
 // Print message when exiting

--- a/examples/javascript/curieimu.js
+++ b/examples/javascript/curieimu.js
@@ -24,19 +24,26 @@
 * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+var mraa = require('mraa');
+console.log('MRAA Version: ' + mraa.getVersion());
+
+// open connection to firmata
+mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0");
+
 var curieImu = require('jsupm_curieimu');
+var myCurie = new curieImu.CurieImu();
 
 var outputStr;
 var myInterval = setInterval(function()
 {
 	// get accelerometer readings
-	curieImu.updateAccel();
-	outputStr = "accel: x " + curieImu.getAccelX()
-				+ " - y " + curieImu.getAccelY()
-				+ " - z " + curieImu.getAccelZ();
+	myCurie.updateAccel();
+	outputStr = "accel: x " + myCurie.getAccelX()
+				+ " - y " + myCurie.getAccelY()
+				+ " - z " + myCurie.getAccelZ();
 	console.log(outputStr);
 	console.log(" ");
-}, 1000);
+}, 500);
 
 // Print message when exiting
 process.on('SIGINT', function()

--- a/examples/python/curieimu.py
+++ b/examples/python/curieimu.py
@@ -24,6 +24,8 @@
 
 import mraa
 print (mraa.getVersion())
+
+# open connection to Firmata
 mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0")
 
 import time, sys, signal, atexit
@@ -31,12 +33,9 @@ import pyupm_curieimu as curieimu
 sensor = curieimu.CurieImu()
 
 ## Exit handlers ##
-# This stops python from printing a stacktrace when you hit control-C
 def SIGINTHandler(signum, frame):
 	raise SystemExit
 
-# This lets you run code on exit,
-# including functions from myAccelrCompass
 def exitHandler():
 	print "Exiting"
 	sys.exit(0)
@@ -47,7 +46,6 @@ signal.signal(signal.SIGINT, SIGINTHandler)
 
 
 while(1):
-	# Get the acceleration
 	sensor.updateAccel();
 
 	outputStr = "acc: gX {0} - gY {1} - gZ {2}".format(

--- a/examples/python/curieimu.py
+++ b/examples/python/curieimu.py
@@ -24,7 +24,7 @@
 
 import mraa
 print (mraa.getVersion())
-mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0");
+mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0")
 
 import time, sys, signal, atexit
 import pyupm_curieimu as curieimu
@@ -55,5 +55,4 @@ while(1):
 	sensor.getAccelZ())
 	print outputStr
 
-	print " "
 	time.sleep(1)

--- a/examples/python/curieimu.py
+++ b/examples/python/curieimu.py
@@ -22,8 +22,13 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
+import mraa
+print (mraa.getVersion())
+mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0");
+
 import time, sys, signal, atexit
 import pyupm_curieimu as curieimu
+sensor = curieimu.CurieImu()
 
 ## Exit handlers ##
 # This stops python from printing a stacktrace when you hit control-C
@@ -43,11 +48,11 @@ signal.signal(signal.SIGINT, SIGINTHandler)
 
 while(1):
 	# Get the acceleration
-	curieimu.updateAccel();
+	sensor.updateAccel();
 
 	outputStr = "acc: gX {0} - gY {1} - gZ {2}".format(
-	curieimu.getAccelX(), curieimu.getAccelY(),
-	curieimu.getAccelZ())
+	sensor.getAccelX(), sensor.getAccelY(),
+	sensor.getAccelZ())
 	print outputStr
 
 	print " "


### PR DESCRIPTION
Here are examples for both JS & Python that use the Firmata subplatform for MRAA.

To connect from JS:
```
var mraa = require('mraa');
// this opens connection to firmata
mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0");

var curieImu = require('jsupm_curieimu');
var myCurie = new curieImu.CurieImu();
```

To connect from Python:
```
import mraa
# this opens connection to firmata
mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0")

import pyupm_curieimu as curieimu
sensor = curieimu.CurieImu()
```