### PR TITLE
apds9930: enable sensor before read out sensor data

### DIFF
--- a/examples/c++/apds9930.cxx
+++ b/examples/c++/apds9930.cxx
@@ -1,6 +1,6 @@
 /*
  * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
- * Copyright (c) 2015 Intel Corporation.
+ * Copyright (c) 2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -46,6 +46,15 @@ main()
     // Instantiate a Digital Proximity and Ambient Light sensor on iio device 4
     upm::APDS9930* light_proximity = new upm::APDS9930(4);
 
+    // Kernel driver implement sleep 5000-5100us after enable illuminance sensor
+    light_proximity->enableIlluminance(true);
+
+    // Kernel driver implement sleep 5000-5100us after enable proximity sensor
+    light_proximity->enableProximity(true);
+
+    // Tested this value works. Please change it on your platform
+    usleep(120000);
+
     while (shouldRun) {
         float lux = light_proximity->getAmbient();
         cout << "Luminance value is " << lux << endl;
@@ -53,6 +62,8 @@ main()
         cout << "Proximity value is " << proximity << endl;
         sleep(1);
     }
+    light_proximity->enableProximity(false);
+    light_proximity->enableIlluminance(false);
     //! [Interesting]
 
     cout << "Exiting" << endl;

--- a/src/apds9930/apds9930.cxx
+++ b/src/apds9930/apds9930.cxx
@@ -1,6 +1,6 @@
 /*
  * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
- * Copyright (c) 2015 Intel Corporation.
+ * Copyright (c) 2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -41,7 +41,7 @@ APDS9930::APDS9930(int device)
 
 APDS9930::~APDS9930()
 {
-    if(m_iio)
+    if (m_iio)
         mraa_iio_close(m_iio);
 }
 
@@ -59,4 +59,26 @@ APDS9930::getProximity()
     int iio_value = 0;
     mraa_iio_read_int(m_iio, "in_proximity_raw", &iio_value);
     return iio_value;
+}
+
+bool
+APDS9930::enableProximity(bool enable)
+{
+    if (enable)
+        mraa_iio_write_int(m_iio, "in_proximity_en", 1);
+    else
+        mraa_iio_write_int(m_iio, "in_proximity_en", 0);
+
+    return true;
+}
+
+bool
+APDS9930::enableIlluminance(bool enable)
+{
+    if (enable)
+        mraa_iio_write_int(m_iio, "in_illuminance_en", 1);
+    else
+        mraa_iio_write_int(m_iio, "in_illuminance_en", 0);
+
+    return true;
 }

--- a/src/apds9930/apds9930.hpp
+++ b/src/apds9930/apds9930.hpp
@@ -1,6 +1,6 @@
 /*
  * Author: Lay, Kuan Loon <kuan.loon.lay@intel.com>
- * Copyright (c) 2015 Intel Corporation.
+ * Copyright (c) 2016 Intel Corporation.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -75,6 +75,16 @@ class APDS9930
      * @return Proximity value
      */
     int getProximity();
+    /**
+     * Enable proximity
+     * @param enable state
+     */
+    bool enableProximity(bool enable);
+    /**
+     * Enable illuminance
+     * @param enable state
+     */
+    bool enableIlluminance(bool enable);
 
   private:
     mraa_iio_context m_iio;


### PR DESCRIPTION
Changes in library:
- enableProximity() function is to enable or disable proximity sensor
- enableIlluminance() function is to enable or disable illuminance sensor
- run clang-format

Changes in example:
- proximity and illuminance kernel IIO-based driver init state is power off,
  require enable before read out sensor data. Sleep time is needed after
  enable, the sleep time may vary on different platform.
- run clang-format

Signed-off-by: Lay, Kuan Loon <kuan.loon.lay@intel.com>