### PR TITLE
e50hx: use the new bacnetutil class

### DIFF
--- a/examples/c++/e50hx.cxx
+++ b/examples/c++/e50hx.cxx
@@ -74,8 +74,8 @@ int main(int argc, char **argv)
   // sensor->setDebug(true);
 
   cout << endl;
-  cout << "Device Description: " << sensor->getDescription() << endl;
-  cout << "Device Location: " << sensor->getLocation() << endl;
+  cout << "Device Description: " << sensor->getDeviceDescription() << endl;
+  cout << "Device Location: " << sensor->getDeviceLocation() << endl;
   cout << endl;
 
   // update and print a few values every 5 seconds

--- a/examples/java/E50HX_Example.java
+++ b/examples/java/E50HX_Example.java
@@ -58,8 +58,10 @@ public class E50HX_Example
         // sensor.setDebug(true);
 
         System.out.println();
-        System.out.println("Device Description: " + sensor.getDescription());
-        System.out.println("Device Location: " + sensor.getLocation());
+        System.out.println("Device Description: "
+                           + sensor.getDeviceDescription());
+        System.out.println("Device Location: "
+                           + sensor.getDeviceLocation());
         System.out.println();
 
         // update and print a few values every 5 seconds
@@ -84,7 +86,6 @@ public class E50HX_Example
                 System.out.println();
                 Thread.sleep(5000);
             }
-
 // ! [Interesting]
     }
 }

--- a/examples/javascript/e50hx.js
+++ b/examples/javascript/e50hx.js
@@ -63,8 +63,8 @@ sensor.initMaster(defaultDev, 38400, 1000001, 2);
 // sensor.setDebug(true);
 
 console.log("");
-console.log("Device Description:", sensor.getDescription());
-console.log("Device Location:", sensor.getLocation());
+console.log("Device Description:", sensor.getDeviceDescription());
+console.log("Device Location:", sensor.getDeviceLocation());
 console.log("");
 
 // update and print a few values every 5 seconds

--- a/examples/python/e50hx.py
+++ b/examples/python/e50hx.py
@@ -69,8 +69,8 @@ sensor.initMaster(defaultDev, 38400, 1000001, 2)
 
 # output the serial number and firmware revision
 print
-print "Device Description:", sensor.getDescription()
-print "Device Location:", sensor.getLocation()
+print "Device Description:", sensor.getDeviceDescription()
+print "Device Location:", sensor.getDeviceLocation()
 print
 
 # update and print available values every second

--- a/src/e50hx/e50hx.cxx
+++ b/src/e50hx/e50hx.cxx
@@ -36,189 +36,16 @@ using namespace std;
 
 
 E50HX::E50HX(uint32_t targetDeviceObjectID) :
-  m_instance(0)
+  BACNETUTIL(targetDeviceObjectID)
 {
-  // Save our device's ID
-  m_targetDeviceObjectID = targetDeviceObjectID;
-
-  // create the BACNETMSTP instance here if it does not already exist,
-  // and store the pointer in our class to save on some typing.
-
-  m_instance = BACNETMSTP::instance();
-
-  // now see if it has been initialized yet for init()
-  m_initialized = m_instance->isInitialized();
-
   setDebug(false);
 
   // we disable this by default for performance reasons
   checkReliability(false);
-
-  // empty our unit caches
-  m_avUnitCache.clear();
-  m_aiUnitCache.clear();
 }
 
 E50HX::~E50HX()
 {
-}
-
-void E50HX::initMaster(std::string port, int baudRate,
-                       int deviceInstanceID, int macAddr, int maxMaster,
-                       int maxInfoFrames)
-{
-  // first we check to see if the bacnetmstp instance has already been
-  // initialized (determined in the ctor).  If not, we will do so here
-  // with the arguments specified.  If it has already been
-  // initialized, then we do not bother calling bacnetmstp's init
-  // again as it will just be ignored.
-
-  if (!m_initialized)
-    m_instance->initMaster(port, baudRate, deviceInstanceID,
-                           macAddr, maxMaster, maxInfoFrames);
-
-  // either it threw an exception, was already initialized or it's
-  // initialized now...
-  m_initialized = true;
-}
-
-void E50HX::setDebug(bool enable)
-{
-  m_debugging = enable;
-
-  // we also enable/disable debugging in BACNETMSTP
-  m_instance->setDebug(enable);
-}
-
-float E50HX::getAnalogValue(ANALOG_VALUES_T objInstance)
-{
-  // check reliability first, if enabled
-  if (m_checkReliability)
-    {
-      if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                   objInstance, PROP_RELIABILITY))
-        {
-          if (m_debugging)
-            cerr << __FUNCTION__ << ": (reliability): " << getAllErrorString()
-                 << endl;
-
-          return RETURN_ERROR;
-        }
-
-      BACNET_RELIABILITY reliable =
-        static_cast<BACNET_RELIABILITY>(m_instance->getDataTypeEnum());
-
-      if (reliable != RELIABILITY_NO_FAULT_DETECTED)
-        {
-          if (m_debugging)
-            cerr << __FUNCTION__ << ": Reliability check failed" << endl;
-
-          return RETURN_UNRELIABLE;
-        }
-    }
-
-  // now get the value
-  if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                               objInstance, PROP_PRESENT_VALUE))
-    {
-          if (m_debugging)
-            cerr << __FUNCTION__ << ": (value): " << getAllErrorString()
-                 << endl;
-
-      return RETURN_ERROR;
-    }
-
-  return m_instance->getDataTypeReal();
-}
-
-string E50HX::getAnalogValueUnits(ANALOG_VALUES_T objInstance)
-{
-  // see if it exists
-  if (m_avUnitCache.count(objInstance) == 0)
-    {
-      // then we need to fetch it
-      if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                   objInstance, PROP_UNITS))
-        {
-          if (m_debugging)
-            cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-          // set to empty string
-          m_avUnitCache[objInstance] = string("");
-        }
-      else
-        {
-          // cache it for future calls
-          m_avUnitCache[objInstance] =
-            string(bactext_engineering_unit_name(m_instance->getDataTypeEnum()));
-        }
-    }
-
-  return m_avUnitCache[objInstance];
-}
-
-float E50HX::getAnalogInput(ANALOG_INPUTS_T objInstance)
-{
-  // check reliability first, if enabled
-  if (m_checkReliability)
-    {
-      if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_ANALOG_INPUT,
-                                   objInstance, PROP_RELIABILITY))
-        {
-          if (m_debugging)
-            cerr << __FUNCTION__ << ": (reliability): "
-                 << getAllErrorString() << endl;
-
-          return RETURN_ERROR;
-        }
-
-      BACNET_RELIABILITY reliable =
-        static_cast<BACNET_RELIABILITY>(m_instance->getDataTypeEnum());
-
-      if (reliable != RELIABILITY_NO_FAULT_DETECTED)
-        {
-          if (m_debugging)
-            cerr << __FUNCTION__ << ": Reliability check failed" << endl;
-
-          return RETURN_UNRELIABLE;
-        }
-    }
-
-  // now get the value
-  if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_ANALOG_INPUT,
-                               objInstance, PROP_PRESENT_VALUE))
-    {
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": (value): " << getAllErrorString() << endl;
-
-      return RETURN_ERROR;
-    }
-
-  return m_instance->getDataTypeReal();
-}
-
-string E50HX::getAnalogInputUnits(ANALOG_INPUTS_T objInstance)
-{
-  // see if it exists
-  if (m_aiUnitCache.count(objInstance) == 0)
-    {
-      // then we need to fetch it
-      if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_ANALOG_INPUT,
-                                   objInstance, PROP_UNITS))
-        {
-          if (m_debugging)
-            cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-          // set to empty string
-          m_aiUnitCache[objInstance] = string("");
-        }
-      else
-        {
-          // cache it for future calls
-          m_aiUnitCache[objInstance] =
-            string(bactext_engineering_unit_name(m_instance->getDataTypeEnum()));
-        }
-    }
-
-  return m_aiUnitCache[objInstance];
 }
 
 uint16_t E50HX::getAlarmBits()
@@ -226,169 +53,17 @@ uint16_t E50HX::getAlarmBits()
   return uint16_t(getAnalogInput(AI_Alarm_Bitmap));
 }
 
-BACNETMSTP::BACERR_TYPE_T E50HX::getErrorType()
+void E50HX::writeConfig(CFG_VALUES_T config)
 {
-  return m_instance->getErrorType();
+  setAnalogValue(AV_Config, float(config));
 }
 
-uint8_t E50HX::getRejectReason()
+void E50HX::writeSystemType(SYSTEM_TYPES_T systype)
 {
-  return m_instance->getRejectReason();
+  setAnalogValue(AV_System_Type, float(systype));
 }
 
-std::string E50HX::getRejectString()
-{
-  return m_instance->getRejectString();
-}
-
-uint8_t E50HX::getAbortReason()
-{
-  return m_instance->getAbortReason();
-}
-
-std::string E50HX::getAbortString()
-{
-  return m_instance->getAbortString();
-}
-
-BACNET_ERROR_CLASS E50HX::getErrorClass()
-{
-  return m_instance->getErrorClass();
-}
-
-BACNET_ERROR_CODE E50HX::getErrorCode()
-{
-  return m_instance->getErrorCode();
-}
-
-std::string E50HX::getUPMErrorString()
-{
-  return m_instance->getUPMErrorString();
-}
-
-std::string E50HX::getErrorString()
-{
-  return m_instance->getErrorString();
-};
-
-
-string E50HX::getAllErrorString()
-{
-  switch (m_instance->getErrorType())
-    {
-    case BACNETMSTP::BACERR_TYPE_NONE:
-      return string("No Error");
-      break;
-
-    case BACNETMSTP::BACERR_TYPE_REJECT:
-      return string("Reject: ") + getRejectString();
-      break;
-
-    case BACNETMSTP::BACERR_TYPE_ABORT:
-      return string("Abort: ") + getAbortString();
-      break;
-
-    case BACNETMSTP::BACERR_TYPE_ERROR:
-      return string("Error: ") + getErrorString();
-      break;
-
-    case BACNETMSTP::BACERR_TYPE_UPM:
-      return string("UPM Error: ") + getUPMErrorString();
-      break;
-    }
-}
-
-string E50HX::getDescription()
-{
-  if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_DEVICE,
-                               m_targetDeviceObjectID, PROP_DESCRIPTION))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return "";
-    }
-
-  return m_instance->getDataTypeString();
-}
-
-string E50HX::getLocation()
-{
-  if (m_instance->readProperty(m_targetDeviceObjectID, OBJECT_DEVICE,
-                               m_targetDeviceObjectID, PROP_LOCATION))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return "";
-    }
-
-  return m_instance->getDataTypeString();
-}
-
-bool E50HX::setLocation(string location)
-{
-  BACNET_APPLICATION_DATA_VALUE myLocation =
-    m_instance->createDataString(location);
-
-  // write the Device Object Location
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_DEVICE,
-                                m_targetDeviceObjectID, PROP_LOCATION,
-                                &myLocation))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
-}
-
-bool E50HX::writeConfig(CFG_VALUES_T config)
-{
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(float(config));
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_Config, PROP_PRESENT_VALUE, &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
-}
-
-bool E50HX::writeSystemType(SYSTEM_TYPES_T systype)
-{
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(float(systype));
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_System_Type, PROP_PRESENT_VALUE, &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
-}
-
-bool E50HX::writeCTRatioPrimary(float ctRatio)
+void E50HX::writeCTRatioPrimary(float ctRatio)
 {
   if (ctRatio < 5 || ctRatio > 32000)
     {
@@ -396,47 +71,15 @@ bool E50HX::writeCTRatioPrimary(float ctRatio)
                               + ": ctRatio must be between 5-32000");
     }
 
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(ctRatio);
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_CT_Ratio_Primary, PROP_PRESENT_VALUE,
-                                &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
+  setAnalogValue(AV_CT_Ratio_Primary, ctRatio);
 }
 
-bool E50HX::writeCTRatioSecondary(CT_SECONDARY_T ctRatio)
+void E50HX::writeCTRatioSecondary(CT_SECONDARY_T ctRatio)
 {
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(float(ctRatio));
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_CT_Ratio_Secondary, PROP_PRESENT_VALUE,
-                                &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
+  setAnalogValue(AV_CT_Ratio_Secondary, ctRatio);
 }
 
-bool E50HX::writePTRatio(float ptRatio)
+void E50HX::writePTRatio(float ptRatio)
 {
   if (ptRatio < 0.01 || ptRatio > 320.0)
     {
@@ -444,26 +87,10 @@ bool E50HX::writePTRatio(float ptRatio)
                               + ": ptRatio must be between 0.01-320.0");
     }
 
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(ptRatio);
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_PT_Ratio, PROP_PRESENT_VALUE,
-                                &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
+  setAnalogValue(AV_PT_Ratio, ptRatio);
 }
 
-bool E50HX::writeSystemVoltage(float sysVolts)
+void E50HX::writeSystemVoltage(float sysVolts)
 {
   if (sysVolts < 82.0 || sysVolts > 32000.0)
     {
@@ -471,47 +98,15 @@ bool E50HX::writeSystemVoltage(float sysVolts)
                               + ": sysVolts must be between 82.0-32000.0");
     }
 
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(sysVolts);
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_System_Voltage, PROP_PRESENT_VALUE,
-                                &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
+  setAnalogValue(AV_System_Voltage, sysVolts);
 }
 
-bool E50HX::writeDisplayUnits(DISP_UNITS_T dispUnits)
+void E50HX::writeDisplayUnits(DISP_UNITS_T dispUnits)
 {
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(float(dispUnits));
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_Display_Units, PROP_PRESENT_VALUE,
-                                &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
+  setAnalogValue(AV_Display_Units, dispUnits);
 }
 
-bool E50HX::writePhaseLossVT(float phaseLoss)
+void E50HX::writePhaseLossVT(float phaseLoss)
 {
   if (phaseLoss < 1.0 || phaseLoss > 99.0)
     {
@@ -519,26 +114,10 @@ bool E50HX::writePhaseLossVT(float phaseLoss)
                               + ": phaseLoss must be between 1.0-99.0");
     }
 
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(phaseLoss);
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_Phase_Loss_Voltage_Threshold,
-                                PROP_PRESENT_VALUE, &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
+  setAnalogValue(AV_Phase_Loss_Voltage_Threshold, phaseLoss);
 }
 
-bool E50HX::writePhaseLossIT(float phaseLoss)
+void E50HX::writePhaseLossIT(float phaseLoss)
 {
   if (phaseLoss < 1.0 || phaseLoss > 99.0)
     {
@@ -546,21 +125,5 @@ bool E50HX::writePhaseLossIT(float phaseLoss)
                               + ": phaseLoss must be between 1.0-99.0");
     }
 
-  // Write the value
-  BACNET_APPLICATION_DATA_VALUE myData =
-    m_instance->createDataReal(phaseLoss);
-
-  // write it
-  if (m_instance->writeProperty(m_targetDeviceObjectID, OBJECT_ANALOG_VALUE,
-                                AV_Phase_Loss_Imbalance_Threshold,
-                                PROP_PRESENT_VALUE, &myData))
-    {
-      // error occurred
-      if (m_debugging)
-        cerr << __FUNCTION__ << ": " << getAllErrorString() << endl;
-
-      return false;
-    }
-
-  return true;
+  setAnalogValue(AV_Phase_Loss_Imbalance_Threshold, phaseLoss);
 }

--- a/src/e50hx/e50hx.hpp
+++ b/src/e50hx/e50hx.hpp
@@ -27,6 +27,7 @@
 #include <map>
 
 #include "bacnetmstp.hpp"
+#include "bacnetutil.hpp"
 
 namespace upm {
 
@@ -81,7 +82,7 @@ namespace upm {
    * @snippet e50hx.cxx Interesting
    */
 
-  class E50HX {
+  class E50HX : public BACNETUTIL {
   public:
 
     // Supported Analog Value Objects.  These are readable and writable.
@@ -209,14 +210,6 @@ namespace upm {
       DISP_UNITS_IEEE               = 1  // IEEE display units
     } DISP_UNITS_T;
 
-    // Since none of the legal values returned by getAnalogValue() or
-    // getAnalogInput() will ever be negative, we use these two values
-    // to indicate either an error (BACnet or UPM), or to indicate
-    // that the value is unreliable if checkReliability() has been
-    // enabled.
-    const float RETURN_ERROR = -1.0;
-    const float RETURN_UNRELIABLE = -2.0;
-
     /**
      * E50HX constructor
      *
@@ -237,352 +230,92 @@ namespace upm {
     ~E50HX();
 
     /**
-     * This function initializes the underlying BACNETMSTP Master
-     * singleton in the event it has not already been initialized.  If
-     * the BACNETMSTP Master singleton has already been initialized,
-     * then this call will be ignored.
-     *
-     * @param port The serial port that the RS-485 interface is
-     * connected to.
-     * @param baudRate The baudrate of the RS-485 interface.  All
-     * devices on a BACnet RS-485 bus must run at the same baudrate.
-     * Valid values are 9600, 19200, 38400, 57600, 76800, and 115200.
-     * @param deviceInstanceNumber This is the unique Device Object
-     * Instance number that will be used for our BACnet Master in
-     * order to communicate over the BACnet interface.  This number
-     * must be between 1-4194302 and must be unique on the BACnet
-     * network.
-     * @param macAddr This is the MAC address of our BACnet Master.
-     * It must be unique on the BACnet segment, and must be between
-     * 1-127.
-     * @param maxMaster This specifies to our Master the maximum MAC
-     * address used by any other Masters on the BACnet network.  This
-     * must be between 1-127, the default is 127.  Do not change this
-     * unless you know what you are doing or you could introduce
-     * token passing errors on the BACnet network.
-     * @param maxInfoFrames This number specifies the maximum number
-     * of transmissions (like requests for data) our Master is allowed
-     * to make before passing the token to the next Master.  The
-     * default is 1.
-     */
-    void initMaster(std::string port, int baudRate, int deviceInstanceNumber,
-                    int macAddr, int maxMaster=DEFAULT_MAX_MASTER,
-                    int maxInfoFrames=1);
-
-    /**
-     * Enable some debugging output in this module as well as the
-     * BACNETMSTP module.  Debugging is disabled by default.
-     *
-     * @param enable true to enable, false to disable.
-     */
-    void setDebug(bool enable);
-
-    /**
-     * Retrieve the Present_Value property of an Analog Value object.
-     * If checkReliability() has been enabled, then the Reliability
-     * property of the object will be retrieved first.  If the
-     * Reliability property is anything other than
-     * RELIABILITY_NO_FAULT_DETECTED, then the RETURN_UNRELIABLE value
-     * will be returned.  Reliability checking is disabled by default
-     * for performance reasons.
-     *
-     * @param objInstance One of the ANALOG_VALUES_T values.
-     * @return the floating point value requested
-     */
-    float getAnalogValue(ANALOG_VALUES_T objInstance);
-
-    /**
-     * Retrieve the Present_Value property of an Analog Input object.
-     * If checkReliability() has been enabled, then the Reliability
-     * property of the object will be retrieved first.  If the
-     * Reliability property is anything other than
-     * RELIABILITY_NO_FAULT_DETECTED, then the RETURN_UNRELIABLE value
-     * will be returned.  Reliability checking is disabled by default
-     * for performance reasons.
-     *
-     * @param objInstance One of the ANALOG_INPUTS_T values.
-     * @return the floating point value requested
-     */
-    float getAnalogInput(ANALOG_INPUTS_T objInstance);
-
-    /**
      * Write one of several 'magic' numbers to the configuration
      * object (AV1).  This is used to clear certain counters, reset
-     * the accumulated Energy consumption values, etc.
+     * the accumulated Energy consumption values, etc.  This method
+     * will throw on error.
      *
      * @param config One of the CFG_VALUES_T values
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writeConfig(CFG_VALUES_T config);
+    void writeConfig(CFG_VALUES_T config);
 
     /**
      * Set the System Type of the device.  This defines the voltage
-     * lines you have connected.
+     * lines you have connected.  This method will throw on error.
      *
      * @param systype One of the SYSTEM_TYPES_T values.
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writeSystemType(SYSTEM_TYPES_T systype);
+    void writeSystemType(SYSTEM_TYPES_T systype);
 
     /**
-     * Set the Primary CT ratio.  See the datasheet for details.
+     * Set the Primary CT ratio.  See the datasheet for details.  This
+     * method will throw on error.
      *
      * @param ctRatio A floating point value between 5-32000
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writeCTRatioPrimary(float ctRatio);
+    void writeCTRatioPrimary(float ctRatio);
 
     /**
      * Set the Secondary CT ratio.  See the datasheet for details.
+     * This method will throw on error.
      *
      * @param ctRatio One of the CT_SECONDARY_T values.
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writeCTRatioSecondary(CT_SECONDARY_T ctRatio);
+    void writeCTRatioSecondary(CT_SECONDARY_T ctRatio);
 
     /**
-     * Set the PT ratio.  See the datasheet for details.
+     * Set the PT ratio.  See the datasheet for details.  This method
+     * will throw on error.
      *
      * @param ptRatio A floating point value between 0.01-320.0
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writePTRatio(float ptRatio);
+    void writePTRatio(float ptRatio);
 
     /**
-     * Set the System Voltage parmeter.  See the datasheet for details.
+     * Set the System Voltage parmeter.  See the datasheet for
+     * details.  This method will throw on error.
      *
      * @param sysVolts A floating point value between 82.0-32000.0
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writeSystemVoltage(float sysVolts);
+    void writeSystemVoltage(float sysVolts);
 
     /**
-     * Set the LCD Display Units in IEC or IEEE format.
+     * Set the LCD Display Units in IEC or IEEE format.  This method
+     * will throw on error.
      *
      * @param dispUnits One of the DISP_UNITS_T values.
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writeDisplayUnits(DISP_UNITS_T dispUnits);
+    void writeDisplayUnits(DISP_UNITS_T dispUnits);
 
     /**
      * Set the Phase Loss Voltage Threshold.  See the datasheet for
-     * details.
+     * details.  This method will throw on error.
      *
      * @param dispUnits A floating point value between 1.0-99.0
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writePhaseLossVT(float phaseLoss);
+    void writePhaseLossVT(float phaseLoss);
 
     /**
      * Set the Phase Loss Imbalance Threshold.  See the datasheet for
-     * details.
+     * details.  This method will throw on error.
      *
      * @param dispUnits A floating point value between 1.0-99.0
-     * @return true if the operation suceeded, false if there was an
-     * error.
      */
-    bool writePhaseLossIT(float phaseLoss);
-
-    /**
-     * Query an Analog Value object for the unit code, translate it
-     * into a string and cache the result for future use.  Return the
-     * BACnet text for the Unit enumeration.  Unit enumerations are
-     * things like 'kilowatt-hours', 'volts', etc.  For Objects which
-     * do not have a Units property defined for them, or for which
-     * Units has no meaning, 'no-units' will typically be returned and
-     * cached.
-     *
-     * @param objInstance One of the ANALOG_VALUES_T values.
-     * @return A string representing the Object's Unit property.
-     */
-    std::string getAnalogValueUnits(ANALOG_VALUES_T objInstance);
-
-    /**
-     * Query an Analog Input object for the unit code, translate it
-     * into a string and cache the result for future use.  Return the
-     * BACnet text for the Unit enumeration.  Unit enumerations are
-     * things like 'kilowatt-hours', 'volts', etc.  For Objects which
-     * do not have a Units property defined for them, or for which
-     * Units has no meaning, 'no-units' will typically be returned and
-     * cached.
-     *
-     * @param objInstance One of the ANALOG_INPUTS_T values.
-     * @return A string representing the Object's Unit property.
-     */
-    std::string getAnalogInputUnits(ANALOG_INPUTS_T objInstance);
+    void writePhaseLossIT(float phaseLoss);
 
     /**
      * Query the AI52 Object and return a bitmask of current Alarms.
      * Compare against ALARM_BITS_T to determine what conditions are
      * signaling an alarm.  Alarm conditions will clear on their own
-     * as soon as the cause is rectified.
+     * as soon as the cause is rectified.  This method will throw on
+     * error.
      *
      * @return A bitmask of values from ALARM_BITS_T indicating
      * current alarm conditions.
      */
     uint16_t getAlarmBits();
 
-    /**
-     * Enable or disable reliability checking.  By default, when using
-     * getAnalogValue() or getAnalogInput() the Present_Value property
-     * is returned.  There is also a property called Reliability that
-     * can be checked to ensure that the Present_Value property is
-     * currently valid.
-     *
-     * Enabling Reliability Checking has these functions check for a
-     * RELIABILITY_NO_FAULT_DETECTED value for the Reliability
-     * property before querying the Present_Value property.  If
-     * anything other than RELIABILITY_NO_FAULT_DETECTED is set, then
-     * these functions will return RETURN_UNRELIABLE rather than the
-     * Present_Value.
-     *
-     * This checking is disabled by default since it will double the
-     * number of queries needed to retrieve a given value.  However,
-     * if you need to ensure that the values returned are always
-     * completely valid as determined by the device firmware, you
-     * should enable this.
-     *
-     * @param enable true to check Reliability before returning a
-     * value, false otherwise.
-     */
-    void checkReliability(bool enable)
-    {
-      m_checkReliability = enable;
-    };
-
-    /**
-     * Query the Device Object of the device and return it's
-     * Description property.  This typically contains information like
-     * the Vendor, model and serial number of a device.
-     *
-     * @return A string containing the Device Object's Description property.
-     */
-    std::string getDescription();
-
-    /**
-     * Query the Device Object of the device and return it's Location
-     * property.  This typically contains a string indication a
-     * customer specific value.  Use setLocation() to change.
-     *
-     * @return A string containing the Device Object's Location property.
-     */
-    std::string getLocation();
-
-    /**
-     * Set the Device Object's Location property.  This must be a
-     * string containing no more than 63 characters.
-     *
-     * @return true if the operation succeeded, false otherwise
-     */
-    bool setLocation(std::string location);
-
-    /**
-     * This is a utility function that will return a string reporting
-     * on the various types of errors that can occur in BACnet
-     * operation.
-     *
-     * @return A string containing the last error message.
-     */
-    std::string getAllErrorString();
-
-    /**
-     * Return an enumration of the last error type to occur.  The
-     * value returned will be one of the BACNETMSTP::BACERR_TYPE_T
-     * values.
-     *
-     * @return The last error type to occur, one of the
-     * BACNETMSTP::BACERR_TYPE_T values.
-     */
-    BACNETMSTP::BACERR_TYPE_T getErrorType();
-
-    /**
-     * In the event of a BACnet Reject error, return the error code.
-     *
-     * @return The Reject error code.
-     */
-    uint8_t getRejectReason();
-
-    /**
-     * In the event of a BACnet Reject error, return the error string.
-     *
-     * @return The Reject error string.
-     */
-    std::string getRejectString();
-
-    /**
-     * In the event of a BACnet Abort error, return the Abort reason code.
-     *
-     * @return The Abort reason code.
-     */
-    uint8_t getAbortReason();
-
-    /**
-     * In the event of a BACnet Abort error, return the Abort string.
-     *
-     * @return The Abort error string.
-     */
-    std::string getAbortString();
-
-    /**
-     * In the event of a general BACnet error, return the BACnet error class.
-     *
-     * @return One of the BACNET_ERROR_CLASS error class codes
-     */
-    BACNET_ERROR_CLASS getErrorClass();
-
-    /**
-     * In the event of a general BACnet error, return the BACnet error code.
-     *
-     * @return One of the BACNET_ERROR_CODE error codes
-     */
-    BACNET_ERROR_CODE getErrorCode();
-
-    /**
-     * In the event of a general BACnet error, return the BACnet error
-     * string.
-     *
-     * @return A string representing the BACnet error class and code.
-     */
-    std::string getErrorString();
-
-    /**
-     * In the event of a non-BACnet UPM error, return a string
-     * describing the error.
-     *
-     * @return A string representing the UPM error.
-     */
-    std::string getUPMErrorString();
-
   protected:
-    // a copy of the BACNETMSTP singleton instance pointer
-    BACNETMSTP* m_instance;
-
-    // unique device object ID of e50hx
-    uint32_t m_targetDeviceObjectID;
-
-    // are we initialized?
-    bool m_initialized;
-
   private:
-    bool m_debugging;
-
-    // whether or not to verify reliability before reading a value.
-    bool m_checkReliability;
-
-    // Unit cache for AV
-    typedef std::map<ANALOG_VALUES_T, std::string> avCacheMap_t;
-    avCacheMap_t m_avUnitCache;
-
-    // Unit cache for AI
-    typedef std::map<ANALOG_INPUTS_T, std::string> aiCacheMap_t;
-    aiCacheMap_t m_aiUnitCache;
   };
 }

--- a/src/e50hx/javaupm_e50hx.i
+++ b/src/e50hx/javaupm_e50hx.i
@@ -1,10 +1,23 @@
 %module javaupm_e50hx
 %include "../upm.i"
 %include "typemaps.i"
+%include "carrays_uint32_t.i"
+
+// We need to use this method for enum wrapping since the enum typedefs used
+// by the derived classes (like ANALOG_VALUES_T) are passed to methods
+// in the base class which expect a uint32_t.  This is fine, and
+// works everywhere except Java.  It's type safety is a little too
+// stringent in these cases.  %javaconst(1) is generally recommended
+// as it avoids JNI calls to determine the enumerant values at
+// runtime.
+%include "enumtypeunsafe.swg"
+%javaconst(1);
 
 %include "bacnetmstp.hpp"
+%include "bacnetutil.hpp"
 %include "e50hx.hpp"
 %{
+    #include "bacnetutil.hpp"
     #include "e50hx.hpp"
 %}
 

--- a/src/e50hx/jsupm_e50hx.i
+++ b/src/e50hx/jsupm_e50hx.i
@@ -3,6 +3,7 @@
 %include "stdint.i"
 
 %include "bacnetmstp.hpp"
+%include "bacnetutil.hpp"
 %include "e50hx.hpp"
 %{
     #include "e50hx.hpp"

--- a/src/e50hx/pyupm_e50hx.i
+++ b/src/e50hx/pyupm_e50hx.i
@@ -7,6 +7,7 @@
 %feature("autodoc", "3");
 
 %include "bacnetmstp.hpp"
+%include "bacnetutil.hpp"
 %include "e50hx.hpp"
 %{
     #include "e50hx.hpp"


### PR DESCRIPTION
This commit removes functionality that is now present in the
bacnetutil class.  This simplifies the driver considerably.  The
examples were modified to reflect the renaming of some utility
functions in bacnetutil.

This PR requires that PR #428 be merged first.  CI will fail on this PR.

Signed-off-by: Jon Trulson <jtrulson@ics.com>