### PR TITLE
Added work around of hardware errata on Grove RGB back light LCD

### DIFF
--- a/src/lcd/jhd1313m1.cxx
+++ b/src/lcd/jhd1313m1.cxx
@@ -46,13 +46,19 @@ Jhd1313m1::Jhd1313m1(int bus, int lcdAddress, int rgbAddress)
                                     ": I2c.address() failed");
     }
 
+    /* HD44780 requires writing three times to initialize or reset
+       according to the hardware errata on page 45 figure 23 of
+       the Hitachi HD44780 datasheet */
+    /* First try */
     usleep(50000);
-    ret = command(LCD_FUNCTIONSET | LCD_2LINE);
-
-    if (!ret) {
-        ret = command(LCD_FUNCTIONSET | LCD_2LINE);
-        UPM_CHECK_MRAA_SUCCESS(ret, "Unable to initialise the LCD controller");
-    }
+    ret = command(LCD_FUNCTIONSET | LCD_8BITMODE);
+    /* Second try */
+    usleep(4500);
+    ret = command(LCD_FUNCTIONSET | LCD_8BITMODE);
+    /* Third try */
+    usleep(150);
+    ret = command(LCD_FUNCTIONSET | LCD_8BITMODE);
+    UPM_CHECK_MRAA_SUCCESS(ret, "Unable to initialise the LCD controller");
 
     usleep(100);
     ret = displayOn();

--- a/src/lcd/jhd1313m1.cxx
+++ b/src/lcd/jhd1313m1.cxx
@@ -60,6 +60,10 @@ Jhd1313m1::Jhd1313m1(int bus, int lcdAddress, int rgbAddress)
     ret = command(LCD_FUNCTIONSET | LCD_8BITMODE);
     UPM_CHECK_MRAA_SUCCESS(ret, "Unable to initialise the LCD controller");
 
+    /* Set 2 row mode and font size */
+    ret = command(LCD_FUNCTIONSET | LCD_8BITMODE | LCD_2LINE | LCD_5x10DOTS);
+    UPM_CHECK_MRAA_SUCCESS(ret, "Unable to initialise the LCD controller");
+
     usleep(100);
     ret = displayOn();
 


### PR DESCRIPTION
Hello,

I have added work around of hardware errata of HD44780 LCD chip used on Grove RGB back light LCD. The HD44780 clones are widely used on many dot-matrix LCD and all has the same errata.
Without this patch, once out of five fails to initialize the HD44780 and often do not show second row or show dark background.

The datasheet of HD44780 was originally written in Japanese but this link bellow has English description of initializing the HD44780.
http://elm-chan.org/docs/lcd/hd44780_e.html

Also, the Seeed studio have already added this work around in there Arduino code.
https://github.com/Seeed-Studio/Grove_LCD_RGB_Backlight/blob/master/rgb_lcd.cpp

I really appreciate for merging my pull request.

I found this issue when I wrote the program on 96Boards at the bellow link.
https://github.com/96boards/Starter_Kit_for_96Boards/tree/master/rgb_lcd_demo 