### PR TITLE
bmp280: Initial implementation

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -265,6 +265,7 @@ if (BACNET_FOUND)
   add_example (e50hx)
 endif()
 add_example (vcap)
+add_example (bmp280)
 
 # These are special cases where you specify example binary, source file and module(s)
 include_directories (${PROJECT_SOURCE_DIR}/src)

--- a/examples/c++/bmp280.cxx
+++ b/examples/c++/bmp280.cxx
@@ -1,0 +1,77 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <signal.h>
+
+#include "bmp280.hpp"
+
+using namespace std;
+using namespace upm;
+
+int shouldRun = true;
+
+void sig_handler(int signo)
+{
+  if (signo == SIGINT)
+    shouldRun = false;
+}
+
+
+int main(int argc, char **argv)
+{
+  signal(SIGINT, sig_handler);
+//! [Interesting]
+
+  // Instantiate a BMP280 instance using default i2c bus and address
+  upm::BMP280 *sensor = new upm::BMP280();
+
+  // For SPI, bus 0, you would pass -1 as the address, and a valid pin for CS:
+  // BMP280(0, -1, 10);
+
+  while (shouldRun)
+    {
+      // update our values from the sensor
+      sensor->update();
+
+      // we show both C and F for temperature
+      cout << "Compensation Temperature: " << sensor->getTemperature()
+           << " C / " << sensor->getTemperature(true) << " F"
+           << endl;
+      cout << "Pressure: " << sensor->getPressure() << " Pa" << endl;
+      cout << "Computed Altitude: " << sensor->getAltitude() << " m" << endl;
+
+      cout << endl;
+
+      sleep(1);
+    }
+//! [Interesting]
+
+  cout << "Exiting..." << endl;
+
+  delete sensor;
+
+  return 0;
+}

--- a/examples/java/BMP280_Example.java
+++ b/examples/java/BMP280_Example.java
@@ -1,0 +1,65 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import upm_bmp280.BMP280;
+
+public class BMP280_Example
+{
+    public static void main(String[] args) throws InterruptedException
+    {
+// ! [Interesting]
+
+        // Instantiate a BMP280 instance using default i2c bus and address
+        BMP280 sensor = new BMP280();
+
+        // For SPI, bus 0, you would pass -1 as the address, and a
+        // valid pin for CS:
+        // BMP280(0, -1, 10);
+
+        while (true)
+            {
+                // update our values from the sensor
+                sensor.update();
+
+                System.out.println("Compensation Temperature: "
+                                   + sensor.getTemperature()
+                                   + " C / "
+                                   + sensor.getTemperature(true)
+                                   + " F");
+
+                System.out.println("Pressure: "
+                                   + sensor.getPressure()
+                                   + " Pa");
+
+                System.out.println("Computed Altitude: "
+                                   + sensor.getAltitude()
+                                   + " m");
+
+                System.out.println();
+                Thread.sleep(1000);
+            }
+
+// ! [Interesting]
+    }
+}

--- a/examples/java/CMakeLists.txt
+++ b/examples/java/CMakeLists.txt
@@ -126,6 +126,7 @@ if (BACNET_FOUND)
   add_example(E50HX_Example e50hx)
 endif()
 add_example(VCAP_Example vcap)
+add_example(BMP280_Example bmp280)
 
 add_example_with_path(Jhd1313m1_lcdSample lcd i2clcd)
 add_example_with_path(Jhd1313m1Sample lcd i2clcd)

--- a/examples/javascript/bmp280.js
+++ b/examples/javascript/bmp280.js
@@ -1,0 +1,67 @@
+/*jslint node:true, vars:true, bitwise:true, unparam:true */
+/*jshint unused:true */
+
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+var sensorObj = require('jsupm_bmp280');
+
+// Instantiate a BMP280 instance using default i2c bus and address
+var sensor = new sensorObj.BMP280();
+
+// For SPI, bus 0, you would pass -1 as the address, and a valid pin for CS:
+// BMP280(0, -1, 10);
+
+setInterval(function()
+{
+    // update our values from the sensor
+    sensor.update();
+
+    console.log("Compensation Temperature: "
+                + sensor.getTemperature()
+                + " C / "
+                + sensor.getTemperature(true)
+                + " F");
+
+    console.log("Pressure: "
+                + sensor.getPressure()
+                + " Pa");
+
+    console.log("Computed Altitude: "
+                + sensor.getAltitude()
+                + " m");
+
+    console.log();
+
+}, 1000);
+
+// exit on ^C
+process.on('SIGINT', function()
+{
+    sensor = null;
+    sensorObj.cleanUp();
+    sensorObj = null;
+    console.log("Exiting.");
+    process.exit(0);
+});

--- a/examples/python/bmp280.py
+++ b/examples/python/bmp280.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# Author: Jon Trulson <jtrulson@ics.com>
+# Copyright (c) 2016 Intel Corporation.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import time, sys, signal, atexit
+import pyupm_bmp280 as sensorObj
+
+# Instantiate a BMP280 instance using default i2c bus and address
+sensor = sensorObj.BMP280()
+
+# For SPI, bus 0, you would pass -1 as the address, and a valid pin for CS:
+# BMP280(0, -1, 10);
+
+## Exit handlers ##
+# This function stops python from printing a stacktrace when you hit control-C
+def SIGINTHandler(signum, frame):
+	raise SystemExit
+
+# This function lets you run code on exit
+def exitHandler():
+	print "Exiting"
+	sys.exit(0)
+
+# Register exit handlers
+atexit.register(exitHandler)
+signal.signal(signal.SIGINT, SIGINTHandler)
+
+while (1):
+        sensor.update()
+
+        print "Compensation Temperature:", sensor.getTemperature(), "C /",
+        print sensor.getTemperature(True), "F"
+
+        print "Pressure: ", sensor.getPressure(), "Pa"
+
+        print "Computed Altitude:", sensor.getAltitude(), "m"
+
+        print
+	time.sleep(1)

--- a/src/bmp280/CMakeLists.txt
+++ b/src/bmp280/CMakeLists.txt
@@ -1,0 +1,5 @@
+set (libname "bmp280")
+set (libdescription "Bosch bmp280 Pressure sensor")
+set (module_src ${libname}.cxx)
+set (module_h ${libname}.hpp)
+upm_module_init()

--- a/src/bmp280/bmp280.cxx
+++ b/src/bmp280/bmp280.cxx
@@ -1,0 +1,563 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <math.h>
+#include <string.h>
+
+#include "bmp280.hpp"
+
+using namespace upm;
+using namespace std;
+
+// Uncomment the following to use test data as specified in the
+// datasheet, section 3.12.  This really only tests the compensation
+// algorithm.
+
+// #define BMP280_USE_TEST_DATA
+
+// conversion from fahrenheit to celcius and back
+
+static float f2c(float f)
+{
+  return ((f - 32.0) / (9.0 / 5.0));
+}
+
+static float c2f(float c)
+{
+  return (c * (9.0 / 5.0) + 32.0);
+}
+
+BMP280::BMP280(int bus, int addr, int cs) :
+  m_i2c(0), m_spi(0), m_gpioCS(0)
+{
+
+  m_addr = addr;
+
+  m_temperature = 0;
+  m_pressure = 0;
+  m_isSPI = false;
+
+  clearData();
+
+  if (cs >= 0)
+    m_isSPI = true;
+
+  mraa::Result rv;
+
+  if (m_isSPI)
+    {
+      m_spi = new mraa::Spi(bus);
+      m_gpioCS = new mraa::Gpio(cs);
+
+      m_gpioCS->dir(mraa::DIR_OUT);
+
+      m_spi->mode(mraa::SPI_MODE0);
+      m_spi->frequency(5000000);
+
+      // toggle it on/off so chip switches into SPI mode
+      csOn();
+      usleep(10000);
+      csOff();
+    }
+  else
+    {
+      // I2C
+      m_i2c = new mraa::I2c(bus);
+
+      if ((rv = m_i2c->address(m_addr)) != mraa::SUCCESS)
+        {
+          throw std::runtime_error(string(__FUNCTION__) +
+                                   ": I2c.address() failed");
+        }
+    }
+
+  // check the chip id
+
+  uint8_t chipID = readReg(REG_CHIPID);
+  if (chipID != BMP280_CHIPID)
+    {
+      throw std::runtime_error(string(__FUNCTION__)
+                               + ": invalid chip ID.  Expected "
+                               + std::to_string(int(BMP280_CHIPID))
+                               + ", got "
+                               + std::to_string(int(chipID)));
+    }
+
+  // set sleep mode for now
+  setMeasureMode(MODE_SLEEP);
+
+  // read calibration data
+  readCalibrationData();
+
+  // set the default mode to the highest resolution mode
+  setUsageMode(USAGE_MODE_INDOOR_NAV);
+}
+
+BMP280::~BMP280()
+{
+  if (m_i2c)
+    delete m_i2c;
+
+  if (m_spi)
+    delete m_spi;
+
+  if (m_gpioCS)
+    delete m_gpioCS;
+}
+
+void BMP280::update()
+{
+  int32_t temp = 0;
+  int32_t pres = 0;
+
+  const int dataLen = 6;
+  uint8_t data[dataLen];
+  memset(data, 0, dataLen);
+
+  // If we are using a forced mode, then we need to manually trigger
+  // the measurement, and wait for it to complete.
+
+  if (m_mode == MODE_FORCED)
+    {
+      // bmp280 measure mode will return to sleep after completion...
+      setMeasureMode(MODE_FORCED);
+
+      uint8_t stat;
+      do
+        {
+          usleep(10000); // 10ms
+          stat = readReg(REG_STATUS);
+        } while (stat & STATUS_MEASURING);
+    }
+
+  int rv;
+  if ((rv = readRegs(REG_PRESSURE_MSB, data, dataLen)) != dataLen)
+    {
+      throw std::runtime_error(std::string(__FUNCTION__)
+                               + ": readRegs() failed, returned "
+                               + std::to_string(rv));
+    }
+
+  // 20 bits unsigned stored in a 32bit signed quanty
+
+#if defined(BMP280_USE_TEST_DATA)
+  // taken from datasheet, section 3.12
+  temp = 519888;
+  pres = 415148;
+#else
+  temp = ( (data[5] >> 4) | (data[4] << 4) | (data[3] << 12) );
+  pres = ( (data[2] >> 4) | (data[1] << 4) | (data[0] << 12) );
+#endif
+
+  m_temperature = float(bmp280_compensate_T_int32(temp));
+  m_temperature /= 100.0;
+
+  m_pressure = float(bmp280_compensate_P_int64(pres));
+  m_pressure /= 256.0;
+}
+
+float BMP280::getAltitude(float sealLevelhPA)
+{
+  // adapted from the NOAA pdf: pressureAltitude.pdf
+  return 44307.69 * (1.0 - pow((m_pressure/100.0) / sealLevelhPA, 0.190284));
+}
+
+uint8_t BMP280::readReg(uint8_t reg)
+{
+  if (m_isSPI)
+    {
+      reg |= 0x80; // needed for read
+      uint8_t pkt[2] = {reg, 0};
+
+      csOn();
+      if (m_spi->transfer(pkt, pkt, 2))
+        {
+          csOff();
+          throw std::runtime_error(string(__FUNCTION__)
+                                   + ": Spi.transfer() failed");
+        }
+      csOff();
+
+#if 0
+      cerr << "readReg: " << std::hex << "p0: " << (int)pkt[0] << " p1: "
+           << (int)pkt[1] << endl;
+#endif // 0
+
+      return pkt[1];
+    }
+  else
+    return m_i2c->readReg(reg);
+}
+
+int BMP280::readRegs(uint8_t reg, uint8_t *buffer, int len)
+{
+  if (m_isSPI)
+    {
+      reg |= 0x80; // needed for read
+
+      csOn();
+      if (m_spi->transfer(&reg, NULL, 1))
+        {
+          csOff();
+          throw std::runtime_error(string(__FUNCTION__)
+                                   + ": Spi.transfer(reg) failed");
+        }
+
+      if (m_spi->transfer(NULL, buffer, len))
+        {
+          csOff();
+          throw std::runtime_error(string(__FUNCTION__)
+                                   + ": Spi.transfer(buf) failed");
+        }
+      csOff();
+
+#if 0
+      cerr << "readRegs(): " << std::hex;
+      for (int i=0; i<len; i++)
+        cerr << (int)buffer[i] << " ";
+      cerr << endl;
+#endif // 0
+
+      return len;
+    }
+  else
+    return m_i2c->readBytesReg(reg, buffer, len);
+}
+
+void BMP280::writeReg(uint8_t reg, uint8_t val)
+{
+  if (m_isSPI)
+    {
+      reg &= 0x7f; // mask off 0x80 for writing
+      uint8_t pkt[2] = {reg, val};
+
+      csOn();
+      if (m_spi->transfer(pkt, NULL, 2))
+        {
+          csOff();
+          throw std::runtime_error(string(__FUNCTION__)
+                                   + ": Spi.transfer() failed");
+        }
+      csOff();
+    }
+  else
+    {
+
+      mraa::Result rv;
+      if ((rv = m_i2c->writeReg(reg, val)) != mraa::SUCCESS)
+        {
+          throw std::runtime_error(std::string(__FUNCTION__)
+                                   + ": I2c.writeReg() failed");
+        }
+    }
+}
+
+void BMP280::clearData()
+{
+  m_t_fine = 0;
+
+  m_dig_T1 = 0;
+  m_dig_T2 = 0;
+  m_dig_T3 = 0;
+
+  m_dig_P1 = 0;
+  m_dig_P2 = 0;
+  m_dig_P3 = 0;
+  m_dig_P4 = 0;
+  m_dig_P5 = 0;
+  m_dig_P6 = 0;
+  m_dig_P7 = 0;
+  m_dig_P8 = 0;
+  m_dig_P9 = 0;
+}
+
+uint8_t BMP280::getChipID()
+{
+
+  return readReg(REG_CHIPID);
+}
+
+void BMP280::reset()
+{
+  writeReg(REG_RESET, BMP280_RESET_BYTE);
+  sleep(1);
+}
+
+
+void BMP280::readCalibrationData()
+{
+#if defined(BMP280_USE_TEST_DATA)
+  cerr << "WARNING: Test data is being used" << endl;
+  // This data is taken from the datasheet, section 3.12
+  m_dig_T1 = 27504;
+  m_dig_T2 = 26435;
+  m_dig_T3 = -1000;
+
+  m_dig_P1 = 36477;
+  m_dig_P2 = -10685;
+  m_dig_P3 = 3024;
+  m_dig_P4 = 2855;
+  m_dig_P5 = 140;
+  m_dig_P6 = -7;
+  m_dig_P7 = 15500;
+  m_dig_P8 = -14600;
+  m_dig_P9 = 6000;
+
+#else
+
+  uint8_t calibData[CALIBRATION_BYTES];
+  readRegs(REG_CALIB00, calibData, CALIBRATION_BYTES);
+
+  m_dig_T1 = uint16_t((calibData[1] << 8) | calibData[0]);
+  m_dig_T2 = int16_t((calibData[3] << 8) | calibData[2]);
+  m_dig_T3 = int16_t((calibData[5] << 8) | calibData[4]);
+
+# if 0
+  cerr << std::dec << "T1: " << (int)m_dig_T1
+       << " T2: " << (int)m_dig_T2
+       << " T3: " << (int)m_dig_T3
+       << endl;
+# endif // 0
+
+  m_dig_P1 = uint16_t((calibData[7] << 8) | calibData[6]);
+  m_dig_P2 = int16_t((calibData[9] << 8) | calibData[8]);
+  m_dig_P3 = int16_t((calibData[11] << 8) | calibData[10]);
+  m_dig_P4 = int16_t((calibData[13] << 8) | calibData[12]);
+  m_dig_P5 = int16_t((calibData[15] << 8) | calibData[14]);
+  m_dig_P6 = int16_t((calibData[17] << 8) | calibData[16]);
+  m_dig_P7 = int16_t((calibData[19] << 8) | calibData[18]);
+  m_dig_P8 = int16_t((calibData[21] << 8) | calibData[20]);
+  m_dig_P9 = int16_t((calibData[23] << 8) | calibData[22]);
+
+# if 0
+  cerr << std::dec << "P1: " << (int)m_dig_P1
+       << " P2: " << (int)m_dig_P2
+       << " P3: " << (int)m_dig_P3
+       << " P4: " << (int)m_dig_P4
+       << " P5: " << (int)m_dig_P5
+       << endl;
+  cerr << std::dec << "P6: " << (int)m_dig_P6
+       << " P7: " << (int)m_dig_P7
+       << " P8: " << (int)m_dig_P8
+       << " P9: " << (int)m_dig_P9
+       << endl;
+# endif // 0
+
+
+#endif
+}
+
+float BMP280::getTemperature(bool fahrenheit)
+{
+  if (fahrenheit)
+    return c2f(m_temperature);
+  else
+    return m_temperature;
+}
+
+float BMP280::getPressure()
+{
+  return m_pressure;
+}
+
+void BMP280::setFilter(FILTER_T filter)
+{
+  uint8_t reg = readReg(REG_CONFIG);
+
+  reg &= ~(_CONFIG_FILTER_MASK << _CONFIG_FILTER_SHIFT);
+  reg |= (filter << _CONFIG_FILTER_SHIFT);
+
+  writeReg(REG_CONFIG, reg);
+}
+
+void BMP280::setTimerStandby(T_SB_T tsb)
+{
+  uint8_t reg = readReg(REG_CONFIG);
+
+  reg &= ~(_CONFIG_T_SB_MASK << _CONFIG_T_SB_SHIFT);
+  reg |= (tsb << _CONFIG_T_SB_SHIFT);
+
+  writeReg(REG_CONFIG, reg);
+}
+
+void BMP280::setMeasureMode(MODES_T mode)
+{
+  uint8_t reg = readReg(REG_CTRL_MEAS);
+
+  reg &= ~(_CTRL_MEAS_MODE_MASK << _CTRL_MEAS_MODE_SHIFT);
+  reg |= (mode << _CTRL_MEAS_MODE_SHIFT);
+
+  writeReg(REG_CTRL_MEAS, reg);
+  m_mode = mode;
+}
+
+void BMP280::setOversampleRatePressure(OSRS_P_T rate)
+{
+  uint8_t reg = readReg(REG_CTRL_MEAS);
+
+  reg &= ~(_CTRL_MEAS_OSRS_P_MASK << _CTRL_MEAS_OSRS_P_SHIFT);
+  reg |= (rate << _CTRL_MEAS_OSRS_P_SHIFT);
+
+  writeReg(REG_CTRL_MEAS, reg);
+}
+
+void BMP280::setOversampleRateTemperature(OSRS_T_T rate)
+{
+  uint8_t reg = readReg(REG_CTRL_MEAS);
+
+  reg &= ~(_CTRL_MEAS_OSRS_T_MASK << _CTRL_MEAS_OSRS_T_SHIFT);
+  reg |= (rate << _CTRL_MEAS_OSRS_T_SHIFT);
+
+  writeReg(REG_CTRL_MEAS, reg);
+}
+
+uint8_t BMP280::getStatus()
+{
+  return readReg(REG_STATUS);
+}
+
+void BMP280::setUsageMode(USAGE_MODE_T mode)
+{
+  // set up the regs for the given usage mode.  These settings come
+  // from the recomendations in the BMP280 datasheet, section 3.4
+  // Filter Selection.
+
+  m_temperature = 0;
+  m_pressure = 0;
+
+  // set sleep mode first
+  setMeasureMode(MODE_SLEEP);
+
+  switch (mode)
+    {
+    case USAGE_MODE_HANDHELD_LOW_POWER:
+      setOversampleRatePressure(OSRS_P_OVERSAMPLING_16);
+      setOversampleRateTemperature(OSRS_T_OVERSAMPLING_2);
+      setFilter(FILTER_4);
+      setMeasureMode(MODE_NORMAL);
+
+      break;
+
+    case USAGE_MODE_HANDHELD_DYNAMIC:
+      setOversampleRatePressure(OSRS_P_OVERSAMPLING_4);
+      setOversampleRateTemperature(OSRS_T_OVERSAMPLING_1);
+      setFilter(FILTER_16);
+      setMeasureMode(MODE_NORMAL);
+
+      break;
+
+    case USAGE_MODE_WEATHER_MONITOR:
+      setOversampleRatePressure(OSRS_P_OVERSAMPLING_1);
+      setOversampleRateTemperature(OSRS_T_OVERSAMPLING_1);
+      setFilter(FILTER_OFF);
+      setMeasureMode(MODE_FORCED);
+
+      break;
+
+    case USAGE_MODE_FLOOR_CHG_DETECT:
+      setOversampleRatePressure(OSRS_P_OVERSAMPLING_4);
+      setOversampleRateTemperature(OSRS_T_OVERSAMPLING_1);
+      setFilter(FILTER_4);
+      setMeasureMode(MODE_NORMAL);
+
+      break;
+
+    case USAGE_MODE_DROP_DETECT:
+      setOversampleRatePressure(OSRS_P_OVERSAMPLING_2);
+      setOversampleRateTemperature(OSRS_T_OVERSAMPLING_1);
+      setFilter(FILTER_OFF);
+      setMeasureMode(MODE_NORMAL);
+
+      break;
+
+    case USAGE_MODE_INDOOR_NAV:
+      setOversampleRatePressure(OSRS_P_OVERSAMPLING_16);
+      setOversampleRateTemperature(OSRS_T_OVERSAMPLING_2);
+      setFilter(FILTER_16);
+      setMeasureMode(MODE_NORMAL);
+
+      break;
+
+    default:
+      throw std::logic_error(string(__FUNCTION__)
+                             + ": invalid mode specified");
+    }
+}
+
+void BMP280::csOn()
+{
+  if (m_gpioCS)
+    m_gpioCS->write(0);
+}
+
+void BMP280::csOff()
+{
+  if (m_gpioCS)
+    m_gpioCS->write(1);
+}
+
+
+// These functions come from the BMP180 datasheet, section 3.11.3
+
+// Returns temperature in DegC, resolution is 0.01 DegC. Output value
+// of “5123” equals 51.23 DegC.  t_fine carries fine temperature as
+// global value
+int32_t BMP280::bmp280_compensate_T_int32(int32_t adc_T)
+{
+  int32_t var1, var2, T;
+  var1 = ((((adc_T>>3) - ((int32_t)m_dig_T1<<1))) * ((int32_t)m_dig_T2)) >> 11;
+  var2 = (((((adc_T>>4) - ((int32_t)m_dig_T1)) * ((adc_T>>4) - ((int32_t)m_dig_T1))) >> 12) *
+          ((int32_t)m_dig_T3)) >> 14;
+  m_t_fine = var1 + var2;
+  T = (m_t_fine * 5 + 128) >> 8;
+  return T;
+}
+
+// Returns pressure in Pa as unsigned 32 bit integer in Q24.8 format
+// (24 integer bits and 8 fractional bits).  Output value of
+// “24674867” represents 24674867/256 = 96386.2 Pa = 963.862 hPa
+uint32_t BMP280::bmp280_compensate_P_int64(int32_t adc_P)
+{
+  int64_t var1, var2, p;
+  var1 = ((int64_t)m_t_fine) - 128000;
+  var2 = var1 * var1 * (int64_t)m_dig_P6;
+  var2 = var2 + ((var1*(int64_t)m_dig_P5)<<17);
+  var2 = var2 + (((int64_t)m_dig_P4)<<35);
+  var1 = ((var1 * var1 * (int64_t)m_dig_P3)>>8) + ((var1 * (int64_t)m_dig_P2)<<12);
+  var1 = (((((int64_t)1)<<47)+var1))*((int64_t)m_dig_P1)>>33;
+  if (var1 == 0)
+    {
+      return 0; // avoid exception caused by division by zero
+    }
+  p = 1048576-adc_P;
+  p = (((p<<31)-var2)*3125)/var1;
+  var1 = (((int64_t)m_dig_P9) * (p>>13) * (p>>13)) >> 25;
+  var2 = (((int64_t)m_dig_P8) * p) >> 19;
+  p = ((p + var1 + var2) >> 8) + (((int64_t)m_dig_P7)<<4);
+  return (uint32_t)p;
+}

--- a/src/bmp280/bmp280.hpp
+++ b/src/bmp280/bmp280.hpp
@@ -1,0 +1,467 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include <mraa/i2c.hpp>
+#include <mraa/spi.hpp>
+#include <mraa/gpio.hpp>
+
+#define BMP280_DEFAULT_I2C_BUS 0
+#define BMP280_DEFAULT_SPI_BUS 0
+#define BMP280_DEFAULT_ADDR 0x77
+
+namespace upm {
+
+  /**
+   * @brief BMP280 Digital Pressure Sensor
+   * @defgroup bmp280 libupm-bmp280
+   * @ingroup i2c spi gpio pressure
+   */
+
+  /**
+   * @library bmp280
+   * @sensor bmp280
+   * @comname BMP280 Digital Pressure Sensor
+   * @type pressure
+   * @man adafruit
+   * @con i2c spi gpio
+   * @web https://www.adafruit.com/products/2651
+   *
+   * @brief API for the BMP280 Digital Pressure Sensor
+   *
+   * The BMP280 is an absolute barometric pressure sensor especially
+   * designed for mobile applications. The sensor module is housed in
+   * an extremely compact 8-pin metal-lid LGA package with a footprint
+   * of only 2.0 × 2.5 mm2 and 0.95 mm package height. Its small
+   * dimensions and its low power consumption of 2.7 μA @1Hz allow the
+   * implementation in battery driven devices such as mobile phones,
+   * GPS modules or watches.
+   *
+   * As the successor to the widely adopted BMP180, the BMP280
+   * delivers high performance in all applications that require
+   * precise pressure measurement. The BMP280 operates at lower noise,
+   * supports new filter modes and an SPI interface within a footprint
+   * 63% smaller than the BMP180.
+   *
+   * @snippet bmp280.cxx Interesting
+   */
+
+  class BMP280 {
+  public:
+    // The chip ID, for verification in the ctor.
+    const uint8_t BMP280_CHIPID = 0x58;
+
+    // special reset byte
+    const uint8_t BMP280_RESET_BYTE = 0xb6;
+
+    // number of bytes of stored calibration data
+    const int CALIBRATION_BYTES = 26;
+
+    /**
+     * BMP280 registers
+     */
+    typedef enum : uint8_t {
+      // Do not write into reserved bits.
+
+      // read-only factory calibration data
+      REG_CALIB00                      = 0x88,
+      REG_CALIB01                      = 0x89,
+      REG_CALIB02                      = 0x8a,
+      REG_CALIB03                      = 0x8b,
+      REG_CALIB04                      = 0x8c,
+      REG_CALIB05                      = 0x8d,
+      REG_CALIB06                      = 0x8e,
+      REG_CALIB07                      = 0x8f,
+      REG_CALIB08                      = 0x90,
+      REG_CALIB09                      = 0x91,
+      REG_CALIB10                      = 0x92,
+      REG_CALIB11                      = 0x93,
+      REG_CALIB12                      = 0x94,
+      REG_CALIB13                      = 0x95,
+      REG_CALIB14                      = 0x96,
+      REG_CALIB15                      = 0x97,
+      REG_CALIB16                      = 0x98,
+      REG_CALIB17                      = 0x99,
+      REG_CALIB18                      = 0x9a,
+      REG_CALIB19                      = 0x9b,
+      REG_CALIB20                      = 0x9c,
+      REG_CALIB21                      = 0x9d,
+      REG_CALIB22                      = 0x9e,
+      REG_CALIB23                      = 0x9f,
+      REG_CALIB24                      = 0xa0,
+      REG_CALIB25                      = 0xa1,
+
+      REG_CHIPID                       = 0xd0,
+      REG_RESET                        = 0xe0,
+      REG_STATUS                       = 0xf3,
+      REG_CTRL_MEAS                    = 0xf4,
+      REG_CONFIG                       = 0xf5,
+
+      REG_PRESSURE_MSB                 = 0xf7,
+      REG_PRESSURE_LSB                 = 0xf8,
+      REG_PRESSURE_XLSB                = 0xf9,
+
+      REG_TEMPERATURE_MSB              = 0xfa,
+      REG_TEMPERATURE_LSB              = 0xfb,
+      REG_TEMPERATURE_XLSB             = 0xfc
+    } REGS_T;
+
+    /**
+     * REG_CONFIG bits
+     */
+    typedef enum {
+      CONFIG_SPI3W_EN                  = 0x01,
+
+      // 0x02 reserved
+
+      CONFIG_FILTER0                   = 0x04,
+      CONFIG_FILTER1                   = 0x08,
+      CONFIG_FILTER2                   = 0x10,
+      _CONFIG_FILTER_MASK              = 7,
+      _CONFIG_FILTER_SHIFT             = 2,
+
+      CONFIG_T_SB0                     = 0x20,
+      CONFIG_T_SB1                     = 0x40,
+      CONFIG_T_SB2                     = 0x80,
+      _CONFIG_T_SB_MASK                = 7,
+      _CONFIG_T_SB_SHIFT               = 5
+    } CONFIG_BITS_T;
+
+    /**
+     * FILTER values (samples to reach >= 75% of step response)
+     */
+    typedef enum {
+      FILTER_OFF                       = 0, // 1 samples
+      FILTER_2                         = 1, // 2
+      FILTER_4                         = 2, // 5
+      FILTER_8                         = 3, // 11
+      FILTER_16                        = 4  // 22
+    } FILTER_T;
+
+    /**
+     * T_SB values (timer standby)
+     */
+    typedef enum {
+      T_SB_0_5                         = 0, // 0.5ms
+      T_SB_62_5                        = 1, // 62.5ms
+      T_SB_125                         = 2, // 125ms
+      T_SB_250                         = 3,
+      T_SB_500                         = 4,
+      T_SB_1000                        = 5,
+      T_SB_2000                        = 6,
+      T_SB_4000                        = 7
+    } T_SB_T;
+
+
+    /**
+     * REG_CTRL_MEAS bits
+     */
+    typedef enum {
+      CTRL_MEAS_MODE0                  = 0x01,
+      CTRL_MEAS_MODE1                  = 0x02,
+      _CTRL_MEAS_MODE_MASK             = 3,
+      _CTRL_MEAS_MODE_SHIFT            = 0,
+
+      CTRL_MEAS_OSRS_P0                = 0x04,
+      CTRL_MEAS_OSRS_P1                = 0x08,
+      CTRL_MEAS_OSRS_P2                = 0x10,
+      _CTRL_MEAS_OSRS_P_MASK           = 7,
+      _CTRL_MEAS_OSRS_P_SHIFT          = 2,
+
+      CTRL_MEAS_OSRS_T0                = 0x04,
+      CTRL_MEAS_OSRS_T1                = 0x08,
+      CTRL_MEAS_OSRS_T2                = 0x10,
+      _CTRL_MEAS_OSRS_T_MASK           = 7,
+      _CTRL_MEAS_OSRS_T_SHIFT          = 5
+    } CTRL_MEAS_T;
+
+    /**
+     * CTRL_MEAS_MODE values
+     */
+    typedef enum {
+      MODE_SLEEP                       = 0,
+      MODE_FORCED                      = 1,
+      // 2 is also FORCED mode
+      MODE_NORMAL                      = 3
+    } MODES_T;
+
+    /**
+     * CTRL_MEAS_OSRS_P values
+     */
+    typedef enum {
+      OSRS_P_SKIPPED                   = 0,
+      OSRS_P_OVERSAMPLING_1            = 1, // x1
+      OSRS_P_OVERSAMPLING_2            = 2, // x2
+      OSRS_P_OVERSAMPLING_4            = 3,
+      OSRS_P_OVERSAMPLING_8            = 4,
+      OSRS_P_OVERSAMPLING_16           = 5
+    } OSRS_P_T;
+
+    /**
+     * CTRL_MEAS_OSRS_T values
+     */
+    typedef enum {
+      OSRS_T_SKIPPED                   = 0,
+      OSRS_T_OVERSAMPLING_1            = 1, // x1
+      OSRS_T_OVERSAMPLING_2            = 2, // x2
+      OSRS_T_OVERSAMPLING_4            = 3,
+      OSRS_T_OVERSAMPLING_8            = 4,
+      OSRS_T_OVERSAMPLING_16           = 5
+    } OSRS_T_T;
+
+    /**
+     * REG_STATUS bits
+     */
+    typedef enum {
+      STATUS_IM_UPDATE                 = 0x01,
+      // 0x02-0x04 reserved
+      STATUS_MEASURING                 = 0x08
+      // 0x10-0x80 reserved
+    } STATUS_T;
+
+    /**
+     * USAGE_MODE values.  This is a fake specification to configure
+     * the various knobs based on their typical use modes, as
+     * recommended by Bosch.
+     */
+    typedef enum {
+      USAGE_MODE_HANDHELD_LOW_POWER    = 0,
+      USAGE_MODE_HANDHELD_DYNAMIC      = 1,
+      USAGE_MODE_WEATHER_MONITOR       = 2, // lowest power consumption
+      USAGE_MODE_FLOOR_CHG_DETECT      = 3,
+      USAGE_MODE_DROP_DETECT           = 4,
+      USAGE_MODE_INDOOR_NAV            = 5  // highest resolution
+    } USAGE_MODE_T;
+
+    /**
+     * BMP280 constructor.
+     *
+     * This device can support both I2C and SPI. For SPI, set the addr
+     * to -1, and specify a positive integer representing the Chip
+     * Select (CS) pin for the cs argument.  The default is I2C.
+     *
+     * @param bus I2C or SPI bus to use.
+     * @param address The address for this device.  -1 for SPI.
+     * @param cs The gpio pin to use for the SPI Chip Select.  -1 for I2C.
+     */
+    BMP280(int bus=BMP280_DEFAULT_I2C_BUS, int addr=BMP280_DEFAULT_ADDR,
+           int cs=-1);
+
+    /**
+     * BMP280 Destructor.
+     */
+    ~BMP280();
+
+    /**
+     * Update the internal stored values from sensor data.
+     */
+    void update();
+
+    /**
+     * Return the chip ID.
+     *
+     * @return The chip ID (BMP280_CHIPID).
+     */
+    uint8_t getChipID();
+
+    /**
+     * Reset the sensor, as if by a power-on-reset.
+     */
+    void reset();
+
+    /**
+     * Return the current measured temperature.  Note, this is not
+     * ambient temperature - this is the temperature used to fine tune
+     * the pressure measurement.  update() must have been called prior
+     * to calling this method.
+     *
+     * @param fahrenheit true to return data in Fahrenheit, false for
+     * Celicus.  Celcius is the default.
+     * @return The temperature in degrees Celcius or Fahrenheit.
+     */
+    float getTemperature(bool fahrenheit=false);
+
+    /**
+     * Return the current measured pressure in Pascals (Pa).  update()
+     * must have been called prior to calling this method.
+     *
+     * @return The pressure in Pascals (Pa).
+     */
+    float getPressure();
+
+    /**
+     * Return the current computed altitude in meters.  update()
+     * must have been called prior to calling this method.
+     *
+     * @param seaLevelhPA The pressure at sea level in hectoPascals
+     * (hPa).  The default is 1013.25 hPA, (101325 Pa).
+     * @return The computed altitude in meters.
+     */
+    float getAltitude(float seaLevelhPA=1013.25);
+
+    /**
+     * Set a general usage mode.  This function can be used to
+     * configure the filters and oversampling for a particular use
+     * case.  These setting are documented in the BMP280 datasheet.
+     * The default mode set in the contructor is
+     * USAGE_MODE_INDOOR_NAV, the highest resolution mode.
+     *
+     * @param mode One of the USAGE_MODE_T values.
+     */
+    void setUsageMode(USAGE_MODE_T mode);
+
+    /**
+     * Set the temperature sensor oversampling parameter.  See the
+     * data sheet for details.  This value can be automatically set to
+     * a suitable value by using one of the predefined modes for
+     * setUsageMode().
+     *
+     * @param mode One of the OSRS_T_T values.
+     */
+    void setOversampleRateTemperature(OSRS_T_T rate);
+
+    /**
+     * Set the pressure sensor oversampling parameter.  See the
+     * data sheet for details.  This value can be automatically set to
+     * a suitable value by using one of the predefined modes for
+     * setUsageMode().
+     *
+     * @param mode One of the OSRS_P_T values.
+     */
+    void setOversampleRatePressure(OSRS_P_T rate);
+
+    /**
+     * Set the timer standby value.  When in NORMAL operating mode,
+     * this timer governs how long the chip will wait before
+     * performing a measurement.  See the data sheet for details.
+     *
+     * @param mode One of the T_SB_T values.
+     */
+    void setTimerStandby(T_SB_T tsb);
+
+    /**
+     * Set the IIR filtering parameter.  See the data sheet for
+     * details.  This value can be automatically set to a suitable
+     * value by using one of the predefined modes for setUsageMode().
+     *
+     * @param mode One of the FILTER_T values.
+     */
+    void setFilter(FILTER_T filter);
+
+    /**
+     * Set the default measuring mode.  Basic values are forced,
+     * sleep, and normal.  See the data sheet for details.  This value
+     * can be automatically set to a suitable value by using one of
+     * the predefined modes for setUsageMode().
+     *
+     * @param mode One of the MODES_T values.
+     */
+    void setMeasureMode(MODES_T mode);
+
+  protected:
+    mraa::I2c *m_i2c;
+    mraa::Spi *m_spi;
+    mraa::Gpio *m_gpioCS;
+
+    uint8_t m_addr;
+
+    // always stored in C
+    float m_temperature;
+
+    // pressure in Pa
+    float m_pressure;
+
+    // return the status register
+    uint8_t getStatus();
+
+    /**
+     * Read a register.
+     *
+     * @param reg The register to read
+     * @return The value of the register
+     */
+    uint8_t readReg(uint8_t reg);
+
+    /**
+     * Read contiguous registers into a buffer.
+     *
+     * @param buffer The buffer to store the results
+     * @param len The number of registers to read
+     * @return The number of bytes read, or -1 on error
+     */
+    int readRegs(uint8_t reg, uint8_t *buffer, int len);
+
+    /**
+     * Write to a register
+     *
+     * @param reg The register to write to
+     * @param val The value to write
+     */
+    void writeReg(uint8_t reg, uint8_t val);
+
+    // clear member data...
+    void clearData();
+
+    // read the calibration data
+    void readCalibrationData();
+
+    // SPI chip select
+    void csOn();
+    void csOff();
+
+  private:
+    // are we doing SPI?
+    bool m_isSPI;
+
+    // current operating mode.  MODE_FORCED requires special attention
+    // in update()
+    MODES_T m_mode;
+
+    // calibration data temperature
+    uint16_t m_dig_T1;
+    int16_t m_dig_T2;
+    int16_t m_dig_T3;
+
+    // calibration data pressure
+    uint16_t m_dig_P1;
+    int16_t m_dig_P2;
+    int16_t m_dig_P3;
+    int16_t m_dig_P4;
+    int16_t m_dig_P5;
+    int16_t m_dig_P6;
+    int16_t m_dig_P7;
+    int16_t m_dig_P8;
+    int16_t m_dig_P9;
+
+    // shared calibration data - set in temp conversion, used in
+    // pressure conversion.
+    int32_t m_t_fine;
+
+    // Bosch supplied conversion/compensation functions from the
+    // datasheet.
+    int32_t bmp280_compensate_T_int32(int32_t adc_T);
+    uint32_t bmp280_compensate_P_int64(int32_t adc_P);
+  };
+}

--- a/src/bmp280/javaupm_bmp280.i
+++ b/src/bmp280/javaupm_bmp280.i
@@ -1,0 +1,23 @@
+%module javaupm_bmp280
+%include "../upm.i"
+%include "cpointer.i"
+%include "typemaps.i"
+%include "arrays_java.i";
+%include "../java_buffer.i"
+
+%{
+    #include "bmp280.hpp"
+%}
+
+%include "bmp280.hpp"
+
+%pragma(java) jniclasscode=%{
+    static {
+        try {
+            System.loadLibrary("javaupm_bmp280");
+        } catch (UnsatisfiedLinkError e) {
+            System.err.println("Native code library failed to load. \n" + e);
+            System.exit(1);
+        }
+    }
+%}

--- a/src/bmp280/jsupm_bmp280.i
+++ b/src/bmp280/jsupm_bmp280.i
@@ -1,0 +1,12 @@
+%module jsupm_bmp280
+%include "../upm.i"
+%include "cpointer.i"
+
+/* Send "int *" and "float *" to JavaScript as intp and floatp */
+%pointer_functions(int, intp);
+%pointer_functions(float, floatp);
+
+%include "bmp280.hpp"
+%{
+    #include "bmp280.hpp"
+%}

--- a/src/bmp280/pyupm_bmp280.i
+++ b/src/bmp280/pyupm_bmp280.i
@@ -1,0 +1,22 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
+%module pyupm_bmp280
+%include "../upm.i"
+%include "cpointer.i"
+
+%include "stdint.i"
+
+/* Send "int *" and "float *" to python as intp and floatp */
+%pointer_functions(int, intp);
+%pointer_functions(float, floatp);
+
+%feature("autodoc", "3");
+
+#ifdef DOXYGEN
+%include "bmp280_doc.i"
+#endif
+
+%include "bmp280.hpp"
+%{
+    #include "bmp280.hpp"
+%}


### PR DESCRIPTION
The BMP280 is an absolute barometric pressure sensor especially
designed for mobile applications. The sensor module is housed in an
extremely compact 8-pin metal-lid LGA package with a footprint of only
2.0 × 2.5 mm2 and 0.95 mm package height. Its small dimensions and its
low power consumption of 2.7 μA @1Hz allow the implementation in
battery driven devices such as mobile phones, GPS modules or watches.

As the successor to the widely adopted BMP180, the BMP280 delivers
high performance in all applications that require precise pressure
measurement. The BMP280 operates at lower noise, supports new filter
modes and an SPI interface within a footprint 63% smaller than the
BMP180.

This driver supports both I2C and SPI operation.  However SPI is not
functional on Edison with the Arduino breakout board.

Signed-off-by: Jon Trulson <jtrulson@ics.com>