### PR TITLE
ppd42ns: convert pcs/0.01cf to μg/m3 to aqi

### DIFF
--- a/src/ppd42ns/ppd42ns.hpp
+++ b/src/ppd42ns/ppd42ns.hpp
@@ -33,7 +33,9 @@ typedef struct
 {
 	int lowPulseOccupancy;
 	double ratio;
-	double concentration;
+	double concentration; // pcs/0.01cf
+    double ugm3; // μg/m3
+    int aqi; // Air Quality Index
 } dustData;
 
   /**


### PR DESCRIPTION
The current implementation does not use the correction factors based
on the presence of humidity and rain.
