### PR TITLE
modbus: Add version check to modules using modbus

### DIFF
--- a/src/h803x/CMakeLists.txt
+++ b/src/h803x/CMakeLists.txt
@@ -4,7 +4,7 @@ set (module_src ${libname}.cxx)
 set (module_hpp ${libname}.hpp)
 
 pkg_check_modules(MODBUS libmodbus)
-if (MODBUS_FOUND)
+if (MODBUS_FOUND AND (NOT (MODBUS_VERSION LESS 3.1.2)))
   set (reqlibname "libmodbus")
   include_directories(${MODBUS_INCLUDE_DIRS})
   upm_module_init()

--- a/src/hwxpxx/CMakeLists.txt
+++ b/src/hwxpxx/CMakeLists.txt
@@ -4,7 +4,7 @@ set (module_src ${libname}.cxx)
 set (module_hpp ${libname}.hpp)
 
 pkg_check_modules(MODBUS libmodbus)
-if (MODBUS_FOUND)
+if (MODBUS_FOUND AND (NOT (MODBUS_VERSION LESS 3.1.2)))
   set (reqlibname "libmodbus")
   include_directories(${MODBUS_INCLUDE_DIRS})
   upm_module_init()


### PR DESCRIPTION
Only adds the check to modules that require
MODBUS_MAX_PDU_LENGTH which was added in libmodbus
versions greater than 3.1.2

Signed-off-by: Thomas Ingleby <thomas.ingleby@intel.com>