### PR TITLE
eboled: change write_word to writeWord for MRAA 1.0 API change.

### DIFF
--- a/src/lcd/eboled.cxx
+++ b/src/lcd/eboled.cxx
@@ -556,7 +556,7 @@ mraa::Result EBOLED::command(uint8_t cmd)
 
 mraa::Result EBOLED::data(uint16_t data)
 {
-  m_spi.write_word(data);
+  m_spi.writeWord(data);
   return mraa::SUCCESS;
 }
 


### PR DESCRIPTION
Should be applied when MRAA is tagged 1.0.

Signed-off-by: Jon Trulson <jtrulson@ics.com>