### PR TITLE
ublox6: Add most popular baud rates to GPS param constants

### DIFF
--- a/src/ublox6/javaupm_ublox6.i
+++ b/src/ublox6/javaupm_ublox6.i
@@ -4,11 +4,19 @@
 
 %{
     #include "ublox6.hpp"
+    speed_t int_B2400 = B2400;
+    speed_t int_B4800 = B4800;
     speed_t int_B9600 = B9600;
+    speed_t int_B19200 = B19200;
+    speed_t int_B38400 = B38400;
 %}
 
 %include "ublox6.hpp"
+speed_t int_B2400 = B2400;
+speed_t int_B4800 = B4800;
 speed_t int_B9600 = B9600;
+speed_t int_B19200 = B19200;
+speed_t int_B38400 = B38400;
 
 %pragma(java) jniclasscode=%{
     static {

--- a/src/ublox6/jsupm_ublox6.i
+++ b/src/ublox6/jsupm_ublox6.i
@@ -5,9 +5,17 @@
 
 %{
     #include "ublox6.hpp"
+    speed_t int_B2400 = B2400;
+    speed_t int_B4800 = B4800;
     speed_t int_B9600 = B9600;
+    speed_t int_B19200 = B19200;
+    speed_t int_B38400 = B38400;
 %}
 
 %include "ublox6.hpp"
+speed_t int_B2400 = B2400;
+speed_t int_B4800 = B4800;
 speed_t int_B9600 = B9600;
+speed_t int_B19200 = B19200;
+speed_t int_B38400 = B38400;
 %array_class(char, charArray);

--- a/src/ublox6/pyupm_ublox6.i
+++ b/src/ublox6/pyupm_ublox6.i
@@ -9,9 +9,17 @@
 
 %{
     #include "ublox6.hpp"
+    speed_t int_B2400 = B2400;
+    speed_t int_B4800 = B4800;
     speed_t int_B9600 = B9600;
+    speed_t int_B19200 = B19200;
+    speed_t int_B38400 = B38400;
 %}
 
 %include "ublox6.hpp"
+speed_t int_B2400 = B2400;
+speed_t int_B4800 = B4800;
 speed_t int_B9600 = B9600;
+speed_t int_B19200 = B19200;
+speed_t int_B38400 = B38400;
 %array_class(char, charArray);


### PR DESCRIPTION
Adds the most common baud rates (2400, 4800, 19200, & 38400) to the GPS param constants, since this is needed to use any GPS with a baud rate other than B9600, which previously was the only allowed value.