### PR TITLE
kxcjk1013: code cleanup and update sensor description

### DIFF
--- a/examples/c++/kxcjk1013.cxx
+++ b/examples/c++/kxcjk1013.cxx
@@ -44,8 +44,7 @@ data_callback(char* data)
 {
     float x, y, z;
     accelerometer->extract3Axis(data, &x, &y, &z);
-    printf("%.1f               %.1f               %.1f\n", x, y, z);
-    // usleep(100);
+    printf("% .1f               % .1f               % .1f\n", x, y, z);
 }
 
 int

--- a/src/kxcjk1013/kxcjk1013.cxx
+++ b/src/kxcjk1013/kxcjk1013.cxx
@@ -28,6 +28,8 @@
 #include <string.h>
 #include "kxcjk1013.h"
 
+#define NUMBER_OF_BITS_IN_BYTE 8
+
 using namespace upm;
 
 KXCJK1013::KXCJK1013(int device)
@@ -45,7 +47,7 @@ KXCJK1013::KXCJK1013(int device)
     sprintf(trigger, "hrtimer-kxcjk1013-hr-dev%d", device);
 
     if (mraa_iio_create_trigger(m_iio, trigger) != MRAA_SUCCESS)
-        fprintf(stderr, "Create trigger failed\n");
+        fprintf(stderr, "Create trigger %s failed\n", trigger);
 
     if (mraa_iio_get_mounting_matrix(m_iio, m_mount_matrix) == MRAA_SUCCESS)
         m_mount_matrix_exist = true;
@@ -58,7 +60,8 @@ KXCJK1013::KXCJK1013(int device)
 
 KXCJK1013::~KXCJK1013()
 {
-    // mraa_iio_stop(m_iio);
+    if(m_iio)
+        mraa_iio_close(m_iio);
 }
 
 void
@@ -70,21 +73,20 @@ KXCJK1013::installISR(void (*isr)(char*), void* arg)
 int64_t
 KXCJK1013::getChannelValue(unsigned char* input, mraa_iio_channel* chan)
 {
-    uint64_t u64;
+    uint64_t u64 = 0;
     int i;
-    int storagebits = chan->bytes * 8;
+    int storagebits = chan->bytes * NUMBER_OF_BITS_IN_BYTE;
     int realbits = chan->bits_used;
     int zeroed_bits = storagebits - realbits;
     uint64_t sign_mask;
     uint64_t value_mask;
 
-    u64 = 0;
 
     if (!chan->lendian)
-        for (i = 0; i < storagebits / 8; i++)
-            u64 = (u64 << 8) | input[i];
+        for (i = 0; i < storagebits / NUMBER_OF_BITS_IN_BYTE; i++)
+            u64 = (u64 << NUMBER_OF_BITS_IN_BYTE) | input[i];
     else
-        for (i = storagebits / 8 - 1; i >= 0; i--)
+        for (i = storagebits / NUMBER_OF_BITS_IN_BYTE - 1; i >= 0; i--)
             u64 = (u64 << 8) | input[i];
 
     u64 = (u64 >> chan->shift) & (~0ULL >> zeroed_bits);

--- a/src/kxcjk1013/kxcjk1013.h
+++ b/src/kxcjk1013/kxcjk1013.h
@@ -59,10 +59,12 @@ class KXCJK1013
      * @param iio device number
      */
     KXCJK1013(int device);
+
     /**
      * KXCJK1013 destructor
      */
     ~KXCJK1013();
+
     /**
      * Installs an interrupt service routine (ISR) to be called when
      * an interrupt occurs
@@ -73,16 +75,17 @@ class KXCJK1013
      * argument to the ISR.
      */
     void installISR(void (*isr)(char*), void* arg);
+
     /**
      * Extract the channel value based on channel type
-   * @param input Channel data
-   * @param chan MRAA iio-layer channel info
+     * @param input Channel data
+     * @param chan MRAA iio-layer channel info
      */
     int64_t getChannelValue(unsigned char* input, mraa_iio_channel* chan);
 
     /**
      * Enable trigger buffer
-   * @param trigger buffer length in string
+     * @param trigger buffer length in string
      */
     bool enableBuffer(int length);
 
@@ -93,13 +96,13 @@ class KXCJK1013
 
     /**
      * Set scale
-   * @param scale in string
+     * @param scale in string
      */
     bool setScale(const float scale);
 
     /**
      * Set sampling frequency
-   * @param sampling frequency  in string
+     * @param sampling frequency in string
      */
     bool setSamplingFrequency(const float sampling_frequency);
 
@@ -110,10 +113,10 @@ class KXCJK1013
 
     /**
      * Process enabled channel buffer and return x, y, z axis
-   * @param data Enabled channel data, 6 bytes, each axis 2 bytes
-   * @param x X-Axis
-   * @param y Y-Axis
-   * @param z Z-Axis
+     * @param data Enabled channel data, 6 bytes, each axis 2 bytes
+     * @param x X-Axis
+     * @param y Y-Axis
+     * @param z Z-Axis
      */
     void extract3Axis(char* data, float* x, float* y, float* z);
 


### PR DESCRIPTION
Code cleanup and proper close iio device in destructor.

KXCJK-1013 is tri-axis accelerometer from Kionix.
This sensor can measure acceleration in metre per second squared or in
G-forces.

The library provided is libupm-kxcjk1013.so.0.4.0.
The example provided is kxcjk1013-example where it will print x,y,z axis when
trigger buffer data is ready.

Signed-off-by: Lay, Kuan Loon <kuan.loon.lay@intel.com>