### PR TITLE
Enable mmc35240 disable java

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -265,6 +265,7 @@ if (BACNET_FOUND)
   add_example (e50hx)
 endif()
 add_example (vcap)
+add_example (l3gd20)
 
 # These are special cases where you specify example binary, source file and module(s)
 include_directories (${PROJECT_SOURCE_DIR}/src)

--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -266,6 +266,7 @@ if (BACNET_FOUND)
 endif()
 add_example (vcap)
 add_example (l3gd20)
+add_example (mmc35240)
 
 # These are special cases where you specify example binary, source file and module(s)
 include_directories (${PROJECT_SOURCE_DIR}/src)

--- a/examples/c++/kxcjk1013.cxx
+++ b/examples/c++/kxcjk1013.cxx
@@ -44,8 +44,7 @@ data_callback(char* data)
 {
     float x, y, z;
     accelerometer->extract3Axis(data, &x, &y, &z);
-    printf("%.1f               %.1f               %.1f\n", x, y, z);
-    // usleep(100);
+    printf("% .1f               % .1f               % .1f\n", x, y, z);
 }
 
 int

--- a/examples/c++/l3gd20.cxx
+++ b/examples/c++/l3gd20.cxx
@@ -1,0 +1,74 @@
+/*
+ * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <signal.h>
+#include "l3gd20.h"
+
+using namespace std;
+
+int shouldRun = true;
+upm::L3GD20* gyroscope;
+
+void
+sig_handler(int signo)
+{
+    if (signo == SIGINT)
+        shouldRun = false;
+}
+
+void
+data_callback(char* data)
+{
+    float x, y, z;
+    if (gyroscope->extract3Axis(data, &x, &y, &z))
+        printf("% .2f               % .2f               % .2f\n", x, y, z);
+}
+
+int
+main()
+{
+    signal(SIGINT, sig_handler);
+    //! [Interesting]
+    // Instantiate a L3GD20 Gyroscope Sensor on iio device 3
+    gyroscope = new upm::L3GD20(3);
+    gyroscope->setScale(0.001222);
+    gyroscope->setSamplingFrequency(95.0);
+    gyroscope->enable3AxisChannel();
+    gyroscope->installISR(data_callback, NULL);
+    gyroscope->enableBuffer(16);
+
+    while (shouldRun) {
+        sleep(1);
+    }
+    gyroscope->disableBuffer();
+
+    //! [Interesting]
+    cout << "Exiting" << endl;
+
+    delete gyroscope;
+
+    return 0;
+}

--- a/examples/c++/mmc35240.cxx
+++ b/examples/c++/mmc35240.cxx
@@ -1,0 +1,86 @@
+/*
+ * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <signal.h>
+#include <math.h>
+#include "mmc35240.h"
+
+using namespace std;
+
+int shouldRun = true;
+upm::MMC35240* magnetometer;
+
+void
+sig_handler(int signo)
+{
+    if (signo == SIGINT)
+        shouldRun = false;
+}
+
+void
+data_callback(char* data)
+{
+    float x, y, z;
+    double azimuth;
+    int level;
+    magnetometer->extract3Axis(data, &x, &y, &z);
+    /* calibrated level
+     * UNRELIABLE = 0
+     * ACCURACY_LOW = 1
+     * ACCURACY_MEDIUM = 2
+     * ACCURACY_HIGH = >=3
+     */
+    level = magnetometer->getCalibratedLevel();
+    azimuth = 90 - atan(y/x) * 180 / M_PI;
+    printf("[Calibrated Level:%d] [Azimuth:%d]    % .2f               % .2f               % .2f\n", level, (int)azimuth, x, y, z);
+}
+
+int
+main()
+{
+    signal(SIGINT, sig_handler);
+    //! [Interesting]
+    // Instantiate a MMC35240 Magnetic Sensor on iio device 5
+    magnetometer = new upm::MMC35240(5);
+
+    magnetometer->setScale(0.001000);
+    magnetometer->setSamplingFrequency(25.000000);
+    magnetometer->enable3AxisChannel();
+    magnetometer->installISR(data_callback, NULL);
+    magnetometer->enableBuffer(16);
+
+    while (shouldRun) {
+        sleep(1);
+    }
+    magnetometer->disableBuffer();
+
+    //! [Interesting]
+    cout << "Exiting" << endl;
+
+    delete magnetometer;
+
+    return 0;
+}

--- a/src/apds9930/apds9930.cxx
+++ b/src/apds9930/apds9930.cxx
@@ -41,7 +41,8 @@ APDS9930::APDS9930(int device)
 
 APDS9930::~APDS9930()
 {
-    // mraa_iio_stop(m_iio);
+    if(m_iio)
+        mraa_iio_close(m_iio);
 }
 
 int

--- a/src/javaswig_blacklist
+++ b/src/javaswig_blacklist
@@ -1,2 +1,3 @@
 nrf8001
 kxcjk1013
+l3gd20

--- a/src/javaswig_blacklist
+++ b/src/javaswig_blacklist
@@ -1,3 +1,4 @@
 nrf8001
 kxcjk1013
 l3gd20
+mmc35240

--- a/src/kxcjk1013/kxcjk1013.cxx
+++ b/src/kxcjk1013/kxcjk1013.cxx
@@ -28,6 +28,8 @@
 #include <string.h>
 #include "kxcjk1013.h"
 
+#define NUMBER_OF_BITS_IN_BYTE 8
+
 using namespace upm;
 
 KXCJK1013::KXCJK1013(int device)
@@ -45,7 +47,7 @@ KXCJK1013::KXCJK1013(int device)
     sprintf(trigger, "hrtimer-kxcjk1013-hr-dev%d", device);
 
     if (mraa_iio_create_trigger(m_iio, trigger) != MRAA_SUCCESS)
-        fprintf(stderr, "Create trigger failed\n");
+        fprintf(stderr, "Create trigger %s failed\n", trigger);
 
     if (mraa_iio_get_mounting_matrix(m_iio, m_mount_matrix) == MRAA_SUCCESS)
         m_mount_matrix_exist = true;
@@ -58,7 +60,8 @@ KXCJK1013::KXCJK1013(int device)
 
 KXCJK1013::~KXCJK1013()
 {
-    // mraa_iio_stop(m_iio);
+    if(m_iio)
+        mraa_iio_close(m_iio);
 }
 
 void
@@ -70,21 +73,20 @@ KXCJK1013::installISR(void (*isr)(char*), void* arg)
 int64_t
 KXCJK1013::getChannelValue(unsigned char* input, mraa_iio_channel* chan)
 {
-    uint64_t u64;
+    uint64_t u64 = 0;
     int i;
-    int storagebits = chan->bytes * 8;
+    int storagebits = chan->bytes * NUMBER_OF_BITS_IN_BYTE;
     int realbits = chan->bits_used;
     int zeroed_bits = storagebits - realbits;
     uint64_t sign_mask;
     uint64_t value_mask;
 
-    u64 = 0;
 
     if (!chan->lendian)
-        for (i = 0; i < storagebits / 8; i++)
-            u64 = (u64 << 8) | input[i];
+        for (i = 0; i < storagebits / NUMBER_OF_BITS_IN_BYTE; i++)
+            u64 = (u64 << NUMBER_OF_BITS_IN_BYTE) | input[i];
     else
-        for (i = storagebits / 8 - 1; i >= 0; i--)
+        for (i = storagebits / NUMBER_OF_BITS_IN_BYTE - 1; i >= 0; i--)
             u64 = (u64 << 8) | input[i];
 
     u64 = (u64 >> chan->shift) & (~0ULL >> zeroed_bits);

--- a/src/kxcjk1013/kxcjk1013.h
+++ b/src/kxcjk1013/kxcjk1013.h
@@ -59,10 +59,12 @@ class KXCJK1013
      * @param iio device number
      */
     KXCJK1013(int device);
+
     /**
      * KXCJK1013 destructor
      */
     ~KXCJK1013();
+
     /**
      * Installs an interrupt service routine (ISR) to be called when
      * an interrupt occurs
@@ -73,16 +75,17 @@ class KXCJK1013
      * argument to the ISR.
      */
     void installISR(void (*isr)(char*), void* arg);
+
     /**
      * Extract the channel value based on channel type
-   * @param input Channel data
-   * @param chan MRAA iio-layer channel info
+     * @param input Channel data
+     * @param chan MRAA iio-layer channel info
      */
     int64_t getChannelValue(unsigned char* input, mraa_iio_channel* chan);
 
     /**
      * Enable trigger buffer
-   * @param trigger buffer length in string
+     * @param trigger buffer length in string
      */
     bool enableBuffer(int length);
 
@@ -93,13 +96,13 @@ class KXCJK1013
 
     /**
      * Set scale
-   * @param scale in string
+     * @param scale in string
      */
     bool setScale(const float scale);
 
     /**
      * Set sampling frequency
-   * @param sampling frequency  in string
+     * @param sampling frequency in string
      */
     bool setSamplingFrequency(const float sampling_frequency);
 
@@ -110,10 +113,10 @@ class KXCJK1013
 
     /**
      * Process enabled channel buffer and return x, y, z axis
-   * @param data Enabled channel data, 6 bytes, each axis 2 bytes
-   * @param x X-Axis
-   * @param y Y-Axis
-   * @param z Z-Axis
+     * @param data Enabled channel data, 6 bytes, each axis 2 bytes
+     * @param x X-Axis
+     * @param y Y-Axis
+     * @param z Z-Axis
      */
     void extract3Axis(char* data, float* x, float* y, float* z);
 

--- a/src/l3gd20/CMakeLists.txt
+++ b/src/l3gd20/CMakeLists.txt
@@ -1,0 +1,5 @@
+set (libname "l3gd20")
+set (libdescription "upm l3gd20 sensor module")
+set (module_src ${libname}.cxx)
+set (module_h ${libname}.h)
+upm_module_init()

--- a/src/l3gd20/jsupm_l3gd20.i
+++ b/src/l3gd20/jsupm_l3gd20.i
@@ -1,0 +1,8 @@
+%module jsupm_l3gd20
+%include "../upm.i"
+
+%{
+    #include "l3gd20.h"
+%}
+
+%include "l3gd20.h"

--- a/src/l3gd20/l3gd20.cxx
+++ b/src/l3gd20/l3gd20.cxx
@@ -1,0 +1,462 @@
+/*
+ * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <string.h>
+#include <math.h>
+#include "l3gd20.h"
+
+#define NUMBER_OF_BITS_IN_BYTE 8
+#define GYRO_MIN_SAMPLES 5 /* Drop first few gyro samples after enable */
+#define GYRO_MAX_ERR 0.05
+#define GYRO_DS_SIZE 100
+
+#define GYRO_DENOISE_MAX_SAMPLES 5
+#define GYRO_DENOISE_NUM_FIELDS 3
+
+using namespace upm;
+
+L3GD20::L3GD20(int device)
+{
+    float gyro_scale;
+    char trigger[64];
+
+    if (!(m_iio = mraa_iio_init(device))) {
+        throw std::invalid_argument(std::string(__FUNCTION__) +
+                                    ": mraa_iio_init() failed, invalid device?");
+        return;
+    }
+    m_scale = 1;
+    m_iio_device_num = device;
+    sprintf(trigger, "hrtimer-l3gd20-hr-dev%d", device);
+
+    if (mraa_iio_create_trigger(m_iio, trigger) != MRAA_SUCCESS)
+        fprintf(stderr, "Create trigger %s failed\n", trigger);
+
+    if (mraa_iio_get_mounting_matrix(m_iio, m_mount_matrix) == MRAA_SUCCESS)
+        m_mount_matrix_exist = true;
+    else
+        m_mount_matrix_exist = false;
+
+    if (mraa_iio_read_float(m_iio, "in_anglvel_x_scale", &gyro_scale) == MRAA_SUCCESS)
+        m_scale = gyro_scale;
+
+    m_event_count = 0;
+
+    // initial calibrate data
+    initCalibrate();
+
+    // initial denoise data
+    m_filter.buff =
+    (float*) calloc(GYRO_DENOISE_MAX_SAMPLES, sizeof(float) * GYRO_DENOISE_NUM_FIELDS);
+    if (m_filter.buff == NULL) {
+        throw std::invalid_argument(std::string(__FUNCTION__) +
+                                    ": mraa_iio_init() failed, calloc denoise data");
+        return;
+    }
+    m_filter.sample_size = GYRO_DENOISE_MAX_SAMPLES;
+    m_filter.count = 0;
+    m_filter.idx = 0;
+}
+
+L3GD20::~L3GD20()
+{
+    if (m_filter.buff) {
+        free(m_filter.buff);
+        m_filter.buff = NULL;
+    }
+    if(m_iio)
+        mraa_iio_close(m_iio);
+}
+
+#ifdef JAVACALLBACK
+void
+L3GD20::installISR(IsrCallback* cb)
+{
+    installISR(generic_callback_isr, cb);
+}
+#endif
+
+void
+L3GD20::installISR(void (*isr)(char*), void* arg)
+{
+    mraa_iio_trigger_buffer(m_iio, isr, NULL);
+}
+
+int64_t
+L3GD20::getChannelValue(unsigned char* input, mraa_iio_channel* chan)
+{
+    uint64_t u64 = 0;
+    int i;
+    int storagebits = chan->bytes * NUMBER_OF_BITS_IN_BYTE;
+    int realbits = chan->bits_used;
+    int zeroed_bits = storagebits - realbits;
+    uint64_t sign_mask;
+    uint64_t value_mask;
+
+    if (!chan->lendian)
+        for (i = 0; i < storagebits / NUMBER_OF_BITS_IN_BYTE; i++)
+            u64 = (u64 << 8) | input[i];
+    else
+        for (i = storagebits / NUMBER_OF_BITS_IN_BYTE - 1; i >= 0; i--)
+            u64 = (u64 << 8) | input[i];
+
+    u64 = (u64 >> chan->shift) & (~0ULL >> zeroed_bits);
+
+    if (!chan->signedd)
+        return (int64_t) u64; /* We don't handle unsigned 64 bits int */
+
+    /* Signed integer */
+
+    switch (realbits) {
+        case 0 ... 1:
+            return 0;
+
+        case 8:
+            return (int64_t)(int8_t) u64;
+
+        case 16:
+            return (int64_t)(int16_t) u64;
+
+        case 32:
+            return (int64_t)(int32_t) u64;
+
+        case 64:
+            return (int64_t) u64;
+
+        default:
+            sign_mask = 1 << (realbits - 1);
+            value_mask = sign_mask - 1;
+
+            if (u64 & sign_mask)
+                return -((~u64 & value_mask) + 1); /* Negative value: return 2-complement */
+            else
+                return (int64_t) u64; /* Positive value */
+    }
+}
+
+bool
+L3GD20::enableBuffer(int length)
+{
+    mraa_iio_write_int(m_iio, "buffer/length", length);
+    // enable must be last step, else will have error in writing above config
+    mraa_iio_write_int(m_iio, "buffer/enable", 1);
+    return true;
+}
+
+bool
+L3GD20::disableBuffer()
+{
+    mraa_iio_write_int(m_iio, "buffer/enable", 0);
+    return true;
+}
+
+bool
+L3GD20::setScale(float scale)
+{
+    mraa_iio_write_float(m_iio, "in_anglvel_x_scale", scale);
+    mraa_iio_write_float(m_iio, "in_anglvel_y_scale", scale);
+    mraa_iio_write_float(m_iio, "in_anglvel_z_scale", scale);
+    return true;
+}
+
+bool
+L3GD20::setSamplingFrequency(float sampling_frequency)
+{
+    mraa_iio_write_float(m_iio, "sampling_frequency", sampling_frequency);
+    return true;
+}
+
+bool
+L3GD20::enable3AxisChannel()
+{
+    char trigger[64];
+    sprintf(trigger, "l3gd20-hr-dev%d", m_iio_device_num);
+
+    mraa_iio_write_string(m_iio, "trigger/current_trigger", trigger);
+    mraa_iio_write_int(m_iio, "scan_elements/in_anglvel_x_en", 1);
+    mraa_iio_write_int(m_iio, "scan_elements/in_anglvel_y_en", 1);
+    mraa_iio_write_int(m_iio, "scan_elements/in_anglvel_z_en", 1);
+
+    // need update channel data size after enable
+    mraa_iio_update_channels(m_iio);
+    return true;
+}
+
+bool
+L3GD20::extract3Axis(char* data, float* x, float* y, float* z)
+{
+    mraa_iio_channel* channels = mraa_iio_get_channels(m_iio);
+    float tmp[3];
+    int iio_x, iio_y, iio_z;
+
+    m_event_count++;
+
+    if (m_event_count < GYRO_MIN_SAMPLES) {
+        /* drop the sample */
+        return false;
+    }
+
+    iio_x = getChannelValue((unsigned char*) (data + channels[0].location), &channels[0]);
+    iio_y = getChannelValue((unsigned char*) (data + channels[1].location), &channels[1]);
+    iio_z = getChannelValue((unsigned char*) (data + channels[2].location), &channels[2]);
+
+    *x = (iio_x * m_scale);
+    *y = (iio_y * m_scale);
+    *z = (iio_z * m_scale);
+
+    if (m_mount_matrix_exist) {
+        tmp[0] = *x * m_mount_matrix[0] + *y * m_mount_matrix[1] + *z * m_mount_matrix[2];
+        tmp[1] = *x * m_mount_matrix[3] + *y * m_mount_matrix[4] + *z * m_mount_matrix[5];
+        tmp[2] = *x * m_mount_matrix[6] + *y * m_mount_matrix[7] + *z * m_mount_matrix[8];
+
+        *x = tmp[0];
+        *y = tmp[1];
+        *z = tmp[2];
+    }
+
+    /* Attempt gyroscope calibration if we have not reached this state */
+    if (m_calibrated == false)
+        m_calibrated = gyroCollect(*x, *y, *z);
+
+    *x = *x - m_cal_data.bias_x;
+    *y = *y - m_cal_data.bias_y;
+    *z = *z - m_cal_data.bias_z;
+
+
+    gyroDenoiseMedian(x, y, z);
+    clampGyroReadingsToZero(x, y, z);
+
+    return true;
+}
+
+void
+L3GD20::initCalibrate()
+{
+    m_calibrated = false;
+    m_cal_data.count = 0;
+    m_cal_data.bias_x = m_cal_data.bias_y = m_cal_data.bias_z = 0;
+    m_cal_data.min_x = m_cal_data.min_y = m_cal_data.min_z = 1.0;
+    m_cal_data.max_x = m_cal_data.max_y = m_cal_data.max_z = -1.0;
+}
+
+bool
+L3GD20::getCalibratedStatus()
+{
+    return m_calibrated;
+}
+
+void
+L3GD20::getCalibratedData(float* bias_x, float* bias_y, float* bias_z)
+{
+    *bias_x = m_cal_data.bias_x;
+    *bias_y = m_cal_data.bias_y;
+    *bias_z = m_cal_data.bias_z;
+}
+
+void
+L3GD20::loadCalibratedData(float bias_x, float bias_y, float bias_z)
+{
+    m_calibrated = true;
+    m_cal_data.bias_x = bias_x;
+    m_cal_data.bias_y = bias_y;
+    m_cal_data.bias_z = bias_z;
+}
+
+bool
+L3GD20::gyroCollect(float x, float y, float z)
+{
+    /* Analyze gyroscope data */
+
+    if (fabs(x) >= 1 || fabs(y) >= 1 || fabs(z) >= 1) {
+        /* We're supposed to be standing still ; start over */
+        m_cal_data.count = 0;
+        m_cal_data.bias_x = m_cal_data.bias_y = m_cal_data.bias_z = 0;
+        m_cal_data.min_x = m_cal_data.min_y = m_cal_data.min_z = 1.0;
+        m_cal_data.max_x = m_cal_data.max_y = m_cal_data.max_z = -1.0;
+
+        return false; /* Uncalibrated */
+    }
+
+    /* Thanks to https://github.com/01org/android-iio-sensors-hal for calibration algorithm */
+    if (m_cal_data.count < GYRO_DS_SIZE) {
+        if (x < m_cal_data.min_x)
+            m_cal_data.min_x = x;
+
+        if (y < m_cal_data.min_y)
+            m_cal_data.min_y = y;
+
+        if (z < m_cal_data.min_z)
+            m_cal_data.min_z = z;
+
+        if (x > m_cal_data.max_x)
+            m_cal_data.max_x = x;
+
+        if (y > m_cal_data.max_y)
+            m_cal_data.max_y = y;
+
+        if (z > m_cal_data.max_z)
+            m_cal_data.max_z = z;
+
+        if (fabs(m_cal_data.max_x - m_cal_data.min_x) <= GYRO_MAX_ERR &&
+            fabs(m_cal_data.max_y - m_cal_data.min_y) <= GYRO_MAX_ERR &&
+            fabs(m_cal_data.max_z - m_cal_data.min_z) <= GYRO_MAX_ERR)
+            m_cal_data.count++; /* One more conformant sample */
+        else {
+            /* Out of spec sample ; start over */
+            m_calibrated = false;
+            m_cal_data.count = 0;
+            m_cal_data.bias_x = m_cal_data.bias_y = m_cal_data.bias_z = 0;
+            m_cal_data.min_x = m_cal_data.min_y = m_cal_data.min_z = 1.0;
+            m_cal_data.max_x = m_cal_data.max_y = m_cal_data.max_z = -1.0;
+        }
+
+        return false; /* Still uncalibrated */
+    }
+
+    /* We got enough stable samples to estimate gyroscope bias */
+    m_cal_data.bias_x = (m_cal_data.max_x + m_cal_data.min_x) / 2;
+    m_cal_data.bias_y = (m_cal_data.max_y + m_cal_data.min_y) / 2;
+    m_cal_data.bias_z = (m_cal_data.max_z + m_cal_data.min_z) / 2;
+
+    return true; /* Calibrated! */
+}
+
+void
+L3GD20::gyroDenoiseMedian(float* x, float* y, float* z)
+{
+    /* Thanks to https://github.com/01org/android-iio-sensors-hal for denoise algorithm */
+    unsigned int offset;
+
+    /* If we are at event count 1 reset the indices */
+    if (m_event_count == 1) {
+        m_filter.count = 0;
+        m_filter.idx = 0;
+    }
+
+    if (m_filter.count < m_filter.sample_size)
+        m_filter.count++;
+
+    offset = 0;
+    m_filter.buff[offset + m_filter.idx] = *x;
+    *x = median(m_filter.buff + offset, m_filter.count);
+
+    offset = m_filter.sample_size * 1;
+    m_filter.buff[offset + m_filter.idx] = *y;
+    *y = median(m_filter.buff + offset, m_filter.count);
+
+    offset = m_filter.sample_size * 2;
+    m_filter.buff[offset + m_filter.idx] = *z;
+    *z = median(m_filter.buff + offset, m_filter.count);
+
+    m_filter.idx = (m_filter.idx + 1) % m_filter.sample_size;
+}
+
+float
+L3GD20::median(float* queue, unsigned int size)
+{
+    /* http://en.wikipedia.org/wiki/Quickselect */
+
+    unsigned int left = 0;
+    unsigned int right = size - 1;
+    unsigned int pivot_index;
+    unsigned int median_index = (right / 2);
+    float temp[size];
+
+    memcpy(temp, queue, size * sizeof(float));
+
+    /* If the list has only one element return it */
+    if (left == right)
+        return temp[left];
+
+    while (left < right) {
+        pivot_index = (left + right) / 2;
+        pivot_index = partition(temp, left, right, pivot_index);
+        if (pivot_index == median_index)
+            return temp[median_index];
+        else if (pivot_index > median_index)
+            right = pivot_index - 1;
+        else
+            left = pivot_index + 1;
+    }
+
+    return temp[left];
+}
+
+unsigned int
+L3GD20::partition(float* list, unsigned int left, unsigned int right, unsigned int pivot_index)
+{
+    unsigned int i;
+    unsigned int store_index = left;
+    float aux;
+    float pivot_value = list[pivot_index];
+
+    /* Swap list[pivotIndex] and list[right] */
+    aux = list[pivot_index];
+    list[pivot_index] = list[right];
+    list[right] = aux;
+
+    for (i = left; i < right; i++) {
+        if (list[i] < pivot_value) {
+            /* Swap list[store_index] and list[i] */
+            aux = list[store_index];
+            list[store_index] = list[i];
+            list[i] = aux;
+            store_index++;
+        }
+    }
+
+    /* Swap list[right] and list[store_index] */
+    aux = list[right];
+    list[right] = list[store_index];
+    list[store_index] = aux;
+    return store_index;
+}
+
+void
+L3GD20::clampGyroReadingsToZero(float* x, float* y, float* z)
+{
+    float near_zero;
+
+    /* If we're calibrated, don't filter out as much */
+    if (m_calibrated)
+        near_zero = 0.02; /* rad/s */
+    else
+        near_zero = 0.1;
+
+    /* If motion on all axes is small enough */
+    if (fabs(*x) < near_zero && fabs(*y) < near_zero && fabs(*z) < near_zero) {
+        /*
+         * Report that we're not moving at all... but not exactly zero as composite sensors
+         * (orientation, rotation vector) don't
+         * seem to react very well to it.
+         */
+
+        *x *= 0.000001;
+        *y *= 0.000001;
+        *z *= 0.000001;
+    }
+}

--- a/src/l3gd20/l3gd20.h
+++ b/src/l3gd20/l3gd20.h
@@ -1,0 +1,210 @@
+/*
+ * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Thanks to https://github.com/01org/android-iio-sensors-hal for gyroscope
+ * calibration and denoise algorithm.
+ */
+#pragma once
+
+#include <string>
+#include <mraa/iio.h>
+
+namespace upm
+{
+/**
+ * @brief L3GD20 Tri-axis Digital Gyroscope
+ * @defgroup l3gd20 libupm-l3gd20
+ * @ingroup STMicroelectronics iio i2c tri-axis digital gyroscope
+ */
+
+/**
+ * @library l3gd20
+ * @sensor l3gd20
+ * @comname L3GD20 Tri-axis Digital Gyroscope
+ * @type gyroscope
+ * @man STMicroelectronics
+ * @con iio i2c
+ *
+ * @brief L3GD20 Tri-axis Digital Gyroscope API
+ *
+ * The L3GD20 The L3GD20 is a low-power three-axis angular rate sensor.
+ *
+ * @snippet l3gd20.cxx Interesting
+ */
+
+class L3GD20
+{
+  public:
+    typedef struct {
+        float bias_x, bias_y, bias_z;
+        int count;
+        float min_x, min_y, min_z;
+        float max_x, max_y, max_z;
+    } gyro_cal_t;
+
+    typedef struct {
+        float* buff;
+        unsigned int idx;
+        unsigned int count;
+        unsigned int sample_size;
+    } filter_median_t;
+    /**
+     * L3GD20 Tri-axis Digital Gyroscope
+     *
+     * @param iio device number
+     */
+    L3GD20(int device);
+
+    /**
+     * L3GD20 destructor
+     */
+    ~L3GD20();
+
+    /**
+     * Installs an interrupt service routine (ISR) to be called when
+     * an interrupt occurs
+     *
+     * @param interrupt channel
+     * @param fptr Pointer to a function to be called on interrupt
+     * @param arg Pointer to an object to be supplied as an
+     * argument to the ISR.
+     */
+    void installISR(void (*isr)(char*), void* arg);
+
+    /**
+     * Extract the channel value based on channel type
+     * @param input Channel data
+     * @param chan MRAA iio-layer channel info
+     */
+    int64_t getChannelValue(unsigned char* input, mraa_iio_channel* chan);
+
+    /**
+     * Enable trigger buffer
+     * @param trigger buffer length in string
+     */
+    bool enableBuffer(int length);
+
+    /**
+     * Disable trigger buffer
+     */
+    bool disableBuffer();
+
+    /**
+     * Set scale
+     * @param scale in string
+     */
+    bool setScale(const float scale);
+
+    /**
+     * Set sampling frequency
+     * @param sampling frequency  in string
+     */
+    bool setSamplingFrequency(const float sampling_frequency);
+
+    /**
+     * Enable 3 axis scan element
+     */
+    bool enable3AxisChannel();
+
+    /**
+     * Process enabled channel buffer and return x, y, z axis
+     * @param data Enabled channel data, 6 bytes, each axis 2 bytes
+     * @param x X-Axis
+     * @param y Y-Axis
+     * @param z Z-Axis
+     */
+    bool extract3Axis(char* data, float* x, float* y, float* z);
+
+    /**
+     * Reset calibration data and start collect calibration data again
+     */
+    void initCalibrate();
+
+    /**
+     * Get calibrated status, return true if calibrate successfully
+     */
+    bool getCalibratedStatus();
+
+    /**
+     * Get calibrated data
+     */
+    void getCalibratedData(float* bias_x, float* bias_y, float* bias_z);
+
+    /**
+     * Load calibrated data
+     */
+    void loadCalibratedData(float bias_x, float bias_y, float bias_z);
+
+    /**
+     * Calibrate gyro
+     * @param x X-Axis
+     * @param y Y-Axis
+     * @param z Z-Axis
+     */
+    bool gyroCollect(float x, float y, float z);
+
+    /**
+     * Denoise gyro
+     * @param x X-Axis
+     * @param y Y-Axis
+     * @param z Z-Axis
+     */
+    void gyroDenoiseMedian(float* x, float* y, float* z);
+
+    /**
+     * median algorithm
+     * @param queue
+     * @param size
+     */
+    float median(float* queue, unsigned int size);
+
+    /**
+     * partition algorithm
+     * @param list
+     * @param left
+     * @param right
+     * @param pivot_index
+     */
+    unsigned int
+    partition(float* list, unsigned int left, unsigned int right, unsigned int pivot_index);
+
+    /**
+     * Clamp Gyro Readings to Zero
+     * @param x X-Axis
+     * @param y Y-Axis
+     * @param z Z-Axis
+     */
+    void clampGyroReadingsToZero(float* x, float* y, float* z);
+
+  private:
+    mraa_iio_context m_iio;
+    int m_iio_device_num;
+    bool m_mount_matrix_exist; // is mount matrix exist
+    float m_mount_matrix[9];   // mount matrix
+    float m_scale;             // gyroscope data scale
+    int m_event_count; // sample data arrive
+    bool m_calibrated;        // calibrate state
+    gyro_cal_t m_cal_data;    // calibrate data
+    filter_median_t m_filter; // filter data
+};
+}

--- a/src/l3gd20/pyupm_l3gd20.i
+++ b/src/l3gd20/pyupm_l3gd20.i
@@ -1,0 +1,9 @@
+%module pyupm_l3gd20
+%include "../upm.i"
+
+%feature("autodoc", "3");
+
+%include "l3gd20.h"
+%{
+    #include "l3gd20.h"
+%}

--- a/src/mmc35240/CMakeLists.txt
+++ b/src/mmc35240/CMakeLists.txt
@@ -1,0 +1,5 @@
+set (libname "mmc35240")
+set (libdescription "upm mmc35240 sensor module")
+set (module_src ${libname}.cxx)
+set (module_h ${libname}.h)
+upm_module_init()

--- a/src/mmc35240/jsupm_mmc35240.i
+++ b/src/mmc35240/jsupm_mmc35240.i
@@ -1,0 +1,8 @@
+%module jsupm_mmc35240
+%include "../upm.i"
+
+%{
+    #include "mmc35240.h"
+%}
+
+%include "mmc35240.h"

--- a/src/mmc35240/mmc35240.cxx
+++ b/src/mmc35240/mmc35240.cxx
@@ -1,0 +1,937 @@
+/*
+ * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <string.h>
+#include <math.h>
+#include "mmc35240.h"
+
+#define NUMBER_OF_BITS_IN_BYTE 8
+
+/* Compass defines */
+#define CONVERT_GAUSS_TO_MICROTESLA(x) ((x) *100)
+#define EPSILON 0.000000001
+#define MAGNETIC_LOW 960 /* 31 micro tesla squared */
+#define CAL_STEPS 5
+
+/* Filter defines */
+#define FILTER_MAX_SAMPLE 20
+#define FILTER_NUM_FILED 3
+
+using namespace upm;
+
+/* We'll have multiple calibration levels so that we can provide an estimation as fast as possible
+ */
+static const float min_diffs[CAL_STEPS] = { 0.2, 0.25, 0.4, 0.6, 1.0 };
+static const float max_sqr_errs[CAL_STEPS] = { 10.0, 10.0, 8.0, 5.0, 3.5 };
+static const unsigned int lookback_counts[CAL_STEPS] = { 2, 3, 4, 5, 6 };
+
+MMC35240::MMC35240(int device)
+{
+    float mag_scale;
+    char trigger[64];
+
+    if (!(m_iio = mraa_iio_init(device))) {
+        throw std::invalid_argument(std::string(__FUNCTION__) +
+                                    ": mraa_iio_init() failed, invalid device?");
+        return;
+    }
+    m_scale = 1;
+    m_iio_device_num = device;
+    sprintf(trigger, "hrtimer-mmc35240-hr-dev%d", device);
+
+    if (mraa_iio_create_trigger(m_iio, trigger) != MRAA_SUCCESS)
+        fprintf(stderr, "Create trigger %s failed\n", trigger);
+
+    if (mraa_iio_get_mounting_matrix(m_iio, m_mount_matrix) == MRAA_SUCCESS)
+        m_mount_matrix_exist = true;
+    else
+        m_mount_matrix_exist = false;
+
+    if (mraa_iio_read_float(m_iio, "in_magn_scale", &mag_scale) == MRAA_SUCCESS)
+        m_scale = mag_scale;
+
+    // calibration init data
+    initCalibrate();
+
+    // filter init data
+    memset(&m_filter, 0, sizeof(filter_average_t));
+    m_filter.max_samples = FILTER_MAX_SAMPLE;
+    m_filter.num_fields = FILTER_NUM_FILED;
+}
+
+MMC35240::~MMC35240()
+{
+    if (m_filter.history) {
+        free(m_filter.history);
+        m_filter.history = NULL;
+    }
+    if (m_filter.history_sum) {
+        free(m_filter.history_sum);
+        m_filter.history_sum = NULL;
+    }
+    if(m_iio)
+        mraa_iio_close(m_iio);
+}
+
+#ifdef JAVACALLBACK
+void
+MMC35240::installISR(IsrCallback* cb)
+{
+    installISR(generic_callback_isr, cb);
+}
+#endif
+
+void
+MMC35240::installISR(void (*isr)(char*), void* arg)
+{
+    mraa_iio_trigger_buffer(m_iio, isr, NULL);
+}
+
+int64_t
+MMC35240::getChannelValue(unsigned char* input, mraa_iio_channel* chan)
+{
+    uint64_t u64 = 0;
+    int i;
+    int storagebits = chan->bytes * NUMBER_OF_BITS_IN_BYTE;
+    int realbits = chan->bits_used;
+    int zeroed_bits = storagebits - realbits;
+    uint64_t sign_mask;
+    uint64_t value_mask;
+
+    if (!chan->lendian)
+        for (i = 0; i < storagebits / NUMBER_OF_BITS_IN_BYTE; i++)
+            u64 = (u64 << 8) | input[i];
+    else
+        for (i = storagebits / NUMBER_OF_BITS_IN_BYTE - 1; i >= 0; i--)
+            u64 = (u64 << 8) | input[i];
+
+    u64 = (u64 >> chan->shift) & (~0ULL >> zeroed_bits);
+
+    if (!chan->signedd)
+        return (int64_t) u64; /* We don't handle unsigned 64 bits int */
+
+    /* Signed integer */
+
+    switch (realbits) {
+        case 0 ... 1:
+            return 0;
+
+        case 8:
+            return (int64_t)(int8_t) u64;
+
+        case 16:
+            return (int64_t)(int16_t) u64;
+
+        case 32:
+            return (int64_t)(int32_t) u64;
+
+        case 64:
+            return (int64_t) u64;
+
+        default:
+            sign_mask = 1 << (realbits - 1);
+            value_mask = sign_mask - 1;
+
+            if (u64 & sign_mask)
+                return -((~u64 & value_mask) + 1); /* Negative value: return 2-complement */
+            else
+                return (int64_t) u64; /* Positive value */
+    }
+}
+
+bool
+MMC35240::enableBuffer(int length)
+{
+    mraa_iio_write_int(m_iio, "buffer/length", length);
+    // enable must be last step, else will have error in writing above config
+    mraa_iio_write_int(m_iio, "buffer/enable", 1);
+    return true;
+}
+
+bool
+MMC35240::disableBuffer()
+{
+    mraa_iio_write_int(m_iio, "buffer/enable", 0);
+    return true;
+}
+
+bool
+MMC35240::setScale(float scale)
+{
+    mraa_iio_write_float(m_iio, "in_magn_scale", scale);
+    return true;
+}
+
+bool
+MMC35240::setSamplingFrequency(float sampling_frequency)
+{
+    m_sampling_frequency = sampling_frequency;
+    mraa_iio_write_float(m_iio, "in_magn_sampling_frequency", sampling_frequency);
+    return true;
+}
+
+bool
+MMC35240::enable3AxisChannel()
+{
+    char trigger[64];
+    sprintf(trigger, "mmc35240-hr-dev%d", m_iio_device_num);
+
+    mraa_iio_write_string(m_iio, "trigger/current_trigger", trigger);
+    mraa_iio_write_int(m_iio, "scan_elements/in_magn_x_en", 1);
+    mraa_iio_write_int(m_iio, "scan_elements/in_magn_y_en", 1);
+    mraa_iio_write_int(m_iio, "scan_elements/in_magn_z_en", 1);
+
+    // need update channel data size after enable
+    mraa_iio_update_channels(m_iio);
+    return true;
+}
+
+void
+MMC35240::extract3Axis(char* data, float* x, float* y, float* z)
+{
+    mraa_iio_channel* channels = mraa_iio_get_channels(m_iio);
+    float tmp[3];
+    int64_t iio_x, iio_y, iio_z;
+
+    iio_x = getChannelValue((unsigned char*) (data), &channels[0]);
+    iio_y = getChannelValue((unsigned char*) (data + 4), &channels[1]);
+    iio_z = getChannelValue((unsigned char*) (data + 8), &channels[2]);
+
+    *x = CONVERT_GAUSS_TO_MICROTESLA(iio_x * m_scale);
+    *y = CONVERT_GAUSS_TO_MICROTESLA(iio_y * m_scale);
+    *z = CONVERT_GAUSS_TO_MICROTESLA(iio_z * m_scale);
+
+    if (m_mount_matrix_exist) {
+        tmp[0] = *x * m_mount_matrix[0] + *y * m_mount_matrix[1] + *z * m_mount_matrix[2];
+        tmp[1] = *x * m_mount_matrix[3] + *y * m_mount_matrix[4] + *z * m_mount_matrix[5];
+        tmp[2] = *x * m_mount_matrix[6] + *y * m_mount_matrix[7] + *z * m_mount_matrix[8];
+
+        *x = tmp[0];
+        *y = tmp[1];
+        *z = tmp[2];
+    }
+
+    calibrateCompass(x, y, z, &m_cal_data);
+    denoise_average(x, y, z);
+}
+
+int
+MMC35240::getCalibratedLevel()
+{
+    return m_cal_level;
+}
+
+void
+MMC35240::initCalibrate()
+{
+    m_cal_level = 0;
+    resetSample(&m_cal_data);
+
+    m_cal_data.offset[0][0] = 0;
+    m_cal_data.offset[1][0] = 0;
+    m_cal_data.offset[2][0] = 0;
+    m_cal_data.w_invert[0][0] = 1;
+    m_cal_data.w_invert[1][0] = 0;
+    m_cal_data.w_invert[2][0] = 0;
+    m_cal_data.w_invert[0][1] = 0;
+    m_cal_data.w_invert[1][1] = 1;
+    m_cal_data.w_invert[2][1] = 0;
+    m_cal_data.w_invert[0][2] = 0;
+    m_cal_data.w_invert[1][2] = 0;
+    m_cal_data.w_invert[2][2] = 1;
+    m_cal_data.bfield = 0;
+}
+
+void
+MMC35240::getCalibratedData(double offset[3][1], double w_invert[3][3], double* bfield)
+{
+    offset[0][0] = m_cal_data.offset[0][0];
+    offset[1][0] = m_cal_data.offset[1][0];
+    offset[2][0] = m_cal_data.offset[2][0];
+    w_invert[0][0] = m_cal_data.w_invert[0][0];
+    w_invert[1][0] = m_cal_data.w_invert[1][0];
+    w_invert[2][0] = m_cal_data.w_invert[2][0];
+    w_invert[0][1] = m_cal_data.w_invert[0][1];
+    w_invert[1][1] = m_cal_data.w_invert[1][1];
+    w_invert[2][1] = m_cal_data.w_invert[2][1];
+    w_invert[0][2] = m_cal_data.w_invert[0][2];
+    w_invert[1][2] = m_cal_data.w_invert[1][2];
+    w_invert[2][2] = m_cal_data.w_invert[2][2];
+    *bfield = m_cal_data.bfield;
+}
+
+void
+MMC35240::loadCalibratedData(int cal_level, double offset[3][1], double w_invert[3][3], double bfield)
+{
+    m_cal_level = cal_level;
+    m_cal_data.offset[0][0] = offset[0][0];
+    m_cal_data.offset[1][0] = offset[1][0];
+    m_cal_data.offset[2][0] = offset[2][0];
+    m_cal_data.w_invert[0][0] = w_invert[0][0];
+    m_cal_data.w_invert[1][0] = w_invert[1][0];
+    m_cal_data.w_invert[2][0] = w_invert[2][0];
+    m_cal_data.w_invert[0][1] = w_invert[0][1];
+    m_cal_data.w_invert[1][1] = w_invert[1][1];
+    m_cal_data.w_invert[2][1] = w_invert[2][1];
+    m_cal_data.w_invert[0][2] = w_invert[0][2];
+    m_cal_data.w_invert[1][2] = w_invert[1][2];
+    m_cal_data.w_invert[2][2] = w_invert[2][2];
+    m_cal_data.bfield = bfield;
+}
+
+void
+MMC35240::resetSample(compass_cal_t* data)
+{
+    int i, j;
+    data->sample_count = 0;
+    for (i = 0; i < MAGN_DS_SIZE; i++)
+        for (j = 0; j < 3; j++)
+            data->sample[i][j] = 0;
+
+    data->average[0] = data->average[1] = data->average[2] = 0;
+}
+
+void
+MMC35240::calibrateCompass(float* x, float* y, float* z, compass_cal_t* cal_data)
+{
+    int cal_level;
+
+    /* Calibration is continuous */
+    compassCollect(x, y, z, cal_data);
+
+    cal_level = compassReady(cal_data);
+
+    switch (cal_level) {
+        case 0:
+            scale(x, y, z);
+            break;
+
+        case 1:
+            compassComputeCal(x, y, z, cal_data);
+            break;
+
+        case 2:
+            compassComputeCal(x, y, z, cal_data);
+            break;
+
+        default:
+            compassComputeCal(x, y, z, cal_data);
+            break;
+    }
+}
+
+int
+MMC35240::compassCollect(float* x, float* y, float* z, compass_cal_t* cal_data)
+{
+    float data[3] = { *x, *y, *z };
+    unsigned int index, j;
+    unsigned int lookback_count;
+    float min_diff;
+
+    /* Discard the point if not valid */
+    if (data[0] == 0 || data[1] == 0 || data[2] == 0)
+        return -1;
+
+    lookback_count = lookback_counts[m_cal_level];
+    min_diff = min_diffs[m_cal_level];
+
+    /* For the current point to be accepted, each x/y/z value must be different enough to the last
+     * several collected points */
+    if (cal_data->sample_count > 0 && cal_data->sample_count < MAGN_DS_SIZE) {
+        unsigned int lookback =
+        lookback_count < cal_data->sample_count ? lookback_count : cal_data->sample_count;
+        for (index = 0; index < lookback; index++)
+            for (j = 0; j < 3; j++)
+                if (fabsf(data[j] - cal_data->sample[cal_data->sample_count - 1 - index][j]) <
+                    min_diff) {
+#ifdef DEBUG
+                    printf("CompassCalibration:point reject: [%f,%f,%f], selected_count=%d\n",
+                           data[0],
+                           data[1],
+                           data[2],
+                           cal_data->sample_count);
+#endif
+                    return 0;
+                }
+    }
+
+    if (cal_data->sample_count < MAGN_DS_SIZE) {
+        memcpy(cal_data->sample[cal_data->sample_count], data, sizeof(float) * 3);
+        cal_data->sample_count++;
+        cal_data->average[0] += data[0];
+        cal_data->average[1] += data[1];
+        cal_data->average[2] += data[2];
+#ifdef DEBUG
+        printf("CompassCalibration:point collected [%f,%f,%f], selected_count=%d\n",
+               (double) data[0],
+               (double) data[1],
+               (double) data[2],
+               cal_data->sample_count);
+#endif
+    }
+    return 1;
+}
+
+
+int
+MMC35240::compassReady(compass_cal_t* cal_data)
+{
+    mat_input_t mat;
+    int i;
+    float max_sqr_err;
+
+    compass_cal_t new_cal_data;
+
+    /*
+     * Some sensors take unrealistically long to calibrate at higher levels. We'll use a
+     * max_cal_level if we have such a property setup,
+     * or go with the default settings if not.
+     */
+    int cal_steps = CAL_STEPS;
+
+    if (cal_data->sample_count < MAGN_DS_SIZE)
+        return m_cal_level;
+
+    max_sqr_err = max_sqr_errs[m_cal_level];
+
+    /* Enough points have been collected, do the ellipsoid calibration */
+
+    /* Compute average per axis */
+    cal_data->average[0] /= MAGN_DS_SIZE;
+    cal_data->average[1] /= MAGN_DS_SIZE;
+    cal_data->average[2] /= MAGN_DS_SIZE;
+
+    for (i = 0; i < MAGN_DS_SIZE; i++) {
+        mat[i][0] = cal_data->sample[i][0];
+        mat[i][1] = cal_data->sample[i][1];
+        mat[i][2] = cal_data->sample[i][2];
+    }
+
+    /* Check if result is good. The sample data must remain the same */
+    new_cal_data = *cal_data;
+
+    if (ellipsoidFit(mat, new_cal_data.offset, new_cal_data.w_invert, &new_cal_data.bfield)) {
+        double new_err = calcSquareErr(&new_cal_data);
+#ifdef DEBUG
+        printf("new err is %f, max sqr err id %f\n", new_err, max_sqr_err);
+#endif
+        if (new_err < max_sqr_err) {
+            double err = calcSquareErr(cal_data);
+            if (new_err < err) {
+                /* New cal data is better, so we switch to the new */
+                memcpy(cal_data->offset, new_cal_data.offset, sizeof(cal_data->offset));
+                memcpy(cal_data->w_invert, new_cal_data.w_invert, sizeof(cal_data->w_invert));
+                cal_data->bfield = new_cal_data.bfield;
+                if (m_cal_level < (cal_steps - 1))
+                    m_cal_level++;
+#ifdef DEBUG
+                printf("CompassCalibration: ready check success, caldata: %f %f %f %f %f %f %f %f "
+                       "%f %f %f %f %f, err %f\n",
+                       cal_data->offset[0][0],
+                       cal_data->offset[1][0],
+                       cal_data->offset[2][0],
+                       cal_data->w_invert[0][0],
+                       cal_data->w_invert[0][1],
+                       cal_data->w_invert[0][2],
+                       cal_data->w_invert[1][0],
+                       cal_data->w_invert[1][1],
+                       cal_data->w_invert[1][2],
+                       cal_data->w_invert[2][0],
+                       cal_data->w_invert[2][1],
+                       cal_data->w_invert[2][2],
+                       cal_data->bfield,
+                       new_err);
+#endif
+            }
+        }
+    }
+    resetSample(cal_data);
+    return m_cal_level;
+}
+
+double
+MMC35240::calcSquareErr(compass_cal_t* data)
+{
+    double err = 0;
+    double raw[3][1], result[3][1], mat_diff[3][1];
+    int i;
+    float stdev[3] = { 0, 0, 0 };
+    double diff;
+
+    for (i = 0; i < MAGN_DS_SIZE; i++) {
+        raw[0][0] = data->sample[i][0];
+        raw[1][0] = data->sample[i][1];
+        raw[2][0] = data->sample[i][2];
+
+        stdev[0] += (raw[0][0] - data->average[0]) * (raw[0][0] - data->average[0]);
+        stdev[1] += (raw[1][0] - data->average[1]) * (raw[1][0] - data->average[1]);
+        stdev[2] += (raw[2][0] - data->average[2]) * (raw[2][0] - data->average[2]);
+
+        substract(3, 1, raw, data->offset, mat_diff);
+        multiply(3, 3, 1, data->w_invert, mat_diff, result);
+
+        diff = sqrt(result[0][0] * result[0][0] + result[1][0] * result[1][0] +
+                    result[2][0] * result[2][0]) -
+               data->bfield;
+
+        err += diff * diff;
+    }
+
+    stdev[0] = sqrt(stdev[0] / MAGN_DS_SIZE);
+    stdev[1] = sqrt(stdev[1] / MAGN_DS_SIZE);
+    stdev[2] = sqrt(stdev[2] / MAGN_DS_SIZE);
+
+    /* A sanity check - if we have too little variation for an axis it's best to reject the
+     * calibration than risking a wrong calibration */
+    if (stdev[0] <= 1 || stdev[1] <= 1 || stdev[2] <= 1)
+        return max_sqr_errs[0];
+
+    err /= MAGN_DS_SIZE;
+    return err;
+}
+
+int
+MMC35240::ellipsoidFit(mat_input_t m, double offset[3][1], double w_invert[3][3], double* bfield)
+{
+    int i;
+    double h[MAGN_DS_SIZE][9];
+    double w[MAGN_DS_SIZE][1];
+    double h_trans[9][MAGN_DS_SIZE];
+    double p_temp1[9][9];
+    double p_temp2[9][MAGN_DS_SIZE];
+    double temp1[3][3], temp[3][3];
+    double temp1_inv[3][3];
+    double temp2[3][1];
+    double result[9][9];
+    double p[9][1];
+    double a[3][3], sqrt_evals[3][3], evecs[3][3], evecs_trans[3][3];
+    double evec1[3][1], evec2[3][1], evec3[3][1];
+
+    for (i = 0; i < MAGN_DS_SIZE; i++) {
+        w[i][0] = m[i][0] * m[i][0];
+        h[i][0] = m[i][0];
+        h[i][1] = m[i][1];
+        h[i][2] = m[i][2];
+        h[i][3] = -1 * m[i][0] * m[i][1];
+        h[i][4] = -1 * m[i][0] * m[i][2];
+        h[i][5] = -1 * m[i][1] * m[i][2];
+        h[i][6] = -1 * m[i][1] * m[i][1];
+        h[i][7] = -1 * m[i][2] * m[i][2];
+        h[i][8] = 1;
+    }
+
+    transpose(MAGN_DS_SIZE, 9, h, h_trans);
+    multiply(9, MAGN_DS_SIZE, 9, h_trans, h, result);
+    invert(9, result, p_temp1);
+    multiply(9, 9, MAGN_DS_SIZE, p_temp1, h_trans, p_temp2);
+    multiply(9, MAGN_DS_SIZE, 1, p_temp2, w, p);
+
+    temp1[0][0] = 2;
+    temp1[0][1] = p[3][0];
+    temp1[0][2] = p[4][0];
+    temp1[1][0] = p[3][0];
+    temp1[1][1] = 2 * p[6][0];
+    temp1[1][2] = p[5][0];
+    temp1[2][0] = p[4][0];
+    temp1[2][1] = p[5][0];
+    temp1[2][2] = 2 * p[7][0];
+
+    temp2[0][0] = p[0][0];
+    temp2[1][0] = p[1][0];
+    temp2[2][0] = p[2][0];
+
+    invert(3, temp1, temp1_inv);
+    multiply(3, 3, 1, temp1_inv, temp2, offset);
+    double off_x = offset[0][0];
+    double off_y = offset[1][0];
+    double off_z = offset[2][0];
+
+    a[0][0] = 1.0 / (p[8][0] + off_x * off_x + p[6][0] * off_y * off_y + p[7][0] * off_z * off_z +
+                     p[3][0] * off_x * off_y + p[4][0] * off_x * off_z + p[5][0] * off_y * off_z);
+
+    a[0][1] = p[3][0] * a[0][0] / 2;
+    a[0][2] = p[4][0] * a[0][0] / 2;
+    a[1][2] = p[5][0] * a[0][0] / 2;
+    a[1][1] = p[6][0] * a[0][0];
+    a[2][2] = p[7][0] * a[0][0];
+    a[2][1] = a[1][2];
+    a[1][0] = a[0][1];
+    a[2][0] = a[0][2];
+
+    double eig1 = 0, eig2 = 0, eig3 = 0;
+    computeEigenvalues(a, &eig1, &eig2, &eig3);
+
+    if (eig1 <= 0 || eig2 <= 0 || eig3 <= 0)
+        return 0;
+
+    sqrt_evals[0][0] = sqrt(eig1);
+    sqrt_evals[1][0] = 0;
+    sqrt_evals[2][0] = 0;
+    sqrt_evals[0][1] = 0;
+    sqrt_evals[1][1] = sqrt(eig2);
+    sqrt_evals[2][1] = 0;
+    sqrt_evals[0][2] = 0;
+    sqrt_evals[1][2] = 0;
+    sqrt_evals[2][2] = sqrt(eig3);
+
+    calcEvector(a, eig1, evec1);
+    calcEvector(a, eig2, evec2);
+    calcEvector(a, eig3, evec3);
+
+    evecs[0][0] = evec1[0][0];
+    evecs[1][0] = evec1[1][0];
+    evecs[2][0] = evec1[2][0];
+    evecs[0][1] = evec2[0][0];
+    evecs[1][1] = evec2[1][0];
+    evecs[2][1] = evec2[2][0];
+    evecs[0][2] = evec3[0][0];
+    evecs[1][2] = evec3[1][0];
+    evecs[2][2] = evec3[2][0];
+
+    multiply(3, 3, 3, evecs, sqrt_evals, temp1);
+    transpose(3, 3, evecs, evecs_trans);
+    multiply(3, 3, 3, temp1, evecs_trans, temp);
+    transpose(3, 3, temp, w_invert);
+
+    *bfield = pow(sqrt(1 / eig1) * sqrt(1 / eig2) * sqrt(1 / eig3), 1.0 / 3.0);
+
+    if (*bfield < 0)
+        return 0;
+
+    multiply_scalar_inplace(3, 3, w_invert, *bfield);
+
+    return 1;
+}
+
+/* Given an real symmetric 3x3 matrix A, compute the eigenvalues */
+void
+MMC35240::computeEigenvalues(double mat[3][3], double* eig1, double* eig2, double* eig3)
+{
+    double p = mat[0][1] * mat[0][1] + mat[0][2] * mat[0][2] + mat[1][2] * mat[1][2];
+
+    if (p < EPSILON) {
+        *eig1 = mat[0][0];
+        *eig2 = mat[1][1];
+        *eig3 = mat[2][2];
+        return;
+    }
+
+    double q = (mat[0][0] + mat[1][1] + mat[2][2]) / 3;
+    double temp1 = mat[0][0] - q;
+    double temp2 = mat[1][1] - q;
+    double temp3 = mat[2][2] - q;
+
+    p = temp1 * temp1 + temp2 * temp2 + temp3 * temp3 + 2 * p;
+    p = sqrt(p / 6);
+
+    double mat2[3][3];
+    assign(3, 3, mat, mat2);
+    mat2[0][0] -= q;
+    mat2[1][1] -= q;
+    mat2[2][2] -= q;
+    multiply_scalar_inplace(3, 3, mat2, 1 / p);
+
+    double r = (mat2[0][0] * mat2[1][1] * mat2[2][2] + mat2[0][1] * mat2[1][2] * mat2[2][0] +
+                mat2[0][2] * mat2[1][0] * mat2[2][1] - mat2[0][2] * mat2[1][1] * mat2[2][0] -
+                mat2[0][0] * mat2[1][2] * mat2[2][1] - mat2[0][1] * mat2[1][0] * mat2[2][2]) /
+               2;
+
+    double phi;
+    if (r <= -1.0)
+        phi = M_PI / 3;
+    else if (r >= 1.0)
+        phi = 0;
+    else
+        phi = acos(r) / 3;
+
+    *eig3 = q + 2 * p* cos(phi);
+    *eig1 = q + 2 * p* cos(phi + 2 * M_PI / 3);
+    *eig2 = 3 * q - *eig1 - *eig3;
+}
+
+void
+MMC35240::calcEvector(double mat[3][3], double eig, double vec[3][1])
+{
+    double h[3][3];
+    double x_tmp[2][2];
+    assign(3, 3, mat, h);
+    h[0][0] -= eig;
+    h[1][1] -= eig;
+    h[2][2] -= eig;
+
+    double x[2][2];
+    x[0][0] = h[1][1];
+    x[0][1] = h[1][2];
+    x[1][0] = h[2][1];
+    x[1][1] = h[2][2];
+    invert(2, x, x_tmp);
+    assign(2, 2, x_tmp, x);
+
+    double temp1 = x[0][0] * (-h[1][0]) + x[0][1] * (-h[2][0]);
+    double temp2 = x[1][0] * (-h[1][0]) + x[1][1] * (-h[2][0]);
+    double norm = sqrt(1 + temp1 * temp1 + temp2 * temp2);
+
+    vec[0][0] = 1.0 / norm;
+    vec[1][0] = temp1 / norm;
+    vec[2][0] = temp2 / norm;
+}
+
+void
+MMC35240::scale(float* x, float* y, float* z)
+{
+    float sqr_norm = 0;
+    float sanity_norm = 0;
+    float scale = 1;
+
+    sqr_norm = (*x * *x + *y * *y + *z * *z);
+
+    if (sqr_norm < MAGNETIC_LOW)
+        sanity_norm = MAGNETIC_LOW;
+
+    if (sanity_norm && sqr_norm) {
+        scale = sanity_norm / sqr_norm;
+        scale = sqrt(scale);
+        *x = *x* scale;
+        *y = *y* scale;
+        *z = *z* scale;
+    }
+}
+
+void
+MMC35240::compassComputeCal(float* x, float* y, float* z, compass_cal_t* cal_data)
+{
+    double result[3][1], raw[3][1], diff[3][1];
+
+    if (!m_cal_level)
+        return;
+
+    raw[0][0] = *x;
+    raw[1][0] = *y;
+    raw[2][0] = *z;
+
+    substract(3, 1, raw, cal_data->offset, diff);
+    multiply(3, 3, 1, cal_data->w_invert, diff, result);
+
+    *x = result[0][0];
+    *y = result[1][0];
+    *z = result[2][0];
+
+    scale(x, y, z);
+}
+
+
+void
+MMC35240::transpose(int rows, int cols, void* m, void* m_trans)
+{
+    int i, j;
+    double(*_m)[cols] = (double(*) [cols]) m;
+    double(*_m_trans)[rows] = (double(*) [rows]) m_trans;
+
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < cols; j++)
+            _m_trans[j][i] = _m[i][j];
+}
+
+void
+MMC35240::multiply(int m, int n, int p, void* m1, void* m2, void* result)
+{
+    int i, j, k;
+    double(*_m1)[n] = (double(*) [n]) m1;
+    double(*_m2)[p] = (double(*) [p]) m2;
+    double(*_result)[p] = (double(*) [p]) result;
+    for (i = 0; i < m; i++)
+        for (k = 0; k < p; k++) {
+            _result[i][k] = 0;
+            for (j = 0; j < n; j++)
+                _result[i][k] += _m1[i][j] * _m2[j][k];
+        }
+}
+
+void
+MMC35240::invert(int s, void* m, void* m_inv)
+{
+    double t;
+    int swap, i, j, k;
+    double tmp[s][s];
+    double(*_m_inv)[s] = (double(*) [s]) m_inv;
+
+    for (i = 0; i < s; i++)
+        for (j = 0; j < s; j++)
+            _m_inv[i][j] = 0;
+
+    for (i = 0; i < s; i++)
+        _m_inv[i][i] = 1;
+
+    assign(s, s, m, tmp);
+
+    for (i = 0; i < s; i++) {
+        swap = i;
+        for (j = i + 1; j < s; j++) {
+            if (fabs(tmp[i][j]) > fabs(tmp[i][i]))
+                swap = j;
+        }
+
+        if (swap != i) {
+            /* swap rows */
+            for (k = 0; k < s; k++) {
+                t = tmp[k][i];
+                tmp[k][i] = tmp[k][swap];
+                tmp[k][swap] = t;
+
+                t = _m_inv[k][i];
+                _m_inv[k][i] = _m_inv[k][swap];
+                _m_inv[k][swap] = t;
+            }
+        }
+
+        t = 1 / tmp[i][i];
+
+        for (k = 0; k < s; k++) {
+            tmp[k][i] *= t;
+            _m_inv[k][i] *= t;
+        }
+
+        for (j = 0; j < s; j++)
+            if (j != i) {
+                t = tmp[i][j];
+                for (k = 0; k < s; k++) {
+                    tmp[k][j] -= tmp[k][i] * t;
+                    _m_inv[k][j] -= _m_inv[k][i] * t;
+                }
+            }
+    }
+}
+
+void
+MMC35240::multiply_scalar_inplace(int rows, int cols, void* m, double scalar)
+{
+    int i, j;
+    double(*_m)[cols] = (double(*) [cols]) m;
+
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < cols; j++)
+            _m[i][j] = _m[i][j] * scalar;
+}
+
+void
+MMC35240::assign(int rows, int cols, void* m, void* m1)
+{
+    int i, j;
+    double(*_m)[cols] = (double(*) [cols]) m;
+    double(*_m1)[cols] = (double(*) [cols]) m1;
+
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < cols; j++)
+            _m1[i][j] = _m[i][j];
+}
+
+void
+MMC35240::substract(int rows, int cols, void* m1, void* m2, void* res)
+{
+    int i, j;
+    double(*_res)[cols] = (double(*) [cols]) res;
+    double(*_m1)[cols] = (double(*) [cols]) m1;
+    double(*_m2)[cols] = (double(*) [cols]) m2;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < cols; j++)
+            _res[i][j] = _m1[i][j] - _m2[i][j];
+}
+
+void
+MMC35240::denoise_average(float* x, float* y, float* z)
+{
+    /*
+     * Smooth out incoming data using a moving average over a number of
+     * samples. We accumulate one second worth of samples, or max_samples,
+     * depending on which is lower.
+     */
+    float* data[3];
+    int f;
+    int history_size;
+    int history_full = 0;
+    filter_average_t* filter;
+
+    data[0] = x;
+    data[1] = y;
+    data[2] = z;
+
+    /* Don't denoise anything if we have less than two samples per second */
+    if (m_sampling_frequency < 2)
+        return;
+
+    filter = (filter_average_t*) &m_filter;
+
+    if (!filter)
+        return;
+
+    /* Restrict window size to the min of sampling_rate and max_samples */
+    if (m_sampling_frequency > filter->max_samples)
+        history_size = filter->max_samples;
+    else
+        history_size = m_sampling_frequency;
+
+    /* Reset history if we're operating on an incorrect window size */
+    if (filter->history_size != history_size) {
+        filter->history_size = history_size;
+        filter->history_entries = 0;
+        filter->history_index = 0;
+        filter->history =
+        (float*) realloc(filter->history, filter->history_size * filter->num_fields * sizeof(float));
+        if (filter->history) {
+            filter->history_sum =
+            (float*) realloc(filter->history_sum, filter->num_fields * sizeof(float));
+            if (filter->history_sum)
+                memset(filter->history_sum, 0, filter->num_fields * sizeof(float));
+        }
+    }
+
+    if (!filter->history || !filter->history_sum)
+        return; /* Unlikely, but still... */
+
+    /* Update initialized samples count */
+    if (filter->history_entries < filter->history_size)
+        filter->history_entries++;
+    else
+        history_full = 1;
+
+    /* Record new sample and calculate the moving sum */
+    for (f = 0; f < filter->num_fields; f++) {
+        /** A field is going to be overwritten if history is full, so decrease the history sum */
+        if (history_full)
+            filter->history_sum[f] -=
+            filter->history[filter->history_index * filter->num_fields + f];
+
+        filter->history[filter->history_index * filter->num_fields + f] = *data[f];
+        filter->history_sum[f] += *data[f];
+
+        /* For now simply compute a mobile mean for each field and output filtered data */
+        *data[f] = filter->history_sum[f] / filter->history_entries;
+    }
+
+    /* Update our rolling index (next evicted cell) */
+    filter->history_index = (filter->history_index + 1) % filter->history_size;
+}

--- a/src/mmc35240/mmc35240.h
+++ b/src/mmc35240/mmc35240.h
@@ -1,0 +1,209 @@
+/*
+ * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Thanks to https://github.com/01org/android-iio-sensors-hal for magnetometer
+ * calibration and denoise algorithm.
+ */
+#pragma once
+
+#include <string>
+#include <mraa/iio.h>
+
+#define MAGN_DS_SIZE 32
+
+namespace upm
+{
+/**
+ * @brief MMC35240 Tri-axis Magnetic Sensor
+ * @defgroup mmc35240 libupm-mmc35240
+ * @ingroup STMicroelectronics iio i2c tri-axis magnetic sensor
+ */
+
+/**
+ * @library mmc35240
+ * @sensor mmc35240
+ * @comname MMC35240 Tri-axis Magnetic Sensor
+ * @type compass
+ * @man Memsic
+ * @con iio i2c
+ *
+ * @brief MMC35240 Tri-axis Magnetic Sensor API
+ *
+ * The MMC3524xPJ is a complete 3-axis magnetic sensor
+ *
+ * @snippet mmc35240.cxx Interesting
+ */
+
+class MMC35240
+{
+  public:
+    typedef struct {
+        /* hard iron offsets */
+        double offset[3][1];
+
+        /* soft iron matrix */
+        double w_invert[3][3];
+
+        /* geomagnetic strength */
+        double bfield;
+
+        /* selection data */
+        float sample[MAGN_DS_SIZE][3];
+        unsigned int sample_count;
+        float average[3];
+    } compass_cal_t;
+
+    typedef double mat_input_t[MAGN_DS_SIZE][3];
+
+    typedef struct {
+        int max_samples;     /* Maximum averaging window size */
+        int num_fields;      /* Number of fields per sample (usually 3) */
+        float* history;      /* Working buffer containing recorded samples */
+        float* history_sum;  /* The current sum of the history elements */
+        int history_size;    /* Number of recorded samples */
+        int history_entries; /* How many of these are initialized */
+        int history_index;   /* Index of sample to evict next time */
+    } filter_average_t;
+
+    /**
+     * MMC35240 Tri-axis Magnetic Sensor
+     *
+     * @param iio device number
+     */
+    MMC35240(int device);
+
+    /**
+     * MMC35240 destructor
+     */
+    ~MMC35240();
+
+    /**
+     * Installs an interrupt service routine (ISR) to be called when
+     * an interrupt occurs
+     *
+     * @param interrupt channel
+     * @param fptr Pointer to a function to be called on interrupt
+     * @param arg Pointer to an object to be supplied as an
+     * argument to the ISR.
+     */
+    void installISR(void (*isr)(char*), void* arg);
+
+    /**
+     * Extract the channel value based on channel type
+     * @param input Channel data
+     * @param chan MRAA iio-layer channel info
+     */
+    int64_t getChannelValue(unsigned char* input, mraa_iio_channel* chan);
+
+    /**
+     * Enable trigger buffer
+     * @param trigger buffer length in string
+     */
+    bool enableBuffer(int length);
+
+    /**
+     * Disable trigger buffer
+     */
+    bool disableBuffer();
+
+    /**
+     * Set scale
+     * @param scale in string
+     */
+    bool setScale(const float scale);
+
+    /**
+     * Set sampling frequency
+     * @param sampling frequency  in string
+     */
+    bool setSamplingFrequency(const float sampling_frequency);
+
+    /**
+     * Enable 3 axis scan element
+     */
+    bool enable3AxisChannel();
+
+    /**
+     * Process enabled channel buffer and return x, y, z axis
+     * @param data Enabled channel data, 6 bytes, each axis 2 bytes
+     * @param x X-Axis
+     * @param y Y-Axis
+     * @param z Z-Axis
+     */
+    void extract3Axis(char* data, float* x, float* y, float* z);
+
+    /**
+     * Get calibrated level
+     */
+    int getCalibratedLevel();
+
+    /**
+     * Reset calibration data and start collect calibration data again
+     */
+    void initCalibrate();
+
+    /**
+     * Get calibrated data
+     */
+    void getCalibratedData(double offset[3][1], double w_invert[3][3], double* bfield);
+
+    /**
+     * Load calibrated data
+     */
+    void
+    loadCalibratedData(int cal_level, double offset[3][1], double w_invert[3][3], double bfield);
+
+  private:
+    /* Adopt https://github.com/01org/android-iio-sensors-hal/blob/master/matrix-ops.h */
+    void transpose(int rows, int cols, void* m, void* m_trans);
+    void multiply(int m, int n, int p, void* m1, void* m2, void* result);
+    void invert(int s, void* m, void* m_inv);
+    void multiply_scalar_inplace(int rows, int cols, void* m, double scalar);
+    void assign(int rows, int cols, void* m, void* m1);
+    void substract(int rows, int cols, void* m1, void* m2, void* res);
+
+    /* Adopt https://github.com/01org/android-iio-sensors-hal/blob/master/compass-calibration.c */
+    void resetSample(compass_cal_t* data);
+    void calibrateCompass(float* x, float* y, float* z, compass_cal_t* cal_data);
+    int compassCollect(float* x, float* y, float* z, compass_cal_t* cal_data);
+    int compassReady(compass_cal_t* cal_data);
+    double calcSquareErr(compass_cal_t* data);
+    int ellipsoidFit(mat_input_t m, double offset[3][1], double w_invert[3][3], double* bfield);
+    void computeEigenvalues(double mat[3][3], double* eig1, double* eig2, double* eig3);
+    void calcEvector(double mat[3][3], double eig, double vec[3][1]);
+    void scale(float* x, float* y, float* z);
+    void compassComputeCal(float* x, float* y, float* z, compass_cal_t* cal_data);
+
+    /* Adopt https://github.com/01org/android-iio-sensors-hal/blob/master/filtering.c */
+    void denoise_average(float* x, float* y, float* z);
+
+    mraa_iio_context m_iio;
+    int m_iio_device_num;
+    float m_sampling_frequency; // sampling frequency
+    bool m_mount_matrix_exist;  // is mount matrix exist
+    float m_mount_matrix[9];    // mount matrix
+    float m_scale;              // data scale
+    compass_cal_t m_cal_data;   // calibrate data
+    int m_cal_level;            // calibrated level
+    filter_average_t m_filter;  // filter data
+};
+}

--- a/src/mmc35240/pyupm_mmc35240.i
+++ b/src/mmc35240/pyupm_mmc35240.i
@@ -1,0 +1,9 @@
+%module pyupm_mmc35240
+%include "../upm.i"
+
+%feature("autodoc", "3");
+
+%include "mmc35240.h"
+%{
+    #include "mmc35240.h"
+%}


### PR DESCRIPTION
```
MMC35240: Enable MMC35240 3-axis magnetic sensor library and example

MMC35240 is 3-axis magnetic sensor from MEMSIC.
This sensor can measure magnetic fields within the full scale range of
+-24 Gauss (G).

The library provided is libupm-mmc35240.so.0.4.0.
The example provided is mmc35240-example where it will print x,y,z axis when
trigger buffer data is ready. It's also print azimuth value.

This sensor requires calibration. Please shake the sensor in figure 8 pattern,
mmc35240-example will print the calibrated level.

As the sensor data is noisy, we have implemented denoise algorithm within the
sensor library.
```
