### PR TITLE
python: Added upm directory for python modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ env:
   global:
     - MRAA_ROOT=/tmp/mraa
     - MRAA_BUILD=$MRAA_ROOT/build
-    - MRAA_INSTALL=$MRAA_ROOT/install
     - UPM_ROOT=$TRAVIS_BUILD_DIR
     - UPM_BUILD=$UPM_ROOT/build
-    - UPM_INSTALL=$UPM_ROOT/install
     - JAVA_HOME=/usr/lib/jvm/java-8-oracle
   matrix:
     - NODE010=true
@@ -31,12 +29,18 @@ before_script:
   # Handle 0.10 NODE_ROOT_DIR differently than other versions
   - if [ -z ${NODE010} ]; then export NODE_ROOT_DIR="/home/travis/.nvm/versions/node/`nvm version`"; else export NODE_ROOT_DIR=/home/travis/.nvm/v0.10.36; fi
 script:
+  # Build/install MRAA
   - echo "CC=$CC BUILDJAVA=$BUILDJAVA NODE010=$NODE010 NODE012=$NODE012 NODE4=$NODE4 NODE5=$NODE5 NODE_ROOT_DIR=$NODE_ROOT_DIR"
   - git clone https://github.com/intel-iot-devkit/mraa.git $MRAA_ROOT
-  - mkdir -p $MRAA_BUILD && cd $_ && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=ON -DFIRMATA=ON -DENABLEEXAMPLES=OFF -DCMAKE_INSTALL_PREFIX:PATH=$MRAA_INSTALL $MRAA_ROOT && make install
-  - cd $UPM_ROOT && mkdir $UPM_BUILD && cd $_ && PKG_CONFIG_PATH=$MRAA_INSTALL/lib/pkgconfig cmake -DNODE_ROOT_DIR:PATH="${NODE_ROOT_DIR}" -DBUILDSWIGJAVA=$BUILDJAVA -DBUILDEXAMPLES=ON -DBUILDJAVAEXAMPLES=$BUILDJAVA -DBUILDTESTS=ON -DCMAKE_INSTALL_PREFIX:PATH=$UPM_INSTALL ..
-  - make install
-  - LD_LIBRARY_PATH=$MRAA_INSTALL/lib:$UPM_INSTALL/lib:$LD_LIBRARY_PATH PYTHONPATH=$UPM_INSTALL/lib/python2.7/site-packages/:$MRAA_INSTALL/lib/python2.7/dist-packages/ ctest --output-on-failure -E examplenames_js
+  - mkdir -p $MRAA_BUILD && cd $_ && cmake -DBUILDSWIGJAVA=$BUILDJAVA -DBUILDSWIGNODE=OFF -DBUILDSWIGPYTHON=ON -DFIRMATA=ON -DENABLEEXAMPLES=OFF $MRAA_ROOT
+  - sudo make install
+  - sudo ldconfig
+  # Build/install UPM
+  - cd $UPM_ROOT && mkdir $UPM_BUILD && cd $_ && cmake -DNODE_ROOT_DIR:PATH="${NODE_ROOT_DIR}" -DBUILDSWIGJAVA=$BUILDJAVA -DBUILDEXAMPLES=ON -DBUILDJAVAEXAMPLES=$BUILDJAVA -DBUILDTESTS=ON ..
+  - sudo make install
+  - sudo ldconfig
+  # Run UPM ctests
+  - ctest --output-on-failure -E examplenames_js
 addons:
   apt:
     sources:

--- a/examples/python/a110x.py
+++ b/examples/python/a110x.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_a110x as upmA110x
+from upm import pyupm_a110x as upmA110x
 
 def main():
     # Instantiate a Hall Effect magnet sensor on digital pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myHallEffectSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,9 +45,9 @@ def main():
 
     while(1):
         if (myHallEffectSensor.magnetDetected()):
-            print "Magnet (south polarity) detected."
+            print("Magnet (south polarity) detected.")
         else:
-            print "No magnet detected."
+            print("No magnet detected.")
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/ad8232.py
+++ b/examples/python/ad8232.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ad8232 as upmAD8232
+from upm import pyupm_ad8232 as upmAD8232
 
 def main():
     # Instantiate a AD8232 sensor on digital pins 10 (LO+), 11 (LO-)
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myAD8232
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -49,7 +50,7 @@ def main():
     # (https://www.processing.org/) to plot the data just like an
     # EKG you would see in a hospital.
     while(1):
-        print myAD8232.value()
+        print(myAD8232.value())
         time.sleep(.001)
 
 if __name__ == '__main__':

--- a/examples/python/adafruitms1438-stepper.py
+++ b/examples/python/adafruitms1438-stepper.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_adafruitms1438 as upmAdafruitms1438
+from upm import pyupm_adafruitms1438 as upmAdafruitms1438
 
 def main():
     # Import header values
@@ -45,7 +46,7 @@ def main():
     # including functions from myMotorShield
     def exitHandler():
         myMotorShield.disableStepper(M12Motor)
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -67,20 +68,20 @@ def main():
     myMotorShield.setStepperDirection(M12Motor, MotorDirCW)
 
     # enable
-    print "Enabling..."
+    print("Enabling...")
     myMotorShield.enableStepper(M12Motor)
 
-    print "Rotating 1 full revolution at 10 RPM speed."
+    print("Rotating 1 full revolution at 10 RPM speed.")
     myMotorShield.stepperSteps(M12Motor, 200)
 
-    print "Sleeping for 2 seconds..."
+    print("Sleeping for 2 seconds...")
     time.sleep(2)
-    print "Rotating 1/2 revolution in opposite direction at 10 RPM speed."
+    print("Rotating 1/2 revolution in opposite direction at 10 RPM speed.")
 
     myMotorShield.setStepperDirection(M12Motor, MotorDirCCW)
     myMotorShield.stepperSteps(M12Motor, 100)
 
-    print "Disabling..."
+    print("Disabling...")
 
     # exitHandler runs automatically
 

--- a/examples/python/adafruitms1438.py
+++ b/examples/python/adafruitms1438.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_adafruitms1438 as upmAdafruitms1438
+from upm import pyupm_adafruitms1438 as upmAdafruitms1438
 
 def main():
     # Import header values
@@ -45,7 +46,7 @@ def main():
     # including functions from myMotorShield
     def exitHandler():
         myMotorShield.disableMotor(M3Motor)
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -70,12 +71,12 @@ def main():
 
     time.sleep(3)
 
-    print "Reversing M3"
+    print("Reversing M3")
     myMotorShield.setMotorDirection(M3Motor, MotorDirCCW)
 
     time.sleep(3)
 
-    print "Stopping M3"
+    print("Stopping M3")
 
     # exitHandler runs automatically
 

--- a/examples/python/adc121c021.py
+++ b/examples/python/adc121c021.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_adc121c021 as upmAdc121c021
+from upm import pyupm_adc121c021 as upmAdc121c021
 
 def main():
     # Instantiate an ADC121C021 on I2C bus 0
@@ -39,7 +40,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myAnalogDigitalConv
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -50,7 +51,7 @@ def main():
     while(1):
         val = myAnalogDigitalConv.value()
         voltsVal = myAnalogDigitalConv.valueToVolts(val)
-        print "ADC value: %s Volts = %s" % (val, voltsVal)
+        print("ADC value: %s Volts = %s" % (val, voltsVal))
         time.sleep(.05)
 
 if __name__ == '__main__':

--- a/examples/python/adxl335.py
+++ b/examples/python/adxl335.py
@@ -21,14 +21,15 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_adxl335 as upmAdxl335
+from upm import pyupm_adxl335 as upmAdxl335
 
 def main():
     myAnalogAccel = upmAdxl335.ADXL335(0, 1, 2)
 
-    print "Please make sure the sensor is completely still."
-    print "Sleeping for 2 seconds"
+    print("Please make sure the sensor is completely still.")
+    print("Sleeping for 2 seconds")
     time.sleep(2)
 
     ## Exit handlers ##
@@ -39,14 +40,14 @@ def main():
     # This function lets you run code on exit,
     # including functions from myAnalogAccel
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Calibrating..."
+    print("Calibrating...")
     myAnalogAccel.calibrate()
 
     x = upmAdxl335.new_intPointer()
@@ -62,7 +63,7 @@ def main():
         outputStr = "Raw Values: X: {0} Y: {1} Z: {2}".format(
         upmAdxl335.intPointer_value(x), upmAdxl335.intPointer_value(y),
         upmAdxl335.intPointer_value(z))
-        print outputStr
+        print(outputStr)
 
         myAnalogAccel.acceleration(aX, aY, aZ)
         outputStr = ("Acceleration: X: {0}g\n"
@@ -70,9 +71,9 @@ def main():
         "Acceleration: Z: {2}g").format(upmAdxl335.floatPointer_value(aX),
         upmAdxl335.floatPointer_value(aY),
         upmAdxl335.floatPointer_value(aZ))
-        print outputStr
+        print(outputStr)
 
-        print " "
+        print(" ")
 
         time.sleep(.2)
 

--- a/examples/python/adxl345.py
+++ b/examples/python/adxl345.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
-import pyupm_adxl345 as adxl345
+from upm import pyupm_adxl345 as adxl345
 
 def main():
     # Create an I2C accelerometer object
@@ -32,10 +33,10 @@ def main():
         adxl.update() # Update the data
         raw = adxl.getRawValues() # Read raw sensor data
         force = adxl.getAcceleration() # Read acceleration force (g)
-        print "Raw: %6d %6d %6d" % (raw[0], raw[1], raw[2])
-        print "ForceX: %5.2f g" % (force[0])
-        print "ForceY: %5.2f g" % (force[1])
-        print "ForceZ: %5.2f g\n" % (force[2])
+        print("Raw: %6d %6d %6d" % (raw[0], raw[1], raw[2]))
+        print("ForceX: %5.2f g" % (force[0]))
+        print("ForceY: %5.2f g" % (force[1]))
+        print("ForceZ: %5.2f g\n" % (force[2]))
 
         # Sleep for 1 s
         sleep(1)

--- a/examples/python/adxrs610.py
+++ b/examples/python/adxrs610.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_adxrs610 as sensorObj
+from upm import pyupm_adxrs610 as sensorObj
 
 def main():
     # Instantiate a ADXRS610 sensor on analog pin A0 (dataout), and
@@ -37,7 +38,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,8 +52,8 @@ def main():
     # corresponding temperature and angular velocity
 
     while (1):
-        print "Vel (deg/s):", sensor.getAngularVelocity()
-        print "Temp (C):", sensor.getTemperature()
+        print("Vel (deg/s):", sensor.getAngularVelocity())
+        print("Temp (C):", sensor.getTemperature())
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/aeotecdsb09104.py
+++ b/examples/python/aeotecdsb09104.py
@@ -21,13 +21,14 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ozw as sensorObj
+from upm import pyupm_ozw as sensorObj
 
 def main():
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -36,7 +37,7 @@ def main():
     defaultDev = "/dev/ttyACM0"
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
-    print "Using device", defaultDev
+    print("Using device", defaultDev)
 
     # Instantiate an Aeotec DSB09104 instance, on device node 12.  You
     # will almost certainly need to change this to reflect your own
@@ -48,25 +49,25 @@ def main():
     sensor.optionsLock()
 
     # Next, initialize it.
-    print "Initializing, this may take awhile depending on your ZWave network"
+    print("Initializing, this may take awhile depending on your ZWave network")
 
     sensor.init(defaultDev)
-    print "Initialization complete"
+    print("Initialization complete")
 
-    print "Querying data..."
+    print("Querying data...")
 
     while (True):
         sensor.update()
 
-        print "Watts, Channel 1: %0.03f W" % sensor.getWattsC1()
-        print "Watts, Channel 2: %0.03f W" % sensor.getWattsC2()
-        print "Watts, Channel 3: %0.03f W" % sensor.getWattsC3()
+        print("Watts, Channel 1: %0.03f W" % sensor.getWattsC1())
+        print("Watts, Channel 2: %0.03f W" % sensor.getWattsC2())
+        print("Watts, Channel 3: %0.03f W" % sensor.getWattsC3())
 
-        print "Energy, Channel 1: %0.03f kWh" % sensor.getEnergyC1()
-        print "Energy, Channel 2: %0.03f kWh" % sensor.getEnergyC2()
-        print "Energy, Channel 3: %0.03f kWh" % sensor.getEnergyC3()
+        print("Energy, Channel 1: %0.03f kWh" % sensor.getEnergyC1())
+        print("Energy, Channel 2: %0.03f kWh" % sensor.getEnergyC2())
+        print("Energy, Channel 3: %0.03f kWh" % sensor.getEnergyC3())
 
-        print "Battery Level: %d\n" % sensor.getBatteryLevel()
+        print("Battery Level: %d\n" % sensor.getBatteryLevel())
         time.sleep(3)
 
 if __name__ == '__main__':

--- a/examples/python/aeotecdw2e.py
+++ b/examples/python/aeotecdw2e.py
@@ -21,13 +21,14 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ozw as sensorObj
+from upm import pyupm_ozw as sensorObj
 
 def main():
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -36,7 +37,7 @@ def main():
     defaultDev = "/dev/ttyACM0"
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
-    print "Using device", defaultDev
+    print("Using device", defaultDev)
 
     # Instantiate an Aeotec Door/Window 2nd Edition sensor instance, on
     # device node 10.  You will almost certainly need to change this to
@@ -49,32 +50,32 @@ def main():
     sensor.optionsLock()
 
     # Next, initialize it.
-    print "Initializing, this may take awhile depending on your ZWave network"
+    print("Initializing, this may take awhile depending on your ZWave network")
 
     sensor.init(defaultDev)
-    print "Initialization complete"
+    print("Initialization complete")
 
-    print "Querying data..."
+    print("Querying data...")
 
     while (True):
         if (sensor.isDeviceAvailable()):
-            print "Alarm status:",
-            print sensor.isAlarmTripped()
+            print("Alarm status:", end=' ')
+            print(sensor.isAlarmTripped())
 
-            print "Tamper Switch status:",
-            print sensor.isTamperTripped()
+            print("Tamper Switch status:", end=' ')
+            print(sensor.isTamperTripped())
 
-            print "Battery Level:",
-            print sensor.getBatteryLevel(),
-            print "%"
+            print("Battery Level:", end=' ')
+            print(sensor.getBatteryLevel(), end=' ')
+            print("%")
 
-            print
+            print()
         else:
-            print "Device has not yet responded to probe."
-            print "Try waking it, or wait until it wakes itself if ",
-            print "configured to do so."
+            print("Device has not yet responded to probe.")
+            print("Try waking it, or wait until it wakes itself if ", end=' ')
+            print("configured to do so.")
 
-            print
+            print()
 
         time.sleep(1)
 

--- a/examples/python/aeotecsdg2.py
+++ b/examples/python/aeotecsdg2.py
@@ -21,16 +21,17 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ozw as sensorObj
+from upm import pyupm_ozw as sensorObj
 
 def main():
     # This function lets you run code on exit
     def exitHandler():
-        print "Turning switch off and sleeping for 5 seconds..."
+        print("Turning switch off and sleeping for 5 seconds...")
         sensor.off()
         time.sleep(5)
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -39,7 +40,7 @@ def main():
     defaultDev = "/dev/ttyACM0"
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
-    print "Using device", defaultDev
+    print("Using device", defaultDev)
 
     # Instantiate an Aeotec Smart Dimmer Gen2 instance, on device node
     # 9.  You will almost certainly need to change this to reflect your
@@ -52,17 +53,17 @@ def main():
     sensor.optionsLock()
 
     # Next, initialize it.
-    print "Initializing, this may take awhile depending on your ZWave network"
+    print("Initializing, this may take awhile depending on your ZWave network")
 
     sensor.init(defaultDev)
-    print "Initialization complete"
+    print("Initialization complete")
 
     # turn light on
-    print "Turning switch on, then sleeping for 5 secs"
+    print("Turning switch on, then sleeping for 5 secs")
     sensor.on();
     time.sleep(5);
 
-    print "Querying data..."
+    print("Querying data...")
     dim = False;
     while (True):
         # put on a light show...
@@ -75,25 +76,25 @@ def main():
 
         sensor.update()
 
-        print "Current Level:",
-        print sensor.getLevel()
+        print("Current Level:", end=' ')
+        print(sensor.getLevel())
 
-        print "Volts:",
-        print sensor.getVolts(),
-        print "volts"
+        print("Volts:", end=' ')
+        print(sensor.getVolts(), end=' ')
+        print("volts")
 
-        print "Energy Consumption:",
-        print sensor.getEnergy(),
-        print "kWh"
+        print("Energy Consumption:", end=' ')
+        print(sensor.getEnergy(), end=' ')
+        print("kWh")
 
-        print "Watts:",
-        print sensor.getWatts()
+        print("Watts:", end=' ')
+        print(sensor.getWatts())
 
-        print "Current:",
-        print sensor.getCurrent(),
-        print "amps"
+        print("Current:", end=' ')
+        print(sensor.getCurrent(), end=' ')
+        print("amps")
 
-        print
+        print()
         time.sleep(5)
 
 if __name__ == '__main__':

--- a/examples/python/aeotecss6.py
+++ b/examples/python/aeotecss6.py
@@ -21,16 +21,17 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ozw as sensorObj
+from upm import pyupm_ozw as sensorObj
 
 def main():
     # This function lets you run code on exit
     def exitHandler():
-        print "Turning switch off and sleeping for 5 seconds..."
+        print("Turning switch off and sleeping for 5 seconds...")
         sensor.off()
         time.sleep(5)
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -39,7 +40,7 @@ def main():
     defaultDev = "/dev/ttyACM0"
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
-    print "Using device", defaultDev
+    print("Using device", defaultDev)
 
     # Instantiate an Aeotec Smart Switch 6 instance, on device node 11.
     # You will almost certainly need to change this to reflect your own
@@ -51,40 +52,40 @@ def main():
     sensor.optionsLock()
 
     # Next, initialize it.
-    print "Initializing, this may take awhile depending on your ZWave network"
+    print("Initializing, this may take awhile depending on your ZWave network")
 
     sensor.init(defaultDev)
-    print "Initialization complete"
+    print("Initialization complete")
 
     # turn light on
-    print "Turning switch on, then sleeping for 5 secs"
+    print("Turning switch on, then sleeping for 5 secs")
     sensor.on();
     time.sleep(5);
 
-    print "Querying data..."
+    print("Querying data...")
 
     while (True):
         sensor.update()
 
-        print "Switch status:",
-        print sensor.isOn()
+        print("Switch status:", end=' ')
+        print(sensor.isOn())
 
-        print "Volts:",
-        print sensor.getVolts(),
-        print "volts"
+        print("Volts:", end=' ')
+        print(sensor.getVolts(), end=' ')
+        print("volts")
 
-        print "Energy Consumption:",
-        print sensor.getEnergy(),
-        print "kWh"
+        print("Energy Consumption:", end=' ')
+        print(sensor.getEnergy(), end=' ')
+        print("kWh")
 
-        print "Watts:",
-        print sensor.getWatts()
+        print("Watts:", end=' ')
+        print(sensor.getWatts())
 
-        print "Current:",
-        print sensor.getCurrent(),
-        print "amps"
+        print("Current:", end=' ')
+        print(sensor.getCurrent(), end=' ')
+        print("amps")
 
-        print
+        print()
         time.sleep(3)
 
 if __name__ == '__main__':

--- a/examples/python/ak8975.py
+++ b/examples/python/ak8975.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mpu9150 as sensorObj
+from upm import pyupm_mpu9150 as sensorObj
 
 def main():
     # Instantiate an AK8975 on I2C bus 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,11 +52,11 @@ def main():
     while (1):
         sensor.update()
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer:  MX: ", sensorObj.floatp_value(x),
-        print " MY: ", sensorObj.floatp_value(y),
-        print " MZ: ", sensorObj.floatp_value(z)
+        print("Magnetometer:  MX: ", sensorObj.floatp_value(x), end=' ')
+        print(" MY: ", sensorObj.floatp_value(y), end=' ')
+        print(" MZ: ", sensorObj.floatp_value(z))
 
-        print
+        print()
 
         time.sleep(.5)
 

--- a/examples/python/apa102.py
+++ b/examples/python/apa102.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_apa102 as mylib
+from upm import pyupm_apa102 as mylib
 
 def main():
     # Instantiate a strip of 30 LEDs on SPI bus 0
@@ -36,13 +37,13 @@ def main():
     # Register exit handlers
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Setting all LEDs to Green"
+    print("Setting all LEDs to Green")
     ledStrip.setAllLeds(31, 0, 255, 0)
 
-    print "Setting LEDs between 10 and 20 to Red"
+    print("Setting LEDs between 10 and 20 to Red")
     ledStrip.setLeds(10, 20, 31, 255, 0, 0)
 
-    print "Setting LED 15 to Blue"
+    print("Setting LED 15 to Blue")
     ledStrip.setLed(15, 31, 0, 0, 255)
 
 if __name__ == '__main__':

--- a/examples/python/apds9002.py
+++ b/examples/python/apds9002.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_apds9002 as upmApds9002
+from upm import pyupm_apds9002 as upmApds9002
 
 def main():
     # Instantiate a Grove Luminance sensor on analog pin A0
@@ -35,7 +36,7 @@ def main():
 
     # This lets you run code on exit, including functions from myLuminance
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -43,8 +44,8 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     while(1):
-        print "Luminance value is {0}".format(
-        myLuminance.value())
+        print("Luminance value is {0}".format(
+        myLuminance.value()))
 
         time.sleep(1)
 

--- a/examples/python/at42qt1070.py
+++ b/examples/python/at42qt1070.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_at42qt1070 as upmAt42qt1070
+from upm import pyupm_at42qt1070 as upmAt42qt1070
 
 def main():
     # functions
@@ -39,13 +40,13 @@ def main():
         if (not buttonPressed):
             sys.stdout.write("None")
 
-        print " "
+        print(" ")
 
         if (touchObj.isCalibrating()):
-            print "Calibration is occurring."
+            print("Calibration is occurring.")
 
         if (touchObj.isOverflowed()):
-            print "Overflow was detected."
+            print("Overflow was detected.")
 
     # Global code that runs on startup
 
@@ -61,7 +62,7 @@ def main():
         raise SystemExit
 
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # This function lets you run code on exit, including functions from myTouchSensor

--- a/examples/python/bh1750.py
+++ b/examples/python/bh1750.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bh1750 as sensorObj
+from upm import pyupm_bh1750 as sensorObj
 
 def main():
     # Instantiate a BH1750 sensor using defaults (I2C bus (0), using
@@ -37,7 +38,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,7 +48,7 @@ def main():
     # Every second, sample the BH1750 and output the measured lux value
 
     while (True):
-        print "Detected Light Level (lux):", sensor.getLux()
+        print("Detected Light Level (lux):", sensor.getLux())
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/biss0001.py
+++ b/examples/python/biss0001.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_biss0001 as upmMotion
+from upm import pyupm_biss0001 as upmMotion
 
 def main():
     # Instantiate a Grove Motion sensor on GPIO pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myMotion
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,9 +46,9 @@ def main():
     # Read the value every second and detect motion
     while(1):
         if (myMotion.value()):
-            print "Detecting moving object"
+            print("Detecting moving object")
         else:
-            print "No moving objects detected"
+            print("No moving objects detected")
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/bma220.py
+++ b/examples/python/bma220.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bma220 as sensorObj
+from upm import pyupm_bma220 as sensorObj
 
 def main():
     # Instantiate an BMA220 using default parameters (bus 0, addr 0x0a)
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -49,9 +50,9 @@ def main():
     while (1):
         sensor.update()
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer: AX:", sensorObj.floatp_value(x),
-        print " AY:", sensorObj.floatp_value(y),
-        print " AZ:", sensorObj.floatp_value(z)
+        print("Accelerometer: AX:", sensorObj.floatp_value(x), end=' ')
+        print(" AY:", sensorObj.floatp_value(y), end=' ')
+        print(" AZ:", sensorObj.floatp_value(z))
 
         time.sleep(.5)
 

--- a/examples/python/bma250e.py
+++ b/examples/python/bma250e.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmx055 as sensorObj
+from upm import pyupm_bmx055 as sensorObj
 
 def main():
     # Instantiate a BMP250E instance using default i2c bus and address
@@ -38,7 +39,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -54,16 +55,16 @@ def main():
         sensor.update()
 
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " g"
+        print("Accelerometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" g")
 
         # we show both C and F for temperature
-        print "Compensation Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Compensation Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print
+        print()
         time.sleep(.250)
 
 if __name__ == '__main__':

--- a/examples/python/bmc150.py
+++ b/examples/python/bmc150.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmx055 as sensorObj
+from upm import pyupm_bmx055 as sensorObj
 
 def main():
     # Instantiate a BMC150 instance using default i2c bus and address
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,18 +52,18 @@ def main():
         sensor.update()
 
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " g"
+        print("Accelerometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" g")
 
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " uT"
+        print("Magnetometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" uT")
 
-        print
+        print()
         time.sleep(.250)
 
 if __name__ == '__main__':

--- a/examples/python/bme280.py
+++ b/examples/python/bme280.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmp280 as sensorObj
+from upm import pyupm_bmp280 as sensorObj
 
 def main():
     # Instantiate a BME280 instance using default i2c bus and address
@@ -38,7 +39,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -48,16 +49,16 @@ def main():
     while (1):
         sensor.update()
 
-        print "Compensation Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Compensation Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Pressure: ", sensor.getPressure(), "Pa"
+        print("Pressure: ", sensor.getPressure(), "Pa")
 
-        print "Computed Altitude:", sensor.getAltitude(), "m"
+        print("Computed Altitude:", sensor.getAltitude(), "m")
 
-        print "Humidity:", sensor.getHumidity(), "%RH"
+        print("Humidity:", sensor.getHumidity(), "%RH")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/bmg160.py
+++ b/examples/python/bmg160.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmx055 as sensorObj
+from upm import pyupm_bmx055 as sensorObj
 
 def main():
     # Instantiate a BMP250E instance using default i2c bus and address
@@ -38,7 +39,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -54,16 +55,16 @@ def main():
         sensor.update()
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " degrees/s"
+        print("Gyroscope x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" degrees/s")
 
         # we show both C and F for temperature
-        print "Compensation Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Compensation Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print
+        print()
         time.sleep(.250)
 
 if __name__ == '__main__':

--- a/examples/python/bmi055.py
+++ b/examples/python/bmi055.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmx055 as sensorObj
+from upm import pyupm_bmx055 as sensorObj
 
 def main():
     # Instantiate a BMI055 instance using default i2c bus and address
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,18 +52,18 @@ def main():
         sensor.update()
 
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " g"
+        print("Accelerometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" g")
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " degrees/s"
+        print("Gyroscope x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" degrees/s")
 
-        print
+        print()
         time.sleep(.250)
 
 if __name__ == '__main__':

--- a/examples/python/bmi160.py
+++ b/examples/python/bmi160.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmi160 as sensorObj
+from upm import pyupm_bmi160 as sensorObj
 
 def main():
     # Instantiate a BMI160 instance using default i2c bus and address
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -49,21 +50,21 @@ def main():
     while (1):
         sensor.update()
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer: AX: ", sensorObj.floatp_value(x),
-        print " AY: ", sensorObj.floatp_value(y),
-        print " AZ: ", sensorObj.floatp_value(z)
+        print("Accelerometer: AX: ", sensorObj.floatp_value(x), end=' ')
+        print(" AY: ", sensorObj.floatp_value(y), end=' ')
+        print(" AZ: ", sensorObj.floatp_value(z))
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope:     GX: ", sensorObj.floatp_value(x),
-        print " GY: ", sensorObj.floatp_value(y),
-        print " GZ: ", sensorObj.floatp_value(z)
+        print("Gyroscope:     GX: ", sensorObj.floatp_value(x), end=' ')
+        print(" GY: ", sensorObj.floatp_value(y), end=' ')
+        print(" GZ: ", sensorObj.floatp_value(z))
 
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer:  MX: ", sensorObj.floatp_value(x),
-        print " MY: ", sensorObj.floatp_value(y),
-        print " MZ: ", sensorObj.floatp_value(z)
+        print("Magnetometer:  MX: ", sensorObj.floatp_value(x), end=' ')
+        print(" MY: ", sensorObj.floatp_value(y), end=' ')
+        print(" MZ: ", sensorObj.floatp_value(z))
 
-        print
+        print()
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/bmm150.py
+++ b/examples/python/bmm150.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmx055 as sensorObj
+from upm import pyupm_bmx055 as sensorObj
 
 def main():
     # Instantiate a BMP250E instance using default i2c bus and address
@@ -38,7 +39,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -54,12 +55,12 @@ def main():
         sensor.update()
 
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " uT"
+        print("Magnetometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" uT")
 
-        print
+        print()
         time.sleep(.250)
 
 if __name__ == '__main__':

--- a/examples/python/bmp280.py
+++ b/examples/python/bmp280.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmp280 as sensorObj
+from upm import pyupm_bmp280 as sensorObj
 
 def main():
     # Instantiate a BMP280 instance using default i2c bus and address
@@ -38,7 +39,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -48,14 +49,14 @@ def main():
     while (1):
         sensor.update()
 
-        print "Compensation Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Compensation Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Pressure: ", sensor.getPressure(), "Pa"
+        print("Pressure: ", sensor.getPressure(), "Pa")
 
-        print "Computed Altitude:", sensor.getAltitude(), "m"
+        print("Computed Altitude:", sensor.getAltitude(), "m")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/bmpx8x.py
+++ b/examples/python/bmpx8x.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmpx8x as upmBmpx8x
+from upm import pyupm_bmpx8x as upmBmpx8x
 
 def main():
     # Load Barometer module on i2c
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myBarometer
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -54,7 +55,7 @@ def main():
         myBarometer.getAltitude(),
         myBarometer.getSealevelPressure()))
 
-        print outputStr
+        print(outputStr)
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/bmx055.py
+++ b/examples/python/bmx055.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bmx055 as sensorObj
+from upm import pyupm_bmx055 as sensorObj
 
 def main():
     # Instantiate a BMX055 instance using default i2c bus and address
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,24 +52,24 @@ def main():
         sensor.update()
 
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " g"
+        print("Accelerometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" g")
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " degrees/s"
+        print("Gyroscope x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" degrees/s")
 
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z),
-        print " uT"
+        print("Magnetometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z), end=' ')
+        print(" uT")
 
-        print
+        print()
         time.sleep(.250)
 
 if __name__ == '__main__':

--- a/examples/python/bno055.py
+++ b/examples/python/bno055.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_bno055 as sensorObj
+from upm import pyupm_bno055 as sensorObj
 
 def main():
     # Instantiate an BNO055 using default parameters (bus 0, addr
@@ -37,7 +38,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -54,24 +55,24 @@ def main():
     y = sensorObj.new_floatp()
     z = sensorObj.new_floatp()
 
-    print "First we need to calibrate.  4 numbers will be output every"
-    print "second for each sensor.  0 means uncalibrated, and 3 means"
-    print "fully calibrated."
-    print "See the UPM documentation on this sensor for instructions on"
-    print "what actions are required to calibrate."
-    print
+    print("First we need to calibrate.  4 numbers will be output every")
+    print("second for each sensor.  0 means uncalibrated, and 3 means")
+    print("fully calibrated.")
+    print("See the UPM documentation on this sensor for instructions on")
+    print("what actions are required to calibrate.")
+    print()
 
     while (not sensor.isFullyCalibrated()):
         sensor.getCalibrationStatus(mag, acc, gyr, syst)
-        print "Magnetometer:", sensorObj.intp_value(mag),
-        print " Accelerometer:", sensorObj.intp_value(acc),
-        print " Gyroscope:", sensorObj.intp_value(gyr),
-        print " System:", sensorObj.intp_value(syst),
+        print("Magnetometer:", sensorObj.intp_value(mag), end=' ')
+        print(" Accelerometer:", sensorObj.intp_value(acc), end=' ')
+        print(" Gyroscope:", sensorObj.intp_value(gyr), end=' ')
+        print(" System:", sensorObj.intp_value(syst), end=' ')
         time.sleep(1)
 
-    print
-    print "Calibration complete."
-    print
+    print()
+    print("Calibration complete.")
+    print()
 
     # now output various fusion data every 250 milliseconds
 
@@ -79,30 +80,30 @@ def main():
         sensor.update()
 
         sensor.getEulerAngles(x, y, z)
-        print "Euler: Heading:", sensorObj.floatp_value(x),
-        print " Roll:", sensorObj.floatp_value(y),
-        print " Pitch:", sensorObj.floatp_value(z),
-        print " degrees"
+        print("Euler: Heading:", sensorObj.floatp_value(x), end=' ')
+        print(" Roll:", sensorObj.floatp_value(y), end=' ')
+        print(" Pitch:", sensorObj.floatp_value(z), end=' ')
+        print(" degrees")
 
         sensor.getQuaternions(w, x, y, z)
-        print "Quaternion: W:", sensorObj.floatp_value(w),
-        print " X:", sensorObj.floatp_value(x),
-        print " Y:", sensorObj.floatp_value(y),
-        print " Z:", sensorObj.floatp_value(z)
+        print("Quaternion: W:", sensorObj.floatp_value(w), end=' ')
+        print(" X:", sensorObj.floatp_value(x), end=' ')
+        print(" Y:", sensorObj.floatp_value(y), end=' ')
+        print(" Z:", sensorObj.floatp_value(z))
 
         sensor.getLinearAcceleration(x, y, z)
-        print "Linear Acceleration: X:", sensorObj.floatp_value(x),
-        print " Y:", sensorObj.floatp_value(y),
-        print " Z:", sensorObj.floatp_value(z),
-        print " m/s^2"
+        print("Linear Acceleration: X:", sensorObj.floatp_value(x), end=' ')
+        print(" Y:", sensorObj.floatp_value(y), end=' ')
+        print(" Z:", sensorObj.floatp_value(z), end=' ')
+        print(" m/s^2")
 
         sensor.getGravityVectors(x, y, z)
-        print "Gravity Vector: X:", sensorObj.floatp_value(x),
-        print " Y:", sensorObj.floatp_value(y),
-        print " Z:", sensorObj.floatp_value(z),
-        print " m/s^2"
+        print("Gravity Vector: X:", sensorObj.floatp_value(x), end=' ')
+        print(" Y:", sensorObj.floatp_value(y), end=' ')
+        print(" Z:", sensorObj.floatp_value(z), end=' ')
+        print(" m/s^2")
 
-        print
+        print()
         time.sleep(.25);
 
 if __name__ == '__main__':

--- a/examples/python/button.py
+++ b/examples/python/button.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # Create the button object using GPIO pin 0
@@ -29,7 +30,7 @@ def main():
 
     # Read the input and print, waiting one second between readings
     while 1:
-        print button.name(), ' value is ', button.value()
+        print(button.name(), ' value is ', button.value())
         time.sleep(1)
 
     # Delete the button object

--- a/examples/python/buzzer.py
+++ b/examples/python/buzzer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_buzzer as upmBuzzer
+from upm import pyupm_buzzer as upmBuzzer
 
 def main():
     # Create the buzzer object using GPIO pin 5
@@ -32,15 +33,15 @@ def main():
               upmBuzzer.SI];
 
     # Print sensor name
-    print buzzer.name()
+    print(buzzer.name())
 
     # Play sound (DO, RE, MI, etc.), pausing for 0.1 seconds between notes
     for chord_ind in range (0,7):
         # play each note for one second
-        print buzzer.playSound(chords[chord_ind], 1000000)
+        print(buzzer.playSound(chords[chord_ind], 1000000))
         time.sleep(0.1)
 
-    print "exiting application"
+    print("exiting application")
 
     # Delete the buzzer object
     del buzzer

--- a/examples/python/cjq4435.py
+++ b/examples/python/cjq4435.py
@@ -23,7 +23,7 @@
 
 from __future__ import division
 import time
-import pyupm_cjq4435 as upmCjq4435
+from upm import pyupm_cjq4435 as upmCjq4435
 
 def main():
     # Instantiate a CJQ4435 MOSFET on a PWM capable digital pin D3

--- a/examples/python/collision.py
+++ b/examples/python/collision.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_collision as upmcollision
+from upm import pyupm_collision as upmcollision
 
 def main():
     # The was tested with the Collision Sensor
@@ -37,7 +38,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myGrovecollision
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,14 +46,14 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     collisionState = False
-    print "No collision"
+    print("No collision")
 
     while(1):
         if (mycollision.isColliding() and not collisionState):
-            print "Collision!"
+            print("Collision!")
             collisionState = True
         elif (not mycollision.isColliding() and collisionState):
-            print "No collision"
+            print("No collision")
             collisionState = False
 
 if __name__ == '__main__':

--- a/examples/python/curieimu.py
+++ b/examples/python/curieimu.py
@@ -22,6 +22,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
+from __future__ import print_function
 import mraa
 print (mraa.getVersion())
 
@@ -29,7 +30,7 @@ print (mraa.getVersion())
 mraa.addSubplatform(mraa.GENERIC_FIRMATA, "/dev/ttyACM0")
 
 import time, sys, signal, atexit
-import pyupm_curieimu as curieimu
+from upm import pyupm_curieimu as curieimu
 
 def main():
     sensor = curieimu.CurieImu()
@@ -39,7 +40,7 @@ def main():
         raise SystemExit
 
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -52,7 +53,7 @@ def main():
         outputStr = "acc: gX {0} - gY {1} - gZ {2}".format(
         sensor.getAccelX(), sensor.getAccelY(),
         sensor.getAccelZ())
-        print outputStr
+        print(outputStr)
 
         time.sleep(1)
 

--- a/examples/python/cwlsxxa.py
+++ b/examples/python/cwlsxxa.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_cwlsxxa as sensorObj
+from upm import pyupm_cwlsxxa as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,14 +33,14 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Initializing..."
+    print("Initializing...")
 
     # Instantiate an CWLSXXA instance, using A0 for CO2, A1 for
     # humidity and A2 for temperature
@@ -51,14 +52,14 @@ def main():
         sensor.update()
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Humidity:", sensor.getHumidity(), "%"
+        print("Humidity:", sensor.getHumidity(), "%")
 
-        print "CO2:", sensor.getCO2(), "ppm"
+        print("CO2:", sensor.getCO2(), "ppm")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/dfrec.py
+++ b/examples/python/dfrec.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_dfrec as sensorObj
+from upm import pyupm_dfrec as sensorObj
 
 def main():
     # Instantiate a DFRobot EC sensor on analog pin A0, with a ds18b20
@@ -38,7 +39,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -49,10 +50,10 @@ def main():
     while (True):
         sensor.update()
 
-        print "EC =", sensor.getEC(), "ms/cm"
-        print "Volts =", sensor.getVolts(),
-        print ", Temperature = ", sensor.getTemperature(), "C"
-        print
+        print("EC =", sensor.getEC(), "ms/cm")
+        print("Volts =", sensor.getVolts(), end=' ')
+        print(", Temperature = ", sensor.getTemperature(), "C")
+        print()
 
         time.sleep(2)
 

--- a/examples/python/dfrorp.py
+++ b/examples/python/dfrorp.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_dfrorp as sensorObj
+from upm import pyupm_dfrorp as sensorObj
 
 def main():
     # Instantiate a DFRobot ORP sensor on analog pin A0 with an analog
@@ -51,7 +52,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -62,9 +63,9 @@ def main():
     while (True):
         sensor.update()
 
-        print "ORP:", sensor.getORP(), "mV"
+        print("ORP:", sensor.getORP(), "mV")
 
-        print
+        print()
 
         time.sleep(1)
 

--- a/examples/python/dfrph.py
+++ b/examples/python/dfrph.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_dfrph as sensorObj
+from upm import pyupm_dfrph as sensorObj
 
 def main():
     # Instantiate a DFRPH sensor on analog pin A0, with an analog
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -52,8 +53,8 @@ def main():
     # analog voltage.
 
     while (1):
-        print "Detected volts: ", sensor.volts()
-        print "pH value: ", sensor.pH()
+        print("Detected volts: ", sensor.volts())
+        print("pH value: ", sensor.pH())
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/ds1307.py
+++ b/examples/python/ds1307.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ds1307 as upmDs1307
+from upm import pyupm_ds1307 as upmDs1307
 
 def main():
     # load RTC clock on i2c bus 0
@@ -36,22 +37,22 @@ def main():
         if (RTCObj.amPmMode):
             timeStr += (" PM " if RTCObj.pm else " AM ")
 
-        print timeStr
+        print(timeStr)
 
-        print "Clock is in", ("AM/PM mode"
-        if RTCObj.amPmMode else "24hr mode")
+        print("Clock is in", ("AM/PM mode"
+        if RTCObj.amPmMode else "24hr mode"))
 
     # always do this first
-    print "Loading the current time... "
+    print("Loading the current time... ")
     result = myRTCClock.loadTime()
     if (not result):
-        print "myRTCClock.loadTime() failed."
+        print("myRTCClock.loadTime() failed.")
         sys.exit(0)
 
     printTime(myRTCClock);
 
     # set the year as an example
-    print "setting the year to 50"
+    print("setting the year to 50")
     myRTCClock.year = 50
     myRTCClock.setTime()
 

--- a/examples/python/ds18b20.py
+++ b/examples/python/ds18b20.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ds18b20 as sensorObj
+from upm import pyupm_ds18b20 as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,14 +33,14 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Initializing..."
+    print("Initializing...")
 
     # Instantiate an DS18B20 instance using the default values (uart 0)
     sensor = sensorObj.DS18B20(0)
@@ -47,8 +48,8 @@ def main():
     # locate and setup our devices
     sensor.init()
 
-    print "Found", sensor.devicesFound(), "device(s)"
-    print
+    print("Found", sensor.devicesFound(), "device(s)")
+    print()
 
     if (not sensor.devicesFound()):
         sys.exit(1);
@@ -59,8 +60,8 @@ def main():
         sensor.update(0)
 
         # we show both C and F for temperature for the first sensor
-        print "Temperature:", sensor.getTemperature(0), "C /",
-        print sensor.getTemperature(0, True), "F"
+        print("Temperature:", sensor.getTemperature(0), "C /", end=' ')
+        print(sensor.getTemperature(0, True), "F")
 
         time.sleep(1)
 

--- a/examples/python/ds2413.py
+++ b/examples/python/ds2413.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ds2413 as sensorObj
+from upm import pyupm_ds2413 as sensorObj
 
 def main():
     # Instantiate a DS2413 Module on a Dallas 1-wire bus connected to UART 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -46,15 +47,15 @@ def main():
     sensor.init();
 
     # how many devices were found?
-    print "Found", sensor.devicesFound(), "device(s)"
+    print("Found", sensor.devicesFound(), "device(s)")
 
     # read the gpio and latch values from the first device
     # the lower 4 bits are of the form:
     # <gpioB latch> <gpioB value> <gpioA latch> <gpioA value>
-    print "GPIO device 0 values:", sensor.readGpios(0)
+    print("GPIO device 0 values:", sensor.readGpios(0))
 
     # set the gpio latch values of the first device
-    print "Setting GPIO latches to on"
+    print("Setting GPIO latches to on")
     sensor.writeGpios(0, 0x03);
 
 if __name__ == '__main__':

--- a/examples/python/e50hx.py
+++ b/examples/python/e50hx.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_e50hx as sensorObj
+from upm import pyupm_e50hx as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -50,8 +51,8 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Using device", defaultDev
-    print "Initializing..."
+    print("Using device", defaultDev)
+    print("Initializing...")
 
     # Instantiate an E50HX object for an E50HX device that has 1075425
     # as it's unique Device Object Instance ID.  NOTE: You will
@@ -69,30 +70,30 @@ def main():
     # sensor.setDebug(True);
 
     # output the serial number and firmware revision
-    print
-    print "Device Description:", sensor.getDeviceDescription()
-    print "Device Location:", sensor.getDeviceLocation()
-    print
+    print()
+    print("Device Description:", sensor.getDeviceDescription())
+    print("Device Location:", sensor.getDeviceLocation())
+    print()
 
     # update and print available values every second
     while (1):
-        print "System Voltage:",
-        print sensor.getAnalogValue(sensorObj.E50HX.AV_System_Voltage),
-        print " ",
-        print sensor.getAnalogValueUnits(sensorObj.E50HX.AV_System_Voltage)
+        print("System Voltage:", end=' ')
+        print(sensor.getAnalogValue(sensorObj.E50HX.AV_System_Voltage), end=' ')
+        print(" ", end=' ')
+        print(sensor.getAnalogValueUnits(sensorObj.E50HX.AV_System_Voltage))
 
-        print "System Type:",
-        print sensor.getAnalogValue(sensorObj.E50HX.AV_System_Type)
+        print("System Type:", end=' ')
+        print(sensor.getAnalogValue(sensorObj.E50HX.AV_System_Type))
 
-        print "Energy Consumption:",
-        print sensor.getAnalogInput(sensorObj.E50HX.AI_Energy),
-        print " ",
-        print sensor.getAnalogInputUnits(sensorObj.E50HX.AI_Energy)
+        print("Energy Consumption:", end=' ')
+        print(sensor.getAnalogInput(sensorObj.E50HX.AI_Energy), end=' ')
+        print(" ", end=' ')
+        print(sensor.getAnalogInputUnits(sensorObj.E50HX.AI_Energy))
 
-        print "Power Up Counter:",
-        print sensor.getAnalogInput(sensorObj.E50HX.AI_Power_Up_Count)
+        print("Power Up Counter:", end=' ')
+        print(sensor.getAnalogInput(sensorObj.E50HX.AI_Power_Up_Count))
 
-        print
+        print()
         time.sleep(5)
 
 if __name__ == '__main__':

--- a/examples/python/eboled.py
+++ b/examples/python/eboled.py
@@ -21,9 +21,10 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys
 
-import pyupm_i2clcd as lcdObj
+from upm import pyupm_i2clcd as lcdObj
 
 def main():
     # setup with default values
@@ -35,7 +36,7 @@ def main():
     lcd.setCursor(30, 15);
     lcd.write("World!");
     lcd.refresh();
-    print "Sleeping for 5 seconds..."
+    print("Sleeping for 5 seconds...")
     time.sleep(5)
 
 if __name__ == '__main__':

--- a/examples/python/ehr.py
+++ b/examples/python/ehr.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ehr as upmehr
+from upm import pyupm_ehr as upmehr
 
 def main():
     # Instantiate a  Ear-clip Heart Rate sensor on digital pin D2
@@ -37,7 +38,7 @@ def main():
     # including functions from myHeartRateSensor
     def exitHandler():
         myHeartRateSensor.stopBeatCounter()
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -62,7 +63,7 @@ def main():
         # output milliseconds passed, beat count, and computed heart rate
         outputStr = "Millis: {0} Beats: {1} Heart Rate: {2}".format(
         millis, beats, fr)
-        print outputStr
+        print(outputStr)
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/eldriver.py
+++ b/examples/python/eldriver.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_eldriver as upmeldriver
+from upm import pyupm_eldriver as upmeldriver
 
 def main():
     # The was tested with the  El Driver Module
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myEldriver
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         myEldriver.off()
         sys.exit(0)
 

--- a/examples/python/electromagnet.py
+++ b/examples/python/electromagnet.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_electromagnet as upmelectromagnet
+from upm import pyupm_electromagnet as upmelectromagnet
 
 def main():
     # This was tested with the  Electromagnetic Module
@@ -37,7 +38,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myElectromagnet
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         myElectromagnet.off()
         sys.exit(0)
 
@@ -54,7 +55,7 @@ def main():
             myElectromagnet.on()
         else:
             myElectromagnet.off()
-        print "Turning magnet", ("on" if magnetState else "off")
+        print("Turning magnet", ("on" if magnetState else "off"))
 
         time.sleep(5)
 

--- a/examples/python/emg.py
+++ b/examples/python/emg.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_emg as upmEmg
+from upm import pyupm_emg as upmEmg
 
 def main():
     # Tested with the EMG Muscle Signal Reader Sensor Module
@@ -36,18 +37,18 @@ def main():
 
     # This lets you run code on exit, including functions from myEMG
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Calibrating...."
+    print("Calibrating....")
     myEMG.calibrate()
 
     while (1):
-        print myEMG.value()
+        print(myEMG.value())
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/enc03r.py
+++ b/examples/python/enc03r.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_enc03r as upmEnc03r
+from upm import pyupm_enc03r as upmEnc03r
 
 def main():
     # Instantiate an ENC03R on analog pin A0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myAnalogGyro
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -50,15 +51,15 @@ def main():
     "This may take a couple of minutes.")
 
     myAnalogGyro.calibrate(CALIBRATION_SAMPLES)
-    print "Calibration complete. "
-    print "Reference value: ", myAnalogGyro.calibrationValue()
+    print("Calibration complete. ")
+    print("Reference value: ", myAnalogGyro.calibrationValue())
 
     while(1):
         gyroVal = myAnalogGyro.value();
         outputStr = ("Raw value: {0}, "
         "angular velocity: {1}"
         " deg/s".format(gyroVal, myAnalogGyro.angularVelocity(gyroVal)))
-        print outputStr
+        print(outputStr)
 
         time.sleep(.1)
 

--- a/examples/python/es08a.py
+++ b/examples/python/es08a.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: John Van Drasek <john.r.van.drasek@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_servo as servo
+from upm import pyupm_servo as servo
 
 def main():
     # Create the servo object using D5
@@ -30,17 +31,17 @@ def main():
     for i in range(0,10):
         # Set the servo arm to 0 degrees
         gServo.setAngle(0)
-        print 'Set angle to 0'
+        print('Set angle to 0')
         time.sleep(1)
 
         # Set the servo arm to 90 degrees
         gServo.setAngle(90)
-        print 'Set angle to 90'
+        print('Set angle to 90')
         time.sleep(1)
 
         # Set the servo arm to 180 degrees
         gServo.setAngle(180)
-        print 'Set angle to 180'
+        print('Set angle to 180')
         time.sleep(1)
 
     # Delete the servo object

--- a/examples/python/gp2y0a.py
+++ b/examples/python/gp2y0a.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gp2y0a as upmGp2y0a
+from upm import pyupm_gp2y0a as upmGp2y0a
 
 def main():
     # Note, for the Grove 80cm version of this sensor, due to the way it is wired,
@@ -39,7 +40,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myIRProximity
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -55,9 +56,9 @@ def main():
     # Every second, print the averaged voltage value
     # (averaged over 20 samples).
     while (1):
-        print "AREF: {0}, Voltage value (higher means closer): {1}".format(
+        print("AREF: {0}, Voltage value (higher means closer): {1}".format(
         GP2Y0A_AREF,
-        myIRProximity.value(GP2Y0A_AREF, SAMPLES_PER_QUERY))
+        myIRProximity.value(GP2Y0A_AREF, SAMPLES_PER_QUERY)))
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/gprs.py
+++ b/examples/python/gprs.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gprs as sensorObj
+from upm import pyupm_gprs as sensorObj
 
 def main():
     # Instantiate a GPRS Module on UART 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,7 +45,7 @@ def main():
 
     # Set the baud rate, 19200 baud is the default.
     if (sensor.setBaudRate(19200)):
-        print "Failed to set baud rate"
+        print("Failed to set baud rate")
         sys.exit(0)
 
     usageStr = ("Usage:\n"
@@ -52,7 +53,7 @@ def main():
     "sent to the module and the response is printed out.\n\n"
     "If no argument is used, then the manufacturer and the current\n"
     "saved profiles are queried and the results printed out.\n\n")
-    print usageStr
+    print(usageStr)
 
     # simple helper function to send a command and wait for a response
     def sendCommand(sensor, cmd):
@@ -62,23 +63,23 @@ def main():
 
         # wait up to 1 second
         if (sensor.dataAvailable(1000)):
-            print "Returned: ",
-            print sensor.readDataStr(1024)
+            print("Returned: ", end=' ')
+            print(sensor.readDataStr(1024))
         else:
-            print "Timed out waiting for response"
+            print("Timed out waiting for response")
 
     if (len(sys.argv) > 1):
-        print "Sending command line argument (" + sys.argv[1] + ")..."
+        print("Sending command line argument (" + sys.argv[1] + ")...")
         sendCommand(sensor, sys.argv[1])
     else:
         # query the module manufacturer
-        print "Querying module manufacturer (AT+CGMI)..."
+        print("Querying module manufacturer (AT+CGMI)...")
         sendCommand(sensor, "AT+CGMI");
 
         time.sleep(1);
 
         # query the saved profiles
-        print "Querying the saved profiles (AT&V)..."
+        print("Querying the saved profiles (AT&V)...")
         sendCommand(sensor, "AT&V");
 
         # A comprehensive list is available from the datasheet at:

--- a/examples/python/grovebutton.py
+++ b/examples/python/grovebutton.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # Create the button object using GPIO pin 0
@@ -29,7 +30,7 @@ def main():
 
     # Read the input and print, waiting one second between readings
     while 1:
-        print button.name(), ' value is ', button.value()
+        print(button.name(), ' value is ', button.value())
         time.sleep(1)
 
     # Delete the button object

--- a/examples/python/grovecircularled.py
+++ b/examples/python/grovecircularled.py
@@ -22,8 +22,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_my9221 as upmGroveCircularLED
+from upm import pyupm_my9221 as upmGroveCircularLED
 
 def main():
     # Exit handlers
@@ -32,7 +33,7 @@ def main():
 
     def exitHandler():
         circle.setLevel(0, True)
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # This function lets you run code on exit

--- a/examples/python/grovecollision.py
+++ b/examples/python/grovecollision.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovecollision as upmGrovecollision
+from upm import pyupm_grovecollision as upmGrovecollision
 
 def main():
     # The was tested with the Grove Collision Sensor
@@ -37,7 +38,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myGrovecollision
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,14 +46,14 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     collisionState = False
-    print "No collision"
+    print("No collision")
 
     while(1):
         if (myGrovecollision.isColliding() and not collisionState):
-            print "Collision!"
+            print("Collision!")
             collisionState = True
         elif (not myGrovecollision.isColliding() and collisionState):
-            print "No collision"
+            print("No collision")
             collisionState = False
 
 if __name__ == '__main__':

--- a/examples/python/groveehr.py
+++ b/examples/python/groveehr.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_groveehr as upmGroveehr
+from upm import pyupm_groveehr as upmGroveehr
 
 def main():
     # Instantiate a Grove Ear-clip Heart Rate sensor on digital pin D2
@@ -37,7 +38,7 @@ def main():
     # including functions from myHeartRateSensor
     def exitHandler():
         myHeartRateSensor.stopBeatCounter()
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -62,7 +63,7 @@ def main():
         # output milliseconds passed, beat count, and computed heart rate
         outputStr = "Millis: {0} Beats: {1} Heart Rate: {2}".format(
         millis, beats, fr)
-        print outputStr
+        print(outputStr)
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/groveeldriver.py
+++ b/examples/python/groveeldriver.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_groveeldriver as upmGroveeldriver
+from upm import pyupm_groveeldriver as upmGroveeldriver
 
 def main():
     # The was tested with the Grove El Driver Module
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myEldriver
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         myEldriver.off()
         sys.exit(0)
 

--- a/examples/python/groveelectromagnet.py
+++ b/examples/python/groveelectromagnet.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_groveelectromagnet as upmGroveelectromagnet
+from upm import pyupm_groveelectromagnet as upmGroveelectromagnet
 
 def main():
     # This was tested with the Grove Electromagnetic Module
@@ -37,7 +38,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myElectromagnet
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         myElectromagnet.off()
         sys.exit(0)
 
@@ -54,7 +55,7 @@ def main():
             myElectromagnet.on()
         else:
             myElectromagnet.off()
-        print "Turning magnet", ("on" if magnetState else "off")
+        print("Turning magnet", ("on" if magnetState else "off"))
 
         time.sleep(5)
 

--- a/examples/python/groveemg.py
+++ b/examples/python/groveemg.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_groveemg as upmGroveemg
+from upm import pyupm_groveemg as upmGroveemg
 
 def main():
     # Tested with the GroveEMG Muscle Signal Reader Sensor Module
@@ -36,18 +37,18 @@ def main():
 
     # This lets you run code on exit, including functions from myEMG
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Calibrating...."
+    print("Calibrating....")
     myEMG.calibrate()
 
     while (1):
-        print myEMG.value()
+        print(myEMG.value())
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/grovegprs.py
+++ b/examples/python/grovegprs.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovegprs as sensorObj
+from upm import pyupm_grovegprs as sensorObj
 
 def main():
     # Instantiate a GroveGPRS Module on UART 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,7 +45,7 @@ def main():
 
     # Set the baud rate, 19200 baud is the default.
     if (sensor.setBaudRate(19200)):
-        print "Failed to set baud rate"
+        print("Failed to set baud rate")
         sys.exit(0)
 
     usageStr = ("Usage:\n"
@@ -52,7 +53,7 @@ def main():
     "sent to the module and the response is printed out.\n\n"
     "If no argument is used, then the manufacturer and the current\n"
     "saved profiles are queried and the results printed out.\n\n")
-    print usageStr
+    print(usageStr)
 
     # simple helper function to send a command and wait for a response
     def sendCommand(sensor, cmd):
@@ -62,23 +63,23 @@ def main():
 
         # wait up to 1 second
         if (sensor.dataAvailable(1000)):
-            print "Returned: ",
-            print sensor.readDataStr(1024)
+            print("Returned: ", end=' ')
+            print(sensor.readDataStr(1024))
         else:
-            print "Timed out waiting for response"
+            print("Timed out waiting for response")
 
     if (len(sys.argv) > 1):
-        print "Sending command line argument (" + sys.argv[1] + ")..."
+        print("Sending command line argument (" + sys.argv[1] + ")...")
         sendCommand(sensor, sys.argv[1])
     else:
         # query the module manufacturer
-        print "Querying module manufacturer (AT+CGMI)..."
+        print("Querying module manufacturer (AT+CGMI)...")
         sendCommand(sensor, "AT+CGMI");
 
         time.sleep(1);
 
         # query the saved profiles
-        print "Querying the saved profiles (AT&V)..."
+        print("Querying the saved profiles (AT&V)...")
         sendCommand(sensor, "AT&V");
 
         # A comprehensive list is available from the datasheet at:

--- a/examples/python/grovegsr.py
+++ b/examples/python/grovegsr.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovegsr as upmGrovegsr
+from upm import pyupm_grovegsr as upmGrovegsr
 
 def main():
     # Tested with the GroveGSR Galvanic Skin Response Sensor module.
@@ -37,18 +38,18 @@ def main():
 
     # This lets you run code on exit, including functions from myGSR
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Calibrating...."
+    print("Calibrating....")
     myGSR.calibrate()
 
     while (1):
-        print myGSR.value()
+        print(myGSR.value())
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/groveled.py
+++ b/examples/python/groveled.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,14 +22,14 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # Create the Grove LED object using GPIO pin 2
     led = grove.GroveLed(2)
 
     # Print the name
-    print led.name()
+    print(led.name())
 
     # Turn the LED on and off 10 times, pausing one second
     # between transitions

--- a/examples/python/groveledbar.py
+++ b/examples/python/groveledbar.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_my9221 as upmMy9221
+from upm import pyupm_my9221 as upmMy9221
 
 def main():
     # Instantiate a MY9221, we use D8 for the data, and D9 for the
@@ -35,7 +36,7 @@ def main():
 
     def exitHandler():
         myLEDBar.setBarLevel(0, True)
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # This function lets you run code on exit

--- a/examples/python/grovelight.py
+++ b/examples/python/grovelight.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # Create the light sensor object using AIO pin 0
@@ -30,8 +31,8 @@ def main():
     # Read the input and print both the raw value and a rough lux value,
     # waiting one second between readings
     while 1:
-        print light.name() + " raw value is %d" % light.raw_value() + \
-            ", which is roughly %d" % light.value() + " lux";
+        print(light.name() + " raw value is %d" % light.raw_value() + \
+            ", which is roughly %d" % light.value() + " lux");
         time.sleep(1)
 
     # Delete the light sensor object

--- a/examples/python/grovelinefinder.py
+++ b/examples/python/grovelinefinder.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovelinefinder as upmGrovelinefinder
+from upm import pyupm_grovelinefinder as upmGrovelinefinder
 
 def main():
     # Instantiate a Grove line finder sensor on digital pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myLineFinder
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,9 +45,9 @@ def main():
 
     while(1):
         if (myLineFinder.whiteDetected()):
-            print "White detected."
+            print("White detected.")
         else:
-            print "Black detected."
+            print("Black detected.")
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/grovemd-stepper.py
+++ b/examples/python/grovemd-stepper.py
@@ -22,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grovemd as upmGrovemd
+from upm import pyupm_grovemd as upmGrovemd
 
 def main():
     I2C_BUS = upmGrovemd.GROVEMD_I2C_BUS

--- a/examples/python/grovemd.py
+++ b/examples/python/grovemd.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time
-import pyupm_grovemd as upmGrovemd
+from upm import pyupm_grovemd as upmGrovemd
 
 def main():
     I2C_BUS = upmGrovemd.GROVEMD_I2C_BUS
@@ -32,18 +33,18 @@ def main():
     myMotorDriver = upmGrovemd.GroveMD(I2C_BUS, I2C_ADDR)
 
     # set direction to CW and set speed to 50%
-    print "Spin M1 and M2 at half speed for 3 seconds"
+    print("Spin M1 and M2 at half speed for 3 seconds")
     myMotorDriver.setMotorDirections(upmGrovemd.GroveMD.DIR_CW, upmGrovemd.GroveMD.DIR_CW)
     myMotorDriver.setMotorSpeeds(127, 127)
 
     time.sleep(3)
     # counter clockwise
-    print "Reversing M1 and M2 for 3 seconds"
+    print("Reversing M1 and M2 for 3 seconds")
     myMotorDriver.setMotorDirections(upmGrovemd.GroveMD.DIR_CCW,
     upmGrovemd.GroveMD.DIR_CCW)
     time.sleep(3)
 
-    print "Stopping motors"
+    print("Stopping motors")
     myMotorDriver.setMotorSpeeds(0, 0)
 
 if __name__ == '__main__':

--- a/examples/python/grovemoisture.py
+++ b/examples/python/grovemoisture.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovemoisture as upmMoisture
+from upm import pyupm_grovemoisture as upmMoisture
 
 def main():
     # Instantiate a Grove Moisture sensor on analog pin A0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myMoisture
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -56,7 +57,7 @@ def main():
             result = "Moist"
         else:
             result = "Wet"
-        print "Moisture value: {0}, {1}".format(moisture_val, result)
+        print("Moisture value: {0}, {1}".format(moisture_val, result))
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/groveo2.py
+++ b/examples/python/groveo2.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_groveo2 as upmGroveo2
+from upm import pyupm_groveo2 as upmGroveo2
 
 def main():
     # This was tested with the O2 Oxygen Concentration Sensor Module
@@ -36,7 +37,7 @@ def main():
 
     # This lets you run code on exit, including functions from myGroveO2
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,8 +45,8 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     while(1):
-        print "The output voltage is: {0}mV".format(
-        myGroveO2.voltageValue())
+        print("The output voltage is: {0}mV".format(
+        myGroveO2.voltageValue()))
 
         time.sleep(.1)
 

--- a/examples/python/groverelay.py
+++ b/examples/python/groverelay.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # Create the relay switch object using GPIO pin 0
@@ -34,11 +35,11 @@ def main():
     for i in range (0,3):
         relay.on()
         if relay.isOn():
-            print relay.name(), 'is on'
+            print(relay.name(), 'is on')
         time.sleep(1)
         relay.off()
         if relay.isOff():
-            print relay.name(), 'is off'
+            print(relay.name(), 'is off')
         time.sleep(1)
 
     # Delete the relay switch object

--- a/examples/python/groverotary.py
+++ b/examples/python/groverotary.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # New knob on AIO pin 0
@@ -38,8 +39,8 @@ def main():
         reldeg = knob.rel_deg()
         relrad = knob.rel_rad()
 
-        print "Abs values: %4d" % int(abs) , " raw %4d" % int(absdeg), "deg = %5.2f" % absrad , " rad ",
-        print "Rel values: %4d" % int(rel) , " raw %4d" % int(reldeg), "deg = %5.2f" % relrad , " rad"
+        print("Abs values: %4d" % int(abs) , " raw %4d" % int(absdeg), "deg = %5.2f" % absrad , " rad ", end=' ')
+        print("Rel values: %4d" % int(rel) , " raw %4d" % int(reldeg), "deg = %5.2f" % relrad , " rad")
 
         # Sleep for 2.5 s
         sleep(2.5)

--- a/examples/python/grovescam.py
+++ b/examples/python/grovescam.py
@@ -22,8 +22,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
-import pyupm_grovescam as upmGrovescam
+from upm import pyupm_grovescam as upmGrovescam
 
 def main():
     # Instantiate a Grove Serial Camera on UART 0
@@ -31,34 +32,34 @@ def main():
 
     # make sure port is initialized properly. 115200 baud is the default.
     if (not camera.setupTty()):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(1)
 
     if (camera.init()):
-        print "Initialized..."
+        print("Initialized...")
     else:
-        print "init() failed"
+        print("init() failed")
 
     if (camera.preCapture()):
-        print "preCapture succeeded..."
+        print("preCapture succeeded...")
     else:
-        print "preCapture failed."
+        print("preCapture failed.")
 
     if (camera.doCapture()):
-        print "doCapture succeeded..."
+        print("doCapture succeeded...")
     else:
-        print "doCapture failed."
+        print("doCapture failed.")
 
-    print "Image size is", camera.getImageSize(), "bytes"
+    print("Image size is", camera.getImageSize(), "bytes")
 
     if (camera.getImageSize() > 0):
-        print "Storing image.jpg..."
+        print("Storing image.jpg...")
         if (camera.storeImage("image.jpg")):
-            print "storeImage succeeded..."
+            print("storeImage succeeded...")
         else:
-            print "storeImage failed."
+            print("storeImage failed.")
 
-    print "Exiting."
+    print("Exiting.")
     sys.exit(0)
 
 if __name__ == '__main__':

--- a/examples/python/groveslide.py
+++ b/examples/python/groveslide.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # New Grove Slider on AIO pin 0
@@ -33,7 +34,7 @@ def main():
         raw = slider.raw_value()
         volts = slider.voltage_value()
 
-        print "Slider value: ", raw , " = %.2f" % volts , " V"
+        print("Slider value: ", raw , " = %.2f" % volts , " V")
 
         # Sleep for 2.5 s
         sleep(2.5)

--- a/examples/python/grovespeaker.py
+++ b/examples/python/grovespeaker.py
@@ -22,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time, sys, signal, atexit
-import pyupm_grovespeaker as upmGrovespeaker
+from upm import pyupm_grovespeaker as upmGrovespeaker
 
 def main():
     # Instantiate a Grove Speaker on digital pin D2

--- a/examples/python/grovetemp.py
+++ b/examples/python/grovetemp.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Brendan Le Foll <brendan.le.foll@intel.com>
 # Contributions: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
@@ -22,20 +23,20 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # Create the temperature sensor object using AIO pin 0
     temp = grove.GroveTemp(0)
-    print temp.name()
+    print(temp.name())
 
     # Read the temperature ten times, printing both the Celsius and
     # equivalent Fahrenheit temperature, waiting one second between readings
     for i in range(0, 10):
         celsius = temp.value()
         fahrenheit = celsius * 9.0/5.0 + 32.0;
-        print "%d degrees Celsius, or %d degrees Fahrenheit" \
-            % (celsius, fahrenheit)
+        print("%d degrees Celsius, or %d degrees Fahrenheit" \
+            % (celsius, fahrenheit))
         time.sleep(1)
 
     # Delete the temperature sensor object

--- a/examples/python/grovevdiv.py
+++ b/examples/python/grovevdiv.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovevdiv as upmGrovevdiv
+from upm import pyupm_grovevdiv as upmGrovevdiv
 
 def main():
     # Instantiate a Grove Voltage Divider sensor on analog pin A0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myVoltageDivider
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,8 +48,8 @@ def main():
         val = myVoltageDivider.value(100)
         gain3val = myVoltageDivider.computedValue(3, val)
         gain10val = myVoltageDivider.computedValue(10, val)
-        print "ADC value: {0} Gain 3: {1}v Gain 10: {2}v".format(
-        val,  gain3val, gain10val)
+        print("ADC value: {0} Gain 3: {1}v Gain 10: {2}v".format(
+        val,  gain3val, gain10val))
 
         time.sleep(1)
 

--- a/examples/python/grovewater.py
+++ b/examples/python/grovewater.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovewater as upmGrovewater
+from upm import pyupm_grovewater as upmGrovewater
 
 def main():
     # Instantiate a Grove Water sensor on digital pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myWaterSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,9 +45,9 @@ def main():
 
     while(1):
         if (myWaterSensor.isWet()):
-            print "Sensor is wet"
+            print("Sensor is wet")
         else:
-            print "Sensor is dry"
+            print("Sensor is dry")
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/grovewfs.py
+++ b/examples/python/grovewfs.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_grovewfs as upmGrovewfs
+from upm import pyupm_grovewfs as upmGrovewfs
 
 def main():
     # Instantiate a Grove Water Flow Sensor on digital pin D2
@@ -37,7 +38,7 @@ def main():
     # including functions from myWaterFlow
     def exitHandler():
         myWaterFlow.stopFlowCounter()
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -59,7 +60,7 @@ def main():
         # output milliseconds passed, flow count, and computed flow rate
         outputStr = "Millis: {0} Flow Count: {1} Flow Rate: {2} LPM".format(
         millis, flowCount, fr)
-        print outputStr
+        print(outputStr)
         time.sleep(2)
 
 if __name__ == '__main__':

--- a/examples/python/gsr.py
+++ b/examples/python/gsr.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gsr as upmGsr
+from upm import pyupm_gsr as upmGsr
 
 def main():
     # Tested with the GSR Galvanic Skin Response Sensor module.
@@ -37,18 +38,18 @@ def main():
 
     # This lets you run code on exit, including functions from myGSR
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Calibrating...."
+    print("Calibrating....")
     myGSR.calibrate()
 
     while (1):
-        print myGSR.value()
+        print(myGSR.value())
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/guvas12d.py
+++ b/examples/python/guvas12d.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_guvas12d as upmUV
+from upm import pyupm_guvas12d as upmUV
 
 def main():
     # Instantiate a UV sensor on analog pin A0
@@ -39,7 +40,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myUVSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,7 +52,7 @@ def main():
         "Voltage value (higher means more UV): "
         "{1}".format(GUVAS12D_AREF,
         myUVSensor.value(GUVAS12D_AREF, SAMPLES_PER_QUERY)))
-        print s
+        print(s)
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/h3lis331dl.py
+++ b/examples/python/h3lis331dl.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_h3lis331dl as upmH3LIS331DL
+from upm import pyupm_h3lis331dl as upmH3LIS331DL
 
 def main():
     # Instantiate an H3LIS331DL on I2C bus 0
@@ -37,7 +38,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myDigitalAccelerometer
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -63,7 +64,7 @@ def main():
         " Z = {2}").format(upmH3LIS331DL.intp_value(x),
         upmH3LIS331DL.intp_value(y),
         upmH3LIS331DL.intp_value(z))
-        print outputStr
+        print(outputStr)
 
         myDigitalAccelerometer.getAcceleration(ax, ay, az)
         outputStr = ("Acceleration: AX = {0}"
@@ -71,7 +72,7 @@ def main():
         " AZ = {2}").format(upmH3LIS331DL.floatp_value(ax),
         upmH3LIS331DL.floatp_value(ay),
         upmH3LIS331DL.floatp_value(az))
-        print outputStr
+        print(outputStr)
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/h803x.py
+++ b/examples/python/h803x.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_h803x as sensorObj
+from upm import pyupm_h803x as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,17 +46,17 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Using device", defaultDev
-    print "Initializing..."
+    print("Using device", defaultDev)
+    print("Initializing...")
 
     # Instantiate an H803X instance, using MODBUS slave address 1, and
     # default comm parameters (9600, 8, N, 2)
     sensor = sensorObj.H803X(defaultDev, 1)
 
     # output the serial number and firmware revision
-    print "Slave ID:", sensor.getSlaveID()
+    print("Slave ID:", sensor.getSlaveID())
 
-    print
+    print()
 
     # update and print available values every second
     while (1):
@@ -63,47 +64,47 @@ def main():
         sensor.update()
 
         # H8035 / H8036
-        print "Consumption (kWh):", sensor.getConsumption()
-        print "Real Power (kW):", sensor.getRealPower()
+        print("Consumption (kWh):", sensor.getConsumption())
+        print("Real Power (kW):", sensor.getRealPower())
 
         if (sensor.isH8036()):
             # The H8036 has much more data available...
 
-            print "Reactive Power (kVAR):", sensor.getReactivePower()
-            print "Apparent Power (kVA):", sensor.getApparentPower()
-            print "Power Factor:", sensor.getPowerFactor()
-            print "Volts Line to Line:", sensor.getVoltsLineToLine()
-            print "Volts Line to Neutral:", sensor.getVoltsLineToNeutral()
+            print("Reactive Power (kVAR):", sensor.getReactivePower())
+            print("Apparent Power (kVA):", sensor.getApparentPower())
+            print("Power Factor:", sensor.getPowerFactor())
+            print("Volts Line to Line:", sensor.getVoltsLineToLine())
+            print("Volts Line to Neutral:", sensor.getVoltsLineToNeutral())
 
-            print "Current:", sensor.getCurrent()
+            print("Current:", sensor.getCurrent())
 
-            print "Real Power Phase A (kW):", sensor.getRealPowerPhaseA()
-            print "Real Power Phase B (kW):", sensor.getRealPowerPhaseB()
-            print "Real Power Phase C (kW):", sensor.getRealPowerPhaseC()
+            print("Real Power Phase A (kW):", sensor.getRealPowerPhaseA())
+            print("Real Power Phase B (kW):", sensor.getRealPowerPhaseB())
+            print("Real Power Phase C (kW):", sensor.getRealPowerPhaseC())
 
-            print "Power Factor Phase A:", sensor.getPowerFactorPhaseA()
-            print "Power Factor Phase B:", sensor.getPowerFactorPhaseB()
-            print "Power Factor Phase C:", sensor.getPowerFactorPhaseC()
+            print("Power Factor Phase A:", sensor.getPowerFactorPhaseA())
+            print("Power Factor Phase B:", sensor.getPowerFactorPhaseB())
+            print("Power Factor Phase C:", sensor.getPowerFactorPhaseC())
 
-            print "Volts Phase A to B:", sensor.getVoltsPhaseAToB()
-            print "Volts Phase B to C:", sensor.getVoltsPhaseBToC()
-            print "Volts Phase A to C:", sensor.getVoltsPhaseAToC()
-            print "Volts Phase A to Neutral: ",
-            print sensor.getVoltsPhaseAToNeutral()
-            print "Volts Phase B to Neutral: ",
-            print sensor.getVoltsPhaseBToNeutral()
-            print "Volts Phase C to Neutral: ",
-            print sensor.getVoltsPhaseCToNeutral()
+            print("Volts Phase A to B:", sensor.getVoltsPhaseAToB())
+            print("Volts Phase B to C:", sensor.getVoltsPhaseBToC())
+            print("Volts Phase A to C:", sensor.getVoltsPhaseAToC())
+            print("Volts Phase A to Neutral: ", end=' ')
+            print(sensor.getVoltsPhaseAToNeutral())
+            print("Volts Phase B to Neutral: ", end=' ')
+            print(sensor.getVoltsPhaseBToNeutral())
+            print("Volts Phase C to Neutral: ", end=' ')
+            print(sensor.getVoltsPhaseCToNeutral())
 
-            print "Current Phase A:", sensor.getCurrentPhaseA()
-            print "Current Phase B:", sensor.getCurrentPhaseB()
-            print "Current Phase C:", sensor.getCurrentPhaseC()
+            print("Current Phase A:", sensor.getCurrentPhaseA())
+            print("Current Phase B:", sensor.getCurrentPhaseB())
+            print("Current Phase C:", sensor.getCurrentPhaseC())
 
-            print "Avg Real Power (kW):", sensor.getAvgRealPower()
-            print "Min Real Power (kW):", sensor.getMinRealPower()
-            print "Max Real Power (kW):", sensor.getMaxRealPower()
+            print("Avg Real Power (kW):", sensor.getAvgRealPower())
+            print("Min Real Power (kW):", sensor.getMinRealPower())
+            print("Max Real Power (kW):", sensor.getMaxRealPower())
 
-        print
+        print()
         time.sleep(2)
 
 if __name__ == '__main__':

--- a/examples/python/hdxxvxta.py
+++ b/examples/python/hdxxvxta.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_hdxxvxta as sensorObj
+from upm import pyupm_hdxxvxta as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,14 +33,14 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Initializing..."
+    print("Initializing...")
 
     # Instantiate an HDXXVXTA instance, using A1 for humidity and A0
     # for temperature
@@ -51,12 +52,12 @@ def main():
         sensor.update()
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Humidity:", sensor.getHumidity(), "%"
+        print("Humidity:", sensor.getHumidity(), "%")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/hka5.py
+++ b/examples/python/hka5.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_hka5 as sensorObj
+from upm import pyupm_hka5 as sensorObj
 
 def main():
     # Instantiate a HKA5 sensor on uart 0.  We don't use the set or
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,19 +48,19 @@ def main():
     while (True):
         sensor.update()
 
-        print "PM 1  :",
-        print sensor.getPM1(),
-        print " ug/m3"
+        print("PM 1  :", end=' ')
+        print(sensor.getPM1(), end=' ')
+        print(" ug/m3")
 
-        print "PM 2.5:",
-        print sensor.getPM2_5(),
-        print " ug/m3"
+        print("PM 2.5:", end=' ')
+        print(sensor.getPM2_5(), end=' ')
+        print(" ug/m3")
 
-        print "PM 10 :",
-        print sensor.getPM10(),
-        print " ug/m3"
+        print("PM 10 :", end=' ')
+        print(sensor.getPM10(), end=' ')
+        print(" ug/m3")
 
-        print
+        print()
         time.sleep(2)
 
 if __name__ == '__main__':

--- a/examples/python/hm11.py
+++ b/examples/python/hm11.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_hm11 as upmHm11
+from upm import pyupm_hm11 as upmHm11
 
 def main():
     # Instantiate a HM11 BLE Module on UART 0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from my_ble_obj
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,7 +48,7 @@ def main():
 
     # make sure port is initialized properly. 9600 baud is the default.
     if (not my_ble_obj.setupTty(upmHm11.cvar.int_B9600)):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(0)
 
     usageStr = ("Usage:\n"
@@ -57,7 +58,7 @@ def main():
     "Running this program without arguments will simply transmit\n"
     "'Hello World!' every second, and output any data received from\n"
     "another radio.\n\n")
-    print usageStr
+    print(usageStr)
 
     # simple helper function to send a command and wait for a response
     def sendCommand(bleObj, cmd):
@@ -75,23 +76,23 @@ def main():
                     break
                 else:
                     bleData += bleBuffer.__getitem__(x)
-            print bleData
+            print(bleData)
         else:
-            print "Timed out waiting for response"
+            print("Timed out waiting for response")
 
     if (len(sys.argv) > 1):
-        print "Sending command line argument (" + sys.argv[1] + ")..."
+        print("Sending command line argument (" + sys.argv[1] + ")...")
         sendCommand(my_ble_obj, sys.argv[1])
     else:
         # query the module address
         addr = "AT+ADDR?";
-        print "Querying module address (" + addr + ")..."
+        print("Querying module address (" + addr + ")...")
 
         sendCommand(my_ble_obj, addr)
         time.sleep(1)
         # query the module address
         pin = "AT+PASS?";
-        print "Querying module PIN (" + pin + ")..."
+        print("Querying module PIN (" + pin + ")...")
         sendCommand(my_ble_obj, pin)
 
         # Other potentially useful commands are:

--- a/examples/python/hmc5883l.py
+++ b/examples/python/hmc5883l.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
-import pyupm_hmc5883l as hmc5883l
+from upm import pyupm_hmc5883l as hmc5883l
 
 def main():
     # Create an I2C compass object and set declination
@@ -36,9 +37,9 @@ def main():
         dir = hmc.direction() # Read direction
 
         # Print values
-        print "Coor: %5d %5d %5d" % (pos[0], pos[1], pos[2])
-        print "Heading: %5.2f" % (hdg)
-        print "Direction: %3.2f\n" % (dir)
+        print("Coor: %5d %5d %5d" % (pos[0], pos[1], pos[2]))
+        print("Heading: %5.2f" % (hdg))
+        print("Direction: %3.2f\n" % (dir))
 
         # Sleep for 1 s
         sleep(1)

--- a/examples/python/hmtrp.py
+++ b/examples/python/hmtrp.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_hmtrp as upmHmtrp
+from upm import pyupm_hmtrp as upmHmtrp
 
 def main():
     # Instantiate a HMTRP radio device on uart 0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from my_HMTRP_Radio
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,7 +52,7 @@ def main():
 
     # make sure port is initialized properly. 9600 baud is the default.
     if (not my_HMTRP_Radio.setupTty(upmHmtrp.cvar.int_B9600)):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(0)
 
     usageStr = ("Usage:\n"
@@ -61,7 +62,7 @@ def main():
     "Running this program without arguments will simply transmit\n"
     "'Hello World!' every second, and output any data received from\n"
     "another radio.\n\n")
-    print usageStr
+    print(usageStr)
 
     '''
     By default, this radio simply transmits data sent via writeData()
@@ -91,23 +92,23 @@ def main():
 
         if (my_HMTRP_Radio.getConfig(freq, dataRate, rxBandwidth,
         modulation, txPower, uartBaud)):
-            print "Radio configuration:"
+            print("Radio configuration:")
             outputStr = ("freq: {0} dataRate: {1} "
             "rxBandwidth: {2}Khz").format(freq.__getitem__(0),
             dataRate.__getitem__(0),
             rxBandwidth.__getitem__(0))
-            print outputStr
+            print(outputStr)
 
             outputStr = "modulation: %d Khz txPower: %d uartBaud: %d" % (
             modulation.__getitem__(0), txPower.__getitem__(0),
             uartBaud.__getitem__(0))
-            print outputStr
+            print(outputStr)
         else:
             errString = ("getConfig() failed.  Make sure the radio "
             "is in CONFIG mode.")
-            print errString
+            print(errString)
     else:
-        print "Running in normal read/write mode."
+        print("Running in normal read/write mode.")
         while (1):
             # we don't want the read to block in this example, so always
             # check to see if data is available first.
@@ -118,17 +119,17 @@ def main():
                     resultStr = "";
                     for x in range(rv):
                         resultStr += radioBuffer.__getitem__(x)
-                    print "Received:", resultStr
+                    print("Received:", resultStr)
 
                 if (rv < 0): # some sort of read error occurred
-                    print "Port read error."
+                    print("Port read error.")
                     sys.exit(0)
             myCounter += 1
             # every second, transmit "Hello World"
             if (myCounter > 10):
                 msg = "Hello World!"
 
-                print "Transmitting %s..." % msg
+                print("Transmitting %s..." % msg)
 
                 # Adding 1 for NULL terminator.
                 # Note that SWIG automatically adds a NULL terminator,

--- a/examples/python/hp20x.py
+++ b/examples/python/hp20x.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_hp20x as barometerObj
+from upm import pyupm_hp20x as barometerObj
 
 def main():
     ## Exit handlers ##
@@ -33,7 +34,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from ringCoder
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,10 +48,10 @@ def main():
     bar.init()
 
     while(1):
-        print "Temperature:", bar.getTemperature(), "Celsius"
-        print "Pressure:   ", bar.getPressure(), "Millibars"
-        print "Altitude:   ", bar.getAltitude(), "Meters"
-        print
+        print("Temperature:", bar.getTemperature(), "Celsius")
+        print("Pressure:   ", bar.getPressure(), "Millibars")
+        print("Altitude:   ", bar.getAltitude(), "Meters")
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/ht9170.py
+++ b/examples/python/ht9170.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ht9170 as upmHt9170
+from upm import pyupm_ht9170 as upmHt9170
 
 def main():
     # Instantiate a DTMF decoder
@@ -35,7 +36,7 @@ def main():
 
     # This lets you run code on exit, including functions from myDTMF
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,7 +48,7 @@ def main():
     # and continue looping.
     while (1):
         if (dtmf_obj.digitReady()):
-            print "Got DTMF code:", dtmf_obj.decodeDigit()
+            print("Got DTMF code:", dtmf_obj.decodeDigit())
             # now spin until digitReady() goes false again
             while (dtmf.digitReady()):
                 pass

--- a/examples/python/hwxpxx.py
+++ b/examples/python/hwxpxx.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_hwxpxx as sensorObj
+from upm import pyupm_hwxpxx as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,21 +46,21 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Using device", defaultDev
-    print "Initializing..."
+    print("Using device", defaultDev)
+    print("Initializing...")
 
     # Instantiate an HWXPXX instance, using MODBUS slave address 3, and
     # default comm parameters (19200, 8, N, 2)
     sensor = sensorObj.HWXPXX(defaultDev, 3)
 
     # output the serial number and firmware revision
-    print "Slave ID:", sensor.getSlaveID()
+    print("Slave ID:", sensor.getSlaveID())
 
     # stored temperature and humidity offsets
-    print "Temperature Offset:", sensor.getTemperatureOffset()
-    print "Humidity Offset:", sensor.getHumidityOffset()
+    print("Temperature Offset:", sensor.getTemperatureOffset())
+    print("Humidity Offset:", sensor.getHumidityOffset())
 
-    print
+    print()
 
     # update and print available values every second
     while (1):
@@ -67,16 +68,16 @@ def main():
         sensor.update()
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Humidity:", sensor.getHumidity(), "%"
+        print("Humidity:", sensor.getHumidity(), "%")
 
-        print "Slider:", sensor.getSlider(), "%"
+        print("Slider:", sensor.getSlider(), "%")
 
-        print "Override Switch Status:", sensor.getOverrideSwitchStatus()
+        print("Override Switch Status:", sensor.getOverrideSwitchStatus())
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/ili9341.py
+++ b/examples/python/ili9341.py
@@ -22,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_ili9341 as ili9341
+from upm import pyupm_ili9341 as ili9341
 
 def main():
     # Pins (Edison)

--- a/examples/python/ina132.py
+++ b/examples/python/ina132.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ina132 as upmIna132
+from upm import pyupm_ina132 as upmIna132
 
 def main():
     # Tested with the INA132 Differential Amplifier Sensor module.
@@ -37,7 +38,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myDifferentialAmplifier
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,7 +46,7 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     while(1):
-        print myDifferentialAmplifier.value()
+        print(myDifferentialAmplifier.value())
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/isd1820.py
+++ b/examples/python/isd1820.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, atexit
-import pyupm_isd1820 as upmIsd1820
+from upm import pyupm_isd1820 as upmIsd1820
 
 def main():
     # Instantiate a ISD1820 on digital pins 2 (play) and 3 (record)
@@ -42,7 +43,7 @@ def main():
             myRecorder.record(False)
         else:
             myRecorder.play(False)
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,10 +52,10 @@ def main():
     # if an argument was specified (any argument), go into record mode,
     # else playback a previously recorded sample
 
-    print "Supply any argument to the command line to record."
-    print "Running this example without arguments will play back any "
-    print "previously recorded sound."
-    print "There is approximately 10 seconds of recording time.\n"
+    print("Supply any argument to the command line to record.")
+    print("Running this example without arguments will play back any ")
+    print("previously recorded sound.")
+    print("There is approximately 10 seconds of recording time.\n")
 
     # depending on what was selected, do it, and sleep for 15 seconds
     if (doRecord):
@@ -64,7 +65,7 @@ def main():
 
     # There are about 10 seconds of recording/playback time, so we will
     # sleep for a little extra time.
-    print "Sleeping for 15 seconds..."
+    print("Sleeping for 15 seconds...")
     time.sleep(15)
 
     # exitHandler runs automatically

--- a/examples/python/itg3200.py
+++ b/examples/python/itg3200.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: John Van Drasek <john.r.van.drasek@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_itg3200 as itg3200
+from upm import pyupm_itg3200 as itg3200
 
 def main():
     # Create an I2C gyro object
@@ -31,12 +32,12 @@ def main():
         gyro.update() # Update the data
         rot = gyro.getRawValues() # Read raw sensor data
         ang = gyro.getRotation() # Read rotational speed (deg/sec)
-        print "Raw: %6d %6d %6d" % (rot[0], rot[1], rot[2])
-        print "AngX: %5.2f" % (ang[0])
-        print "AngY: %5.2f" % (ang[1])
-        print "AngZ: %5.2f" % (ang[2])
-        print "Temp: %5.2f Raw: %6d" % (gyro.getTemperature(), gyro.getRawTemp())
-        print ' '
+        print("Raw: %6d %6d %6d" % (rot[0], rot[1], rot[2]))
+        print("AngX: %5.2f" % (ang[0]))
+        print("AngY: %5.2f" % (ang[1]))
+        print("AngZ: %5.2f" % (ang[2]))
+        print("Temp: %5.2f Raw: %6d" % (gyro.getTemperature(), gyro.getRawTemp()))
+        print(' ')
         time.sleep(1)
 
     # Delete the gyro object

--- a/examples/python/jhd1313m1-lcd.py
+++ b/examples/python/jhd1313m1-lcd.py
@@ -21,7 +21,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import pyupm_i2clcd as lcd
+from upm import pyupm_i2clcd as lcd
 
 def main():
     # Initialize Jhd1313m1 at 0x3E (LCD_ADDRESS) and 0x62 (RGB_ADDRESS)

--- a/examples/python/joystick12.py
+++ b/examples/python/joystick12.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_joystick12 as upmJoystick12
+from upm import pyupm_joystick12 as upmJoystick12
 
 def main():
     # Instantiate a joystick on analog pins A0 and A1
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myJoystick
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -46,7 +47,7 @@ def main():
     while(1):
         XString = "Driving X:" + str(myJoystick.getXInput())
         YString = ": and Y:" + str(myJoystick.getYInput())
-        print XString + YString
+        print(XString + YString)
 
         time.sleep(1)
 

--- a/examples/python/l298-stepper.py
+++ b/examples/python/l298-stepper.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_l298 as upmL298
+from upm import pyupm_l298 as upmL298
 
 def main():
     # Instantiate a Stepper motor on a L298 Dual H-Bridge.
@@ -37,7 +38,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myHBridge
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -48,14 +49,14 @@ def main():
     myHBridge.setDirection(upmL298.L298.DIR_CW)
     myHBridge.enable(True)
 
-    print "Rotating 1 full revolution at 10 RPM speed."
+    print("Rotating 1 full revolution at 10 RPM speed.")
     # move 200 steps, a full rev
     myHBridge.stepperSteps(200)
 
-    print "Sleeping for 2 seconds..."
+    print("Sleeping for 2 seconds...")
     time.sleep(2)
 
-    print "Rotating 1/2 revolution in opposite direction at 10 RPM speed."
+    print("Rotating 1/2 revolution in opposite direction at 10 RPM speed.")
     myHBridge.setDirection(upmL298.L298.DIR_CCW)
     myHBridge.stepperSteps(100)
 

--- a/examples/python/l298.py
+++ b/examples/python/l298.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_l298 as upmL298
+from upm import pyupm_l298 as upmL298
 
 def main():
     # Instantiate one of the 2 possible DC motors on a L298 Dual
@@ -38,21 +39,21 @@ def main():
     # This lets you run code on exit,
     # including functions from myHBridge
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Starting motor at 50% for 3 seconds..."
+    print("Starting motor at 50% for 3 seconds...")
     myHBridge.setSpeed(50)
     myHBridge.setDirection(upmL298.L298.DIR_CW)
     myHBridge.enable(True)
 
     time.sleep(3)
 
-    print "Reversing direction..."
+    print("Reversing direction...")
     myHBridge.setDirection(upmL298.L298.DIR_NONE) # fast stop
     myHBridge.setDirection(upmL298.L298.DIR_CCW)
     time.sleep(3);

--- a/examples/python/ldt0028.py
+++ b/examples/python/ldt0028.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -22,7 +23,7 @@
 
 import time
 import array
-import pyupm_ldt0028 as ldt0028
+from upm import pyupm_ldt0028 as ldt0028
 
 def main():
     NUMBER_OF_SECONDS = 10
@@ -33,8 +34,8 @@ def main():
     sensor = ldt0028.LDT0028(0)
 
     # Read the signal every 20 milliseconds for 10 seconds
-    print 'For the next', NUMBER_OF_SECONDS, 'seconds,', \
-          SAMPLES_PER_SECOND, 'samples will be taken every second.\n'
+    print('For the next', NUMBER_OF_SECONDS, 'seconds,', \
+          SAMPLES_PER_SECOND, 'samples will be taken every second.\n')
     buffer = array.array('H')
     for i in range(0, NUMBER_OF_SECONDS * SAMPLES_PER_SECOND):
         buffer.append(sensor.getSample())
@@ -45,15 +46,15 @@ def main():
     for i in range(0, NUMBER_OF_SECONDS * SAMPLES_PER_SECOND):
         if buffer[i] > THRESHOLD:
             count += 1
-    print sensor.name(), ' exceeded the threshold value of', \
-            THRESHOLD, 'a total of', count, 'times,'
-    print 'out of a total of', NUMBER_OF_SECONDS*SAMPLES_PER_SECOND, \
-            'reading.\n'
+    print(sensor.name(), ' exceeded the threshold value of', \
+            THRESHOLD, 'a total of', count, 'times,')
+    print('out of a total of', NUMBER_OF_SECONDS*SAMPLES_PER_SECOND, \
+            'reading.\n')
 
     # Print a graphical representation of the average value sampled
     # each second for the past 10 seconds, using a scale factor of 15
-    print 'Now printing a graphical representation of the average reading '
-    print 'each second for the last', NUMBER_OF_SECONDS, 'seconds.'
+    print('Now printing a graphical representation of the average reading ')
+    print('each second for the last', NUMBER_OF_SECONDS, 'seconds.')
     SCALE_FACTOR = 15
     for i in range(0, NUMBER_OF_SECONDS):
         sum = 0
@@ -61,7 +62,7 @@ def main():
             sum += buffer[i*SAMPLES_PER_SECOND+j]
         average = sum / SAMPLES_PER_SECOND
         stars_to_print = int(round(average / SCALE_FACTOR))
-        print '(' + repr(int(round(average))).rjust(4) + ') |', '*' * stars_to_print
+        print('(' + repr(int(round(average))).rjust(4) + ') |', '*' * stars_to_print)
 
     # Delete the sensor object
     del sensor

--- a/examples/python/led.py
+++ b/examples/python/led.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,14 +22,14 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_led as led
+from upm import pyupm_led as led
 
 def main():
     # Create the Grove LED object using GPIO pin 2
     led = led.Led(2)
 
     # Print the name
-    print led.name()
+    print(led.name())
 
     # Turn the LED on and off 10 times, pausing one second
     # between transitions

--- a/examples/python/light.py
+++ b/examples/python/light.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_light as light
+from upm import pyupm_light as light
 
 def main():
     # Create the light sensor object using AIO pin 0
@@ -30,8 +31,8 @@ def main():
     # Read the input and print both the raw value and a rough lux value,
     # waiting one second between readings
     while 1:
-        print light.name() + " raw value is %d" % light.raw_value() + \
-            ", which is roughly %d" % light.value() + " lux";
+        print(light.name() + " raw value is %d" % light.raw_value() + \
+            ", which is roughly %d" % light.value() + " lux");
         time.sleep(1)
 
     # Delete the light sensor object

--- a/examples/python/linefinder.py
+++ b/examples/python/linefinder.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_linefinder as upmlinefinder
+from upm import pyupm_linefinder as upmlinefinder
 
 def main():
     # Instantiate a  line finder sensor on digital pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myLineFinder
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,9 +45,9 @@ def main():
 
     while(1):
         if (myLineFinder.whiteDetected()):
-            print "White detected."
+            print("White detected.")
         else:
-            print "Black detected."
+            print("Black detected.")
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/lm35.py
+++ b/examples/python/lm35.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_lm35 as sensorObj
+from upm import pyupm_lm35 as sensorObj
 
 def main():
     # Instantiate a LM35 on analog pin A0, with a default analog
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -46,7 +47,7 @@ def main():
     # Every half second, sample the sensor and output the temperature
 
     while (1):
-        print "Temperature:", sensor.getTemperature(), "C"
+        print("Temperature:", sensor.getTemperature(), "C")
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/loudness.py
+++ b/examples/python/loudness.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_loudness as sensorObj
+from upm import pyupm_loudness as sensorObj
 
 def main():
     # Instantiate a Loudness sensor on analog pin A0, with an analog
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,7 +48,7 @@ def main():
     # corresponding analog voltage.
 
     while (1):
-        print "Detected loudness (volts): ", sensor.loudness()
+        print("Detected loudness (volts): ", sensor.loudness())
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/lsm303.py
+++ b/examples/python/lsm303.py
@@ -23,8 +23,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_lsm303 as lsm303
+from upm import pyupm_lsm303 as lsm303
 
 def main():
     # Instantiate LSM303 compass on I2C
@@ -38,7 +39,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myAccelrCompass
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -57,15 +58,15 @@ def main():
         outputStr = "coor: rX {0} - rY {1} - rZ {2}".format(
         coords.__getitem__(0), coords.__getitem__(1),
         coords.__getitem__(2))
-        print outputStr
+        print(outputStr)
 
         outputStr = "coor: gX {0} - gY {1} - gZ {2}".format(
         myAccelrCompass.getCoorX(), myAccelrCompass.getCoorY(),
         myAccelrCompass.getCoorZ())
-        print outputStr
+        print(outputStr)
 
         # Get and print out the heading
-        print "heading:", myAccelrCompass.getHeading()
+        print("heading:", myAccelrCompass.getHeading())
 
         # Get the acceleration
         myAccelrCompass.getAcceleration();
@@ -75,14 +76,14 @@ def main():
         # using two different methods
         outputStr = "acc: rX {0} - rY {1} - Z {2}".format(
         accel.__getitem__(0), accel.__getitem__(1), accel.__getitem__(2))
-        print outputStr
+        print(outputStr)
 
         outputStr = "acc: gX {0} - gY {1} - gZ {2}".format(
         myAccelrCompass.getAccelX(), myAccelrCompass.getAccelY(),
         myAccelrCompass.getAccelZ())
-        print outputStr
+        print(outputStr)
 
-        print " "
+        print(" ")
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/lsm9ds0.py
+++ b/examples/python/lsm9ds0.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_lsm9ds0 as sensorObj
+from upm import pyupm_lsm9ds0 as sensorObj
 
 def main():
     # Instantiate an LSM9DS0 using default parameters (bus 1, gyro addr 6b,
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -52,22 +53,22 @@ def main():
     while (1):
         sensor.update()
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer: AX: ", sensorObj.floatp_value(x),
-        print " AY: ", sensorObj.floatp_value(y),
-        print " AZ: ", sensorObj.floatp_value(z)
+        print("Accelerometer: AX: ", sensorObj.floatp_value(x), end=' ')
+        print(" AY: ", sensorObj.floatp_value(y), end=' ')
+        print(" AZ: ", sensorObj.floatp_value(z))
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope:     GX: ", sensorObj.floatp_value(x),
-        print " GY: ", sensorObj.floatp_value(y),
-        print " GZ: ", sensorObj.floatp_value(z)
+        print("Gyroscope:     GX: ", sensorObj.floatp_value(x), end=' ')
+        print(" GY: ", sensorObj.floatp_value(y), end=' ')
+        print(" GZ: ", sensorObj.floatp_value(z))
 
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer:  MX: ", sensorObj.floatp_value(x),
-        print " MY: ", sensorObj.floatp_value(y),
-        print " MZ: ", sensorObj.floatp_value(z)
+        print("Magnetometer:  MX: ", sensorObj.floatp_value(x), end=' ')
+        print(" MY: ", sensorObj.floatp_value(y), end=' ')
+        print(" MZ: ", sensorObj.floatp_value(z))
 
-        print "Temperature:  ", sensor.getTemperature()
-        print
+        print("Temperature:  ", sensor.getTemperature())
+        print()
 
         time.sleep(.5)
 

--- a/examples/python/m24lr64e.py
+++ b/examples/python/m24lr64e.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
-import pyupm_m24lr64e as nfcTagObj
+from upm import pyupm_m24lr64e as nfcTagObj
 
 def main():
     # Instantiate a M24LR64E Grove NFC Tag Module on UART 0
@@ -34,19 +35,19 @@ def main():
 
     # Read the last byte of the EEPROM area
     addr = (nfcTagObj.M24LR64E.EEPROM_I2C_LENGTH - 1)
-    print "Address: ", addr
+    print("Address: ", addr)
     byte = nfcTag.readByte(addr)
 
-    print "Read byte: ", format(byte, '02x')
+    print("Read byte: ", format(byte, '02x'))
 
     # Now change it to it's opposite and write it
     byte = (~byte & 0xff)
     nfcTag.writeByte(addr, byte)
-    print "Wrote inverted byte: ", format(byte, '02x')
+    print("Wrote inverted byte: ", format(byte, '02x'))
 
     # Now read it back.
     byte = nfcTag.readByte(addr)
-    print "Read byte: ", format(byte, '02x')
+    print("Read byte: ", format(byte, '02x'))
 
 if __name__ == '__main__':
     main()

--- a/examples/python/maxsonarez.py
+++ b/examples/python/maxsonarez.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_maxsonarez as MaxSonarEZ
+from upm import pyupm_maxsonarez as MaxSonarEZ
 
 def main():
     # Instantiate a MaxSonar-EZ on analog pin A1, with an analog
@@ -37,7 +38,7 @@ def main():
     # This lets you run code on exit,
     # including functions from Sonar
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -54,9 +55,9 @@ def main():
     # between 6 and 33 inches
 
     while (1):
-        print "AREF: {0}, distance in inches: {1}".format(
+        print("AREF: {0}, distance in inches: {1}".format(
                 MAXSONAREZ_AREF,
-                Sonar.inches())
+                Sonar.inches()))
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/md-stepper.py
+++ b/examples/python/md-stepper.py
@@ -22,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_md as upmmd
+from upm import pyupm_md as upmmd
 
 def main():
     I2C_BUS = upmmd.MD_I2C_BUS

--- a/examples/python/md.py
+++ b/examples/python/md.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time
-import pyupm_md as upmmd
+from upm import pyupm_md as upmmd
 
 def main():
     I2C_BUS = upmmd.MD_I2C_BUS
@@ -32,18 +33,18 @@ def main():
     myMotorDriver = upmmd.MD(I2C_BUS, I2C_ADDR)
 
     # set direction to CW and set speed to 50%
-    print "Spin M1 and M2 at half speed for 3 seconds"
+    print("Spin M1 and M2 at half speed for 3 seconds")
     myMotorDriver.setMotorDirections(upmmd.MD.DIR_CW, upmmd.MD.DIR_CW)
     myMotorDriver.setMotorSpeeds(127, 127)
 
     time.sleep(3)
     # counter clockwise
-    print "Reversing M1 and M2 for 3 seconds"
+    print("Reversing M1 and M2 for 3 seconds")
     myMotorDriver.setMotorDirections(upmmd.MD.DIR_CCW,
     upmmd.MD.DIR_CCW)
     time.sleep(3)
 
-    print "Stopping motors"
+    print("Stopping motors")
     myMotorDriver.setMotorSpeeds(0, 0)
 
 if __name__ == '__main__':

--- a/examples/python/mg811.py
+++ b/examples/python/mg811.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mg811 as sensorObj
+from upm import pyupm_mg811 as sensorObj
 
 def main():
     # Instantiate an MG811 on analog pin A0, and digital pin D2 with an
@@ -37,7 +38,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -48,7 +49,7 @@ def main():
     # detected CO2 concentration in parts per million (ppm)
 
     while (1):
-        print "CO2 concentration in PPM: ", sensor.ppm()
+        print("CO2 concentration in PPM: ", sensor.ppm())
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/mhz16.py
+++ b/examples/python/mhz16.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mhz16 as upmMhz16
+from upm import pyupm_mhz16 as upmMhz16
 
 def main():
     # Instantiate a MHZ16 serial CO2 sensor on uart 0.
@@ -37,7 +38,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myCO2
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -46,7 +47,7 @@ def main():
 
     # make sure port is initialized properly.  9600 baud is the default.
     if (not myCO2.setupTty(upmMhz16.cvar.int_B9600)):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(0)
 
     print ("Make sure that the sensor has had "
@@ -59,12 +60,12 @@ def main():
 
     while(1):
         if (not myCO2.getData()):
-            print "Failed to retrieve data"
+            print("Failed to retrieve data")
         else:
             outputStr = ("CO2 concentration: {0} PPM, "
             "Temperature (in C): {1}".format(
             myCO2.getGas(), myCO2.getTemperature()))
-            print outputStr
+            print(outputStr)
 
         time.sleep(2)
 

--- a/examples/python/mic.py
+++ b/examples/python/mic.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: John Van Drasek <john.r.van.drasek@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_mic as upmMicrophone
+from upm import pyupm_mic as upmMicrophone
 
 def main():
     # Attach microphone to analog port A0
@@ -42,7 +43,7 @@ def main():
             thresh = myMic.findThreshold(threshContext, 30, buffer, len)
             myMic.printGraph(threshContext)
             if(thresh):
-                print "Threshold is ", thresh
+                print("Threshold is ", thresh)
 
     # Delete the upmMicrophone object
     del myMic

--- a/examples/python/mma7361.py
+++ b/examples/python/mma7361.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mma7361 as sensorObj
+from upm import pyupm_mma7361 as sensorObj
 
 def main():
     # Instantiate a MMA7361 sensor on analog pins A0 (X), A1 (Y) A2
@@ -41,7 +42,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -57,16 +58,16 @@ def main():
         sensor.update()
 
         sensor.getAcceleration(x, y, z)
-        print "Accelerometer x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z)
+        print("Accelerometer x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z))
 
         sensor.getVolts(x, y, z)
-        print "Volts x:", sensorObj.floatp_value(x),
-        print " y:", sensorObj.floatp_value(y),
-        print " z:", sensorObj.floatp_value(z)
+        print("Volts x:", sensorObj.floatp_value(x), end=' ')
+        print(" y:", sensorObj.floatp_value(y), end=' ')
+        print(" z:", sensorObj.floatp_value(z))
 
-        print
+        print()
         time.sleep(.100)
 
 if __name__ == '__main__':

--- a/examples/python/mma7660.py
+++ b/examples/python/mma7660.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mma7660 as upmMMA7660
+from upm import pyupm_mma7660 as upmMMA7660
 
 def main():
     # Instantiate an MMA7660 on I2C bus 0
@@ -37,7 +38,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myDigitalAccelerometer
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -68,7 +69,7 @@ def main():
         " z = {2}").format(upmMMA7660.intp_value(x),
         upmMMA7660.intp_value(y),
         upmMMA7660.intp_value(z))
-        print outputStr
+        print(outputStr)
 
         myDigitalAccelerometer.getAcceleration(ax, ay, az)
         outputStr = ("Acceleration: x = {0}"
@@ -76,7 +77,7 @@ def main():
         "g z = {2}g").format(upmMMA7660.floatp_value(ax),
         upmMMA7660.floatp_value(ay),
         upmMMA7660.floatp_value(az))
-        print outputStr
+        print(outputStr)
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/moisture.py
+++ b/examples/python/moisture.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_moisture as upmMoisture
+from upm import pyupm_moisture as upmMoisture
 
 def main():
     # Instantiate a Grove Moisture sensor on analog pin A0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myMoisture
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -56,7 +57,7 @@ def main():
             result = "Moist"
         else:
             result = "Wet"
-        print "Moisture value: {0}, {1}".format(moisture_val, result)
+        print("Moisture value: {0}, {1}".format(moisture_val, result))
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/mpr121.py
+++ b/examples/python/mpr121.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mpr121 as upmMpr121
+from upm import pyupm_mpr121 as upmMpr121
 
 def main():
     I2C_BUS = upmMpr121.MPR121_I2C_BUS
@@ -39,7 +40,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myTouchSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -59,10 +60,10 @@ def main():
         if (not buttonPressed):
             outputStr += "None"
 
-        print outputStr
+        print(outputStr)
 
         if (touchSensor.m_overCurrentFault):
-            print "Over Current Fault detected!"
+            print("Over Current Fault detected!")
 
     while(1):
         myTouchSensor.readButtons()

--- a/examples/python/mpu60x0.py
+++ b/examples/python/mpu60x0.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mpu9150 as sensorObj
+from upm import pyupm_mpu9150 as sensorObj
 
 def main():
     # Instantiate an MPU60X0 on I2C bus 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,17 +52,17 @@ def main():
     while (1):
         sensor.update()
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer: AX: ", sensorObj.floatp_value(x),
-        print " AY: ", sensorObj.floatp_value(y),
-        print " AZ: ", sensorObj.floatp_value(z)
+        print("Accelerometer: AX: ", sensorObj.floatp_value(x), end=' ')
+        print(" AY: ", sensorObj.floatp_value(y), end=' ')
+        print(" AZ: ", sensorObj.floatp_value(z))
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope:     GX: ", sensorObj.floatp_value(x),
-        print " GY: ", sensorObj.floatp_value(y),
-        print " GZ: ", sensorObj.floatp_value(z)
+        print("Gyroscope:     GX: ", sensorObj.floatp_value(x), end=' ')
+        print(" GY: ", sensorObj.floatp_value(y), end=' ')
+        print(" GZ: ", sensorObj.floatp_value(z))
 
-        print "Temperature:  ", sensor.getTemperature()
-        print
+        print("Temperature:  ", sensor.getTemperature())
+        print()
 
         time.sleep(.5)
 

--- a/examples/python/mpu9150.py
+++ b/examples/python/mpu9150.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mpu9150 as sensorObj
+from upm import pyupm_mpu9150 as sensorObj
 
 def main():
     # Instantiate an MPU9150 on I2C bus 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,22 +52,22 @@ def main():
     while (1):
         sensor.update()
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer: AX: ", sensorObj.floatp_value(x),
-        print " AY: ", sensorObj.floatp_value(y),
-        print " AZ: ", sensorObj.floatp_value(z)
+        print("Accelerometer: AX: ", sensorObj.floatp_value(x), end=' ')
+        print(" AY: ", sensorObj.floatp_value(y), end=' ')
+        print(" AZ: ", sensorObj.floatp_value(z))
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope:     GX: ", sensorObj.floatp_value(x),
-        print " GY: ", sensorObj.floatp_value(y),
-        print " GZ: ", sensorObj.floatp_value(z)
+        print("Gyroscope:     GX: ", sensorObj.floatp_value(x), end=' ')
+        print(" GY: ", sensorObj.floatp_value(y), end=' ')
+        print(" GZ: ", sensorObj.floatp_value(z))
 
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer:  MX: ", sensorObj.floatp_value(x),
-        print " MY: ", sensorObj.floatp_value(y),
-        print " MZ: ", sensorObj.floatp_value(z)
+        print("Magnetometer:  MX: ", sensorObj.floatp_value(x), end=' ')
+        print(" MY: ", sensorObj.floatp_value(y), end=' ')
+        print(" MZ: ", sensorObj.floatp_value(z))
 
-        print "Temperature:  ", sensor.getTemperature()
-        print
+        print("Temperature:  ", sensor.getTemperature())
+        print()
 
         time.sleep(.5)
 

--- a/examples/python/mpu9250.py
+++ b/examples/python/mpu9250.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_mpu9150 as sensorObj
+from upm import pyupm_mpu9150 as sensorObj
 
 def main():
     # Instantiate an MPU9250 on I2C bus 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -51,22 +52,22 @@ def main():
     while (1):
         sensor.update()
         sensor.getAccelerometer(x, y, z)
-        print "Accelerometer: AX: ", sensorObj.floatp_value(x),
-        print " AY: ", sensorObj.floatp_value(y),
-        print " AZ: ", sensorObj.floatp_value(z)
+        print("Accelerometer: AX: ", sensorObj.floatp_value(x), end=' ')
+        print(" AY: ", sensorObj.floatp_value(y), end=' ')
+        print(" AZ: ", sensorObj.floatp_value(z))
 
         sensor.getGyroscope(x, y, z)
-        print "Gyroscope:     GX: ", sensorObj.floatp_value(x),
-        print " GY: ", sensorObj.floatp_value(y),
-        print " GZ: ", sensorObj.floatp_value(z)
+        print("Gyroscope:     GX: ", sensorObj.floatp_value(x), end=' ')
+        print(" GY: ", sensorObj.floatp_value(y), end=' ')
+        print(" GZ: ", sensorObj.floatp_value(z))
 
         sensor.getMagnetometer(x, y, z)
-        print "Magnetometer:  MX: ", sensorObj.floatp_value(x),
-        print " MY: ", sensorObj.floatp_value(y),
-        print " MZ: ", sensorObj.floatp_value(z)
+        print("Magnetometer:  MX: ", sensorObj.floatp_value(x), end=' ')
+        print(" MY: ", sensorObj.floatp_value(y), end=' ')
+        print(" MZ: ", sensorObj.floatp_value(z))
 
-        print "Temperature:  ", sensor.getTemperature()
-        print
+        print("Temperature:  ", sensor.getTemperature())
+        print()
 
         time.sleep(.5)
 

--- a/examples/python/mq2.py
+++ b/examples/python/mq2.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGas
+from upm import pyupm_gas as upmGas
 
 def main():
     # Attach gas sensor to AIO0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myMQ2
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -58,7 +59,7 @@ def main():
             thresh = myMQ2.findThreshold(threshContext, 30, mybuffer, samplelen)
             myMQ2.printGraph(threshContext, 5)
             if(thresh):
-                print "Threshold is ", thresh
+                print("Threshold is ", thresh)
 
 if __name__ == '__main__':
     main()

--- a/examples/python/mq3.py
+++ b/examples/python/mq3.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGas
+from upm import pyupm_gas as upmGas
 
 def main():
     # Attach gas sensor to AIO0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myMQ3
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -58,7 +59,7 @@ def main():
             thresh = myMQ3.findThreshold(threshContext, 30, mybuffer, samplelen)
             myMQ3.printGraph(threshContext, 5)
             if(thresh):
-                print "Threshold is ", thresh
+                print("Threshold is ", thresh)
 
 if __name__ == '__main__':
     main()

--- a/examples/python/mq303a.py
+++ b/examples/python/mq303a.py
@@ -21,10 +21,11 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
 
 # Load alcohol sensor module
-import pyupm_mq303a as upmMq303a
+from upm import pyupm_mq303a as upmMq303a
 
 def main():
     # Instantiate an mq303a sensor on analog pin A0
@@ -41,21 +42,21 @@ def main():
 
     # This function lets you run code on exit, including functions from myAlcoholSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Enabling heater and waiting 2 minutes for warmup."
+    print("Enabling heater and waiting 2 minutes for warmup.")
 
     # give time updates every 30 seconds until 2 minutes have passed
     # for the alcohol sensor to warm up
     def warmup(iteration):
         totalSeconds = (30 * iteration)
         time.sleep(30)
-        print totalSeconds, "seconds have passed"
+        print(totalSeconds, "seconds have passed")
     warmup(1)
     warmup(2)
     warmup(3)
@@ -63,14 +64,14 @@ def main():
 
     notice = ("This sensor may need to warm "
     "until the value drops below about 450.")
-    print notice
+    print(notice)
 
     # Print the detected alcohol value every second
     while(1):
         val = myAlcoholSensor.value()
         msg = "Alcohol detected "
         msg += "(higher means stronger alcohol): "
-        print msg + str(val)
+        print(msg + str(val))
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/mq4.py
+++ b/examples/python/mq4.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGAS
+from upm import pyupm_gas as upmGAS
 
 def main():
     # Attach gas sensor to Analog A0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from sensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers

--- a/examples/python/mq5.py
+++ b/examples/python/mq5.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGas
+from upm import pyupm_gas as upmGas
 
 def main():
     # Attach gas sensor to AIO0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myMQ5
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -58,7 +59,7 @@ def main():
             thresh = myMQ5.findThreshold(threshContext, 30, mybuffer, samplelen)
             myMQ5.printGraph(threshContext, 5)
             if(thresh):
-                print "Threshold is ", thresh
+                print("Threshold is ", thresh)
 
 if __name__ == '__main__':
     main()

--- a/examples/python/mq6.py
+++ b/examples/python/mq6.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGAS
+from upm import pyupm_gas as upmGAS
 
 def main():
     # Attach gas sensor to Analog A0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from sensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers

--- a/examples/python/mq7.py
+++ b/examples/python/mq7.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGAS
+from upm import pyupm_gas as upmGAS
 
 def main():
     # Attach gas sensor to Analog A0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from sensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers

--- a/examples/python/mq8.py
+++ b/examples/python/mq8.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGAS
+from upm import pyupm_gas as upmGAS
 
 def main():
     # Attach gas sensor to Analog A0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from sensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers

--- a/examples/python/mq9.py
+++ b/examples/python/mq9.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_gas as upmGas
+from upm import pyupm_gas as upmGas
 
 def main():
     # Attach gas sensor to AIO0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myMQ9
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -58,7 +59,7 @@ def main():
             thresh = myMQ9.findThreshold(threshContext, 30, mybuffer, samplelen)
             myMQ9.printGraph(threshContext, 5)
             if(thresh):
-                print "Threshold is ", thresh
+                print("Threshold is ", thresh)
 
 if __name__ == '__main__':
     main()

--- a/examples/python/nlgpio16.py
+++ b/examples/python/nlgpio16.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys, signal, atexit
-import pyupm_nlgpio16 as sensorObj
+from upm import pyupm_nlgpio16 as sensorObj
 
 def main():
     # Instantiate a NLGPIO16 Module on the default UART (/dev/ttyACM0)
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -43,11 +44,11 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     # get the Version
-    print "Device Version:", sensor.getVersion()
+    print("Device Version:", sensor.getVersion())
     # read the gpio at pin 3
-    print "GPIO 3 Value:", sensor.gpioRead(3)
+    print("GPIO 3 Value:", sensor.gpioRead(3))
     # read the analog voltage at pin 5
-    print "Analog 5 Voltage:", sensor.analogReadVolts(5)
+    print("Analog 5 Voltage:", sensor.analogReadVolts(5))
     # set the gpio at pin 14 to HIGH
     sensor.gpioSet(14)
 

--- a/examples/python/nmea_gps.py
+++ b/examples/python/nmea_gps.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_nmea_gps as sensorObj
+from upm import pyupm_nmea_gps as sensorObj
 
 def main():
     # Instantiate a NMEAGPS sensor on uart 0 at 9600 baud with enable
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,7 +48,7 @@ def main():
     while (sensor.dataAvailable(5000)):
         sys.stdout.write(sensor.readStr(256))
 
-    print "Timed out"
+    print("Timed out")
 
 if __name__ == '__main__':
     main()

--- a/examples/python/nmea_gps_i2c.py
+++ b/examples/python/nmea_gps_i2c.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_nmea_gps as sensorObj
+from upm import pyupm_nmea_gps as sensorObj
 
 def main():
     # Instantiate a NMEA_GPS UBLOX based i2c sensor on i2c bus 0 at
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers

--- a/examples/python/nunchuck.py
+++ b/examples/python/nunchuck.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_nunchuck as upmNunchuck
+from upm import pyupm_nunchuck as upmNunchuck
 
 def main():
     # Instantiate a nunchuck controller bus 0 on I2C
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myNunchuck
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -43,9 +44,9 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     # always do this first
-    print "Initializing... "
+    print("Initializing... ")
     if (not myNunchuck.init()):
-        print "nunchuck->init() failed."
+        print("nunchuck->init() failed.")
         sys.exit(0);
 
     def buttonStateStr(buttonState):
@@ -57,17 +58,17 @@ def main():
 
         outputStr = "stickX: {0}, stickY: {1}".format(
         myNunchuck.stickX, myNunchuck.stickY)
-        print outputStr
+        print(outputStr)
         outputStr = "accelX: {0}, accelY: {1}, accelZ: {2}".format(
         myNunchuck.accelX, myNunchuck.accelY, myNunchuck.accelZ)
-        print outputStr
+        print(outputStr)
 
         outputStr = "button C: {0}".format(
         buttonStateStr(myNunchuck.buttonC))
-        print outputStr
+        print(outputStr)
         outputStr = "button Z: {0}".format(
         buttonStateStr(myNunchuck.buttonZ))
-        print outputStr
+        print(outputStr)
 
         time.sleep(.1)
 

--- a/examples/python/o2.py
+++ b/examples/python/o2.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_o2 as upmO2
+from upm import pyupm_o2 as upmO2
 
 def main():
     # This was tested with the O2 Oxygen Concentration Sensor Module
@@ -36,7 +37,7 @@ def main():
 
     # This lets you run code on exit, including functions from myO2
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,8 +45,8 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     while(1):
-        print "The output voltage is: {0}mV".format(
-        myO2.voltageValue())
+        print("The output voltage is: {0}mV".format(
+        myO2.voltageValue()))
 
         time.sleep(.1)
 

--- a/examples/python/oled_ssd1308.py
+++ b/examples/python/oled_ssd1308.py
@@ -22,8 +22,9 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Load i2clcd display module
+from __future__ import print_function
 import time, signal, sys
-import pyupm_i2clcd as upmLCD
+from upm import pyupm_i2clcd as upmLCD
 
 def main():
     myLCD = upmLCD.SSD1308(0, 0x3C);
@@ -93,7 +94,7 @@ def main():
 
     del intelLogo
     del myLCD
-    print "Exiting"
+    print("Exiting")
 
 if __name__ == '__main__':
     main()

--- a/examples/python/oled_ssd1327.py
+++ b/examples/python/oled_ssd1327.py
@@ -22,8 +22,9 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Load i2clcd display module
+from __future__ import print_function
 import time, signal, sys
-import pyupm_i2clcd as upmLCD
+from upm import pyupm_i2clcd as upmLCD
 
 def main():
     myLCD = upmLCD.SSD1327(0, 0x3C);
@@ -187,7 +188,7 @@ def main():
         myLCD.setGrayLevel(i)
         myLCD.write('Hello World')
 
-    print "Exiting"
+    print("Exiting")
 
 if __name__ == '__main__':
     main()

--- a/examples/python/otp538u.py
+++ b/examples/python/otp538u.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_otp538u as upmOtp538u
+from upm import pyupm_otp538u as upmOtp538u
 
 def main():
     # analog voltage, usually 3.3 or 5.0
@@ -40,7 +41,7 @@ def main():
 
     # This lets you run code on exit, including functions from myTempIR
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -52,7 +53,7 @@ def main():
         " C, Object temp: {1}"
         " C".format(myTempIR.ambientTemperature(),
         myTempIR.objectTemperature()))
-        print outputStr
+        print(outputStr)
 
         time.sleep(1)
 

--- a/examples/python/ozwdump.py
+++ b/examples/python/ozwdump.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ozw as sensorObj
+from upm import pyupm_ozw as sensorObj
 
 def main():
     # Instantiate an OZW instance
@@ -30,7 +31,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,13 +46,13 @@ def main():
     sensor.optionsLock()
 
     # Next, initialize it.
-    print "Initializing, this may take awhile depending on your ZWave network"
+    print("Initializing, this may take awhile depending on your ZWave network")
 
     sensor.init(defaultDev)
 
-    print "Initialization complete"
+    print("Initialization complete")
 
-    print "Dumping nodes..."
+    print("Dumping nodes...")
 
     sensor.dumpNodes(True)
 

--- a/examples/python/pn532-writeurl.py
+++ b/examples/python/pn532-writeurl.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_pn532 as upmPn532
+from upm import pyupm_pn532 as upmPn532
 
 def main():
     # Instantiate an PN532 on I2C bus 0 (default) using gpio 3 for the
@@ -36,7 +37,7 @@ def main():
 
     # This lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,15 +45,15 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     if (not myNFC.init()):
-        print "init() failed"
+        print("init() failed")
         sys.exit(0)
 
     vers = myNFC.getFirmwareVersion()
 
     if (vers):
-        print "Got firmware version: %08x" % vers
+        print("Got firmware version: %08x" % vers)
     else:
-        print "Could not identify PN532"
+        print("Could not identify PN532")
         sys.exit(0)
 
     # Now scan and identify any cards that come in range (1 for now)
@@ -77,21 +78,21 @@ def main():
         if (myNFC.readPassiveTargetID(upmPn532.PN532.BAUD_MIFARE_ISO14443A,
                                       uid, uidSize, 2000)):
             # found a card
-            print "Found a card: UID len", uidSize.__getitem__(0)
-            print "UID: ",
+            print("Found a card: UID len", uidSize.__getitem__(0))
+            print("UID: ", end=' ')
             for i in range(uidSize.__getitem__(0)):
-                print "%02x" % uid.__getitem__(i),
-            print
-            print "SAK: %02x" % myNFC.getSAK()
-            print "ATQA: %04x" % myNFC.getATQA()
-            print
+                print("%02x" % uid.__getitem__(i), end=' ')
+            print()
+            print("SAK: %02x" % myNFC.getSAK())
+            print("ATQA: %04x" % myNFC.getATQA())
+            print()
             foundCard = True
         else:
-            print "Waiting for a card...\n"
+            print("Waiting for a card...\n")
 
     if (uidSize.__getitem__(0) != 7):
-        print "This example will only write an NDEF URI to preformatted"
-        print "Mifare Ultralight or NTAG2XX tags"
+        print("This example will only write an NDEF URI to preformatted")
+        print("Mifare Ultralight or NTAG2XX tags")
         sys.exit(1)
 
     # 48 bytes is maximum data area on ultralight cards, so we use that
@@ -99,10 +100,10 @@ def main():
     # card, you can write more data.
     if (not myNFC.ntag2xx_WriteNDEFURI(upmPn532.PN532.NDEF_URIPREFIX_HTTP, url, 48)):
         # failure
-        print "Failed to write NDEF record tag."
+        print("Failed to write NDEF record tag.")
         sys.exit(1)
 
-    print "Success, URL record written to tag."
+    print("Success, URL record written to tag.")
 
 if __name__ == '__main__':
     main()

--- a/examples/python/pn532.py
+++ b/examples/python/pn532.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_pn532 as upmPn532
+from upm import pyupm_pn532 as upmPn532
 
 def main():
     # Instantiate an PN532 on I2C bus 0 (default) using gpio 3 for the
@@ -36,7 +37,7 @@ def main():
 
     # This lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,15 +45,15 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     if (not myNFC.init()):
-        print "init() failed"
+        print("init() failed")
         sys.exit(0)
 
     vers = myNFC.getFirmwareVersion()
 
     if (vers):
-        print "Got firmware version: %08x" % vers
+        print("Got firmware version: %08x" % vers)
     else:
-        print "Could not identify PN532"
+        print("Could not identify PN532")
         sys.exit(0)
 
     # Now scan and identify any cards that come in range (1 for now)
@@ -71,17 +72,17 @@ def main():
         if (myNFC.readPassiveTargetID(upmPn532.PN532.BAUD_MIFARE_ISO14443A,
                                       uid, uidSize, 2000)):
             # found a card
-            print "Found a card: UID len", uidSize.__getitem__(0)
-            print "UID: ",
+            print("Found a card: UID len", uidSize.__getitem__(0))
+            print("UID: ", end=' ')
             for i in range(uidSize.__getitem__(0)):
-                print "%02x" % uid.__getitem__(i),
-            print
-            print "SAK: %02x" % myNFC.getSAK()
-            print "ATQA: %04x" % myNFC.getATQA()
-            print
+                print("%02x" % uid.__getitem__(i), end=' ')
+            print()
+            print("SAK: %02x" % myNFC.getSAK())
+            print("ATQA: %04x" % myNFC.getATQA())
+            print()
             time.sleep(1)
         else:
-            print "Waiting for a card...\n"
+            print("Waiting for a card...\n")
 
 if __name__ == '__main__':
     main()

--- a/examples/python/ppd42ns.py
+++ b/examples/python/ppd42ns.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ppd42ns as upmPpd42ns
+from upm import pyupm_ppd42ns as upmPpd42ns
 
 def main():
     # Instantiate a dust sensor on digital pin D8
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myDustSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,15 +45,15 @@ def main():
 
     notice = ("This program will give readings "
     "every 30 seconds until you stop it")
-    print notice
+    print(notice)
 
     while(1):
         data = myDustSensor.getData()
         # we need to sleep for a bit for the data to print out
         time.sleep(.1)
-        print "Low pulse occupancy: " + str(data.lowPulseOccupancy)
-        print "Ratio: " + str(data.ratio)
-        print "Concentration: " + str(data.concentration)
+        print("Low pulse occupancy: " + str(data.lowPulseOccupancy))
+        print("Ratio: " + str(data.ratio))
+        print("Concentration: " + str(data.concentration))
 
 if __name__ == '__main__':
     main()

--- a/examples/python/relay.py
+++ b/examples/python/relay.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # Create the relay switch object using GPIO pin 0
@@ -34,11 +35,11 @@ def main():
     for i in range (0,3):
         relay.on()
         if relay.isOn():
-            print relay.name(), 'is on'
+            print(relay.name(), 'is on')
         time.sleep(1)
         relay.off()
         if relay.isOff():
-            print relay.name(), 'is off'
+            print(relay.name(), 'is off')
         time.sleep(1)
 
     # Delete the relay switch object

--- a/examples/python/rfr359f.py
+++ b/examples/python/rfr359f.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_rfr359f as upmRfr359f
+from upm import pyupm_rfr359f as upmRfr359f
 
 def main():
     # Instantiate an RFR359F digital pin D2
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myDistInterrupter
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,9 +46,9 @@ def main():
 
     while(1):
         if (myDistInterrupter.objectDetected()):
-            print "Object detected"
+            print("Object detected")
         else:
-            print "Area is clear"
+            print("Area is clear")
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/rgbringcoder.py
+++ b/examples/python/rgbringcoder.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_rgbringcoder as upmRGBRingCoder
+from upm import pyupm_rgbringcoder as upmRGBRingCoder
 
 def main():
     # There are a lot of pins to hook up.  These pins are valid for the
@@ -53,7 +54,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from ringCoder
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -78,13 +79,13 @@ def main():
         # check button state
         bstate = ringCoder.getButtonState()
         if (bstate != oldState):
-            print "Button state changed from", oldState, " to ", bstate
+            print("Button state changed from", oldState, " to ", bstate)
             oldState = bstate
 
         # check encoder position
         epos = ringCoder.getEncoderPosition()
         if (epos != oldPos):
-            print "Encoder position changed from", oldPos, "to", epos
+            print("Encoder position changed from", oldPos, "to", epos)
             oldPos = epos
 
         time.sleep(0.1)

--- a/examples/python/rhusb.py
+++ b/examples/python/rhusb.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_rhusb as sensorObj
+from upm import pyupm_rhusb as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,15 +46,15 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Using device", defaultDev
-    print "Initializing..."
+    print("Using device", defaultDev)
+    print("Initializing...")
 
     # Instantiate an RHUSB instance on defaultDev
     sensor = sensorObj.RHUSB(defaultDev)
 
     # output the firmware ID
-    print "Firmware ID:", sensor.getFirmwareID()
-    print
+    print("Firmware ID:", sensor.getFirmwareID())
+    print()
 
     # update and print available values every second
     while (1):
@@ -61,12 +62,12 @@ def main():
         sensor.update()
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Humidity:", sensor.getHumidity(), "%"
+        print("Humidity:", sensor.getHumidity(), "%")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/rotary.py
+++ b/examples/python/rotary.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
-import pyupm_grove as grove
+from upm import pyupm_grove as grove
 
 def main():
     # New knob on AIO pin 0
@@ -38,8 +39,8 @@ def main():
         reldeg = knob.rel_deg()
         relrad = knob.rel_rad()
 
-        print "Abs values: %4d" % int(abs) , " raw %4d" % int(absdeg), "deg = %5.2f" % absrad , " rad ",
-        print "Rel values: %4d" % int(rel) , " raw %4d" % int(reldeg), "deg = %5.2f" % relrad , " rad"
+        print("Abs values: %4d" % int(abs) , " raw %4d" % int(absdeg), "deg = %5.2f" % absrad , " rad ", end=' ')
+        print("Rel values: %4d" % int(rel) , " raw %4d" % int(reldeg), "deg = %5.2f" % relrad , " rad")
 
         # Sleep for 2.5 s
         sleep(2.5)

--- a/examples/python/rotaryencoder.py
+++ b/examples/python/rotaryencoder.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_rotaryencoder as upmRotaryEncoder
+from upm import pyupm_rotaryencoder as upmRotaryEncoder
 
 def main():
     # Instantiate a Grove Rotary Encoder, using signal pins D2 and D3
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myRotaryEncoder
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,7 +45,7 @@ def main():
 
     # Read the value every second and detect motion
     while(1):
-        print "Position: {0}".format(myRotaryEncoder.position())
+        print("Position: {0}".format(myRotaryEncoder.position()))
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/rpr220.py
+++ b/examples/python/rpr220.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_rpr220 as upmRpr220
+from upm import pyupm_rpr220 as upmRpr220
 
 def main():
     # This example uses a simple method to determine current status
@@ -39,7 +40,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myReflectiveSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -48,9 +49,9 @@ def main():
 
     while(1):
         if (myReflectiveSensor.blackDetected()):
-            print "Black detected"
+            print("Black detected")
         else:
-            print "Black NOT detected"
+            print("Black NOT detected")
 
         time.sleep(.1)
 

--- a/examples/python/sainsmartks.py
+++ b/examples/python/sainsmartks.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_i2clcd as sainsmartObj
+from upm import pyupm_i2clcd as sainsmartObj
 
 def main():
     ## Exit handlers ##
@@ -33,7 +34,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from ringCoder
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -50,7 +51,7 @@ def main():
 
     # output current key value every second.
     while(1):
-        print "Button value: ", lcd.getRawKeyValue()
+        print("Button value: ", lcd.getRawKeyValue())
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/scam.py
+++ b/examples/python/scam.py
@@ -22,8 +22,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
-import pyupm_scam as upmscam
+from upm import pyupm_scam as upmscam
 
 def main():
     # Instantiate a Serial Camera on UART 0
@@ -31,34 +32,34 @@ def main():
 
     # make sure port is initialized properly. 115200 baud is the default.
     if (not camera.setupTty()):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(1)
 
     if (camera.init()):
-        print "Initialized..."
+        print("Initialized...")
     else:
-        print "init() failed"
+        print("init() failed")
 
     if (camera.preCapture()):
-        print "preCapture succeeded..."
+        print("preCapture succeeded...")
     else:
-        print "preCapture failed."
+        print("preCapture failed.")
 
     if (camera.doCapture()):
-        print "doCapture succeeded..."
+        print("doCapture succeeded...")
     else:
-        print "doCapture failed."
+        print("doCapture failed.")
 
-    print "Image size is", camera.getImageSize(), "bytes"
+    print("Image size is", camera.getImageSize(), "bytes")
 
     if (camera.getImageSize() > 0):
-        print "Storing image.jpg..."
+        print("Storing image.jpg...")
         if (camera.storeImage("image.jpg")):
-            print "storeImage succeeded..."
+            print("storeImage succeeded...")
         else:
-            print "storeImage failed."
+            print("storeImage failed.")
 
-    print "Exiting."
+    print("Exiting.")
     sys.exit(0)
 
 if __name__ == '__main__':

--- a/examples/python/sht1x.py
+++ b/examples/python/sht1x.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_sht1x as sensorObj
+from upm import pyupm_sht1x as sensorObj
 
 def main():
     # Instantiate a SHT1X sensor using D2 as the clock, and D3 as the
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,9 +48,9 @@ def main():
     while (True):
         sensor.update()
 
-        print "Temperature:", sensor.getTemperature(), "C"
-        print "Humidity:   ", sensor.getHumidity(), "RH"
-        print
+        print("Temperature:", sensor.getTemperature(), "C")
+        print("Humidity:   ", sensor.getHumidity(), "RH")
+        print()
 
         time.sleep(2)
 

--- a/examples/python/si114x.py
+++ b/examples/python/si114x.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_si114x as upmSi114x
+from upm import pyupm_si114x as upmSi114x
 
 def main():
     # Instantiate a SI114x UV Sensor on I2C bus 0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myUVSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -46,13 +47,13 @@ def main():
     # First initialize it
     myUVSensor.initialize()
 
-    print "UV Index Scale:"
-    print "---------------"
-    print "11+        Extreme"
-    print "8-10       Very High"
-    print "6-7        High"
-    print "3-5        Moderate"
-    print "0-2        Low\n"
+    print("UV Index Scale:")
+    print("---------------")
+    print("11+        Extreme")
+    print("8-10       Very High")
+    print("6-7        High")
+    print("3-5        Moderate")
+    print("0-2        Low\n")
 
     # update every second and print the currently measured UV Index
     while (1):
@@ -60,7 +61,7 @@ def main():
         myUVSensor.update()
 
         # print detected value
-        print "UV Index:", myUVSensor.getUVIndex()
+        print("UV Index:", myUVSensor.getUVIndex())
 
         time.sleep(1)
 

--- a/examples/python/slide.py
+++ b/examples/python/slide.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
-import pyupm_slide as slide
+from upm import pyupm_slide as slide
 
 def main():
     # New Grove Slider on AIO pin 0
@@ -33,7 +34,7 @@ def main():
         raw = slider.raw_value()
         volts = slider.voltage_value()
 
-        print "Slider value: ", raw , " = %.2f" % volts , " V"
+        print("Slider value: ", raw , " = %.2f" % volts , " V")
 
         # Sleep for 2.5 s
         sleep(2.5)

--- a/examples/python/sm130.py
+++ b/examples/python/sm130.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_sm130 as sensorObj
+from upm import pyupm_sm130 as sensorObj
 
 def main():
     # Instantiate a UART based SM130 RFID Module using defaults
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,24 +45,24 @@ def main():
 
     # Set the baud rate, 19200 baud is the default.
     if (sensor.setBaudRate(19200)):
-        print "Failed to set baud rate"
+        print("Failed to set baud rate")
         sys.exit(0)
 
-    print "Resetting..."
+    print("Resetting...")
     sensor.reset()
 
-    print "Firmware revision: " + sensor.getFirmwareVersion()
+    print("Firmware revision: " + sensor.getFirmwareVersion())
 
-    print "Waiting up to 5 seconds for a tag..."
+    print("Waiting up to 5 seconds for a tag...")
 
     if (sensor.waitForTag(5000)):
-        print "Found tag, UID:",
-        print sensor.string2HexString(sensor.getUID())
-        print "Tag Type:",
-        print sensor.tag2String(sensor.getTagType())
+        print("Found tag, UID:", end=' ')
+        print(sensor.string2HexString(sensor.getUID()))
+        print("Tag Type:", end=' ')
+        print(sensor.tag2String(sensor.getTagType()))
     else:
         # error
-        print "waitForTag failed: " + sensor.getLastErrorString()
+        print("waitForTag failed: " + sensor.getLastErrorString())
 
 if __name__ == '__main__':
     main()

--- a/examples/python/speaker.py
+++ b/examples/python/speaker.py
@@ -22,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time, sys, signal, atexit
-import pyupm_speaker as upmspeaker
+from upm import pyupm_speaker as upmspeaker
 
 def main():
     # Instantiate a Speaker on digital pin D2

--- a/examples/python/stepmotor.py
+++ b/examples/python/stepmotor.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_stepmotor as mylib
+from upm import pyupm_stepmotor as mylib
 
 def main():
     # Instantiate a StepMotor object on pins 2 (dir) and 3 (step)
@@ -35,28 +36,28 @@ def main():
 
     # This lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Rotating 1 revolution forward and back at 60 rpm."
+    print("Rotating 1 revolution forward and back at 60 rpm.")
     stepper.setSpeed(60)
     stepper.stepForward(200)
     time.sleep(1)
     stepper.stepBackward(200)
     time.sleep(1)
 
-    print "Rotating 1 revolution forward and back at 150 rpm."
+    print("Rotating 1 revolution forward and back at 150 rpm.")
     stepper.setSpeed(150)
     stepper.stepForward(200)
     time.sleep(1)
     stepper.stepBackward(200)
     time.sleep(1)
 
-    print "Rotating 1 revolution forward and back at 300 rpm."
+    print("Rotating 1 revolution forward and back at 300 rpm.")
     stepper.setSpeed(300)
     stepper.stepForward(200)
     time.sleep(1)

--- a/examples/python/sx1276-fsk.py
+++ b/examples/python/sx1276-fsk.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_sx1276 as sensorObj
+from upm import pyupm_sx1276 as sensorObj
 
 def main():
     # Instantiate an SX1276 using default parameters
@@ -35,14 +36,14 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Specify an argument to go into receive mode.  Default is transmit"
+    print("Specify an argument to go into receive mode.  Default is transmit")
 
     # 915Mhz
     sensor.setChannel(915000000)
@@ -70,12 +71,12 @@ def main():
     while True:
         if (len(sys.argv) > 1):
             # receive mode
-            print "Attempting to receive..."
+            print("Attempting to receive...")
             rv = sensor.setRx(3000)
             if (rv):
-                print "setRx returned ", rv
+                print("setRx returned ", rv)
             else:
-                print "Received Buffer: ", sensor.getRxBufferStr();
+                print("Received Buffer: ", sensor.getRxBufferStr());
                 # go back to sleep when done
 
                 sensor.setSleep()
@@ -84,7 +85,7 @@ def main():
             # transmit mode
             buffer = "Ping " + str(count)
             count += 1
-            print "Sending..." + buffer
+            print("Sending..." + buffer)
             sensor.sendStr(buffer, 3000)
             sensor.setSleep();
             time.sleep(1);

--- a/examples/python/sx1276-lora.py
+++ b/examples/python/sx1276-lora.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_sx1276 as sensorObj
+from upm import pyupm_sx1276 as sensorObj
 
 def main():
     # Instantiate an SX1276 using default parameters
@@ -35,14 +36,14 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Specify an argument to go into receive mode.  Default is transmit"
+    print("Specify an argument to go into receive mode.  Default is transmit")
 
     # 915Mhz
     sensor.setChannel(915000000)
@@ -69,12 +70,12 @@ def main():
     while True:
         if (len(sys.argv) > 1):
             # receive mode
-            print "Attempting to receive..."
+            print("Attempting to receive...")
             rv = sensor.setRx(3000)
             if (rv):
-                print "setRx returned ", rv
+                print("setRx returned ", rv)
             else:
-                print "Received Buffer: ", sensor.getRxBufferStr();
+                print("Received Buffer: ", sensor.getRxBufferStr());
                 # go back to sleep when done
 
                 sensor.setSleep()
@@ -83,7 +84,7 @@ def main():
             # transmit mode
             buffer = "Ping " + str(count)
             count += 1
-            print "Sending..." + buffer
+            print("Sending..." + buffer)
             sensor.sendStr(buffer, 3000)
             sensor.setSleep();
             time.sleep(1);

--- a/examples/python/sx6119.py
+++ b/examples/python/sx6119.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
-import pyupm_sx6119 as upmSx6119
+from upm import pyupm_sx6119 as upmSx6119
 
 def main():
     # Instantiate a SX6119 on digital pins 2 (power) and 3 (seek)
@@ -32,10 +33,10 @@ def main():
     # if an argument was specified (any argument), seek to the next
     # station, else just toggle the power.
 
-    print "Supply any argument to the command line to seek to the"
-    print "next station."
-    print "Running the example without an argument will toggle the"
-    print "power on or off.\n"
+    print("Supply any argument to the command line to seek to the")
+    print("next station.")
+    print("Running the example without an argument will toggle the")
+    print("power on or off.\n")
 
     doSeek = False
 
@@ -48,7 +49,7 @@ def main():
     else:
         myFM_receiver_obj.togglePower()
 
-    print "Exiting";
+    print("Exiting");
 
 if __name__ == '__main__':
     main()

--- a/examples/python/t3311.py
+++ b/examples/python/t3311.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_t3311 as sensorObj
+from upm import pyupm_t3311 as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,17 +46,17 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Initializing..."
+    print("Initializing...")
 
     # Instantiate an T3311 instance, using MODBUS slave address 1, and
     # default comm parameters (9600, 8, N, 2)
     sensor = sensorObj.T3311(defaultDev, 1)
 
     # output the serial number and firmware revision
-    print "Serial Number:", sensor.getSerialNumber()
-    print "Firmware Revision: {0}.{1}".format(sensor.getFirmwareMajor(),
-                                              sensor.getFirmwareMinor())
-    print
+    print("Serial Number:", sensor.getSerialNumber())
+    print("Firmware Revision: {0}.{1}".format(sensor.getFirmwareMajor(),
+                                              sensor.getFirmwareMinor()))
+    print()
 
     # update and print available values every second
     while (1):
@@ -63,31 +64,31 @@ def main():
         sensor.update()
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Humidity:", sensor.getHumidity(), "%"
+        print("Humidity:", sensor.getHumidity(), "%")
 
         # this value depends on the sensor configuration -- by default
         # it is the dew point temperature
-        print "Computed Value:", sensor.getComputedValue()
+        print("Computed Value:", sensor.getComputedValue())
 
         # with FW revisions > 2.44, extended computed data is available
         if (sensor.extendedDataAvailable()):
-            print "Dew Point Temperature:", sensor.getDewPointTemperature(),
-            print "C /", sensor.getDewPointTemperature(True), "F"
+            print("Dew Point Temperature:", sensor.getDewPointTemperature(), end=' ')
+            print("C /", sensor.getDewPointTemperature(True), "F")
 
-            print "Absolute Humidity:", sensor.getAbsoluteHumidity(), "g/m3"
+            print("Absolute Humidity:", sensor.getAbsoluteHumidity(), "g/m3")
 
-            print "Specific Humidity:", sensor.getSpecificHumidity(),
-            print "g/kg"
+            print("Specific Humidity:", sensor.getSpecificHumidity(), end=' ')
+            print("g/kg")
 
-            print "Mixing Ratio:", sensor.getMixingRatio(), "g/kg"
+            print("Mixing Ratio:", sensor.getMixingRatio(), "g/kg")
 
-            print "Specific Enthalpy:", sensor.getSpecificEnthalpy(),
-            print "kJ/kg"
+            print("Specific Enthalpy:", sensor.getSpecificEnthalpy(), end=' ')
+            print("kJ/kg")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/t8100.py
+++ b/examples/python/t8100.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_t8100 as sensorObj
+from upm import pyupm_t8100 as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -50,8 +51,8 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Using device", defaultDev
-    print "Initializing..."
+    print("Using device", defaultDev)
+    print("Initializing...")
 
     # Instantiate an T8100 object for an T8100 device that has 568000
     # as it's unique Device Object Instance ID.  NOTE: You will
@@ -69,32 +70,32 @@ def main():
     # sensor.setDebug(True);
 
     # output the serial number and firmware revision
-    print
-    print "Device Description:", sensor.getDeviceDescription()
-    print "Device Location:", sensor.getDeviceLocation()
-    print
+    print()
+    print("Device Description:", sensor.getDeviceDescription())
+    print("Device Location:", sensor.getDeviceLocation())
+    print()
 
     # update and print available values every 5 seconds
     while (1):
         # update our values
         sensor.update();
 
-        print "CO2 Concentration:",
-        print sensor.getCO2(),
-        print "ppm"
+        print("CO2 Concentration:", end=' ')
+        print(sensor.getCO2(), end=' ')
+        print("ppm")
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(),
-        print "C /", sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), end=' ')
+        print("C /", sensor.getTemperature(True), "F")
 
-        print "Humidity:",
-        print sensor.getHumidity(),
-        print "%RH"
+        print("Humidity:", end=' ')
+        print(sensor.getHumidity(), end=' ')
+        print("%RH")
 
-        print "Relay State:",
-        print sensor.getRelayState()
+        print("Relay State:", end=' ')
+        print(sensor.getRelayState())
 
-        print
+        print()
         time.sleep(5)
 
 if __name__ == '__main__':

--- a/examples/python/ta12200.py
+++ b/examples/python/ta12200.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ta12200 as upmTa12200
+from upm import pyupm_ta12200 as upmTa12200
 
 def main():
     # Instantiate a TA12-200 sensor on analog pin A0
@@ -36,7 +37,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myElectricitySensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -49,7 +50,7 @@ def main():
         current = myElectricitySensor.milliAmps(maxVal)
 
         outputStr = "Max ADC Value: %s, current: %smA" % (maxVal, current)
-        print outputStr
+        print(outputStr)
         time.sleep(.1)
 
 if __name__ == '__main__':

--- a/examples/python/tb7300.py
+++ b/examples/python/tb7300.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_tb7300 as sensorObj
+from upm import pyupm_tb7300 as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -50,8 +51,8 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Using device", defaultDev
-    print "Initializing..."
+    print("Using device", defaultDev)
+    print("Initializing...")
 
     # Instantiate an TB7300 object for an TB7300 device that has 73001
     # as it's unique Device Object Instance ID.  NOTE: You will
@@ -69,20 +70,20 @@ def main():
     # sensor.setDebug(True);
 
     # output the serial number and firmware revision
-    print
-    print "Device Name:", sensor.getDeviceName()
-    print "Device Description:", sensor.getDeviceDescription()
-    print "Device Location:", sensor.getDeviceLocation()
-    print
+    print()
+    print("Device Name:", sensor.getDeviceName())
+    print("Device Description:", sensor.getDeviceDescription())
+    print("Device Location:", sensor.getDeviceLocation())
+    print()
 
-    print "Fan Mode:", sensor.getMultiStateValueText(sensorObj.TB7300.MV_Fan_Mode)
-    print "Fan Status:",
-    print  sensor.getMultiStateValueText(sensorObj.TB7300.MV_Fan_Status)
-    print "System Mode:",
-    print  sensor.getMultiStateValueText(sensorObj.TB7300.MV_System_Mode)
-    print "Service Alarm:",
-    print  sensor.getBinaryInputText(sensorObj.TB7300.BI_Service_Alarm)
-    print
+    print("Fan Mode:", sensor.getMultiStateValueText(sensorObj.TB7300.MV_Fan_Mode))
+    print("Fan Status:", end=' ')
+    print(sensor.getMultiStateValueText(sensorObj.TB7300.MV_Fan_Status))
+    print("System Mode:", end=' ')
+    print(sensor.getMultiStateValueText(sensorObj.TB7300.MV_System_Mode))
+    print("Service Alarm:", end=' ')
+    print(sensor.getBinaryInputText(sensorObj.TB7300.BI_Service_Alarm))
+    print()
 
     # update and print the room temperature every 5 seconds
     while (1):
@@ -90,10 +91,10 @@ def main():
         sensor.update();
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(),
-        print "C /", sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), end=' ')
+        print("C /", sensor.getTemperature(True), "F")
 
-        print
+        print()
         time.sleep(5)
 
 if __name__ == '__main__':

--- a/examples/python/tcs3414cs.py
+++ b/examples/python/tcs3414cs.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_tcs3414cs as upmTcs3414cs
+from upm import pyupm_tcs3414cs as upmTcs3414cs
 
 def main():
     # Instantiate the color sensor on I2C
@@ -36,7 +37,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myColorSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -48,8 +49,8 @@ def main():
     # Print out the r, g, b, and clr value every 0.5 seconds
     while(1):
         myColorSensor.readRGB(myrgb)
-        print "{0}, {1}, {2}, {3}".format(myrgb.r,
-        myrgb.g, myrgb.b, myrgb.clr)
+        print("{0}, {1}, {2}, {3}".format(myrgb.r,
+        myrgb.g, myrgb.b, myrgb.clr))
 
         time.sleep(.5)
 

--- a/examples/python/teams.py
+++ b/examples/python/teams.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_teams as sensorObj
+from upm import pyupm_teams as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,14 +33,14 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Initializing..."
+    print("Initializing...")
 
     # Instantiate an TEAMS instance, using A0 for temperature, and
     # 165.0 ohms for the rResistor value (for the libelium 4-20ma
@@ -52,17 +53,17 @@ def main():
         sensor.update()
 
         # is the sensor connected? (current >= 4ma)
-        print "Is Connected:", sensor.isConnected()
+        print("Is Connected:", sensor.isConnected())
 
         # print computed current on the loop.  This includes the offset,
         # if one was set by setOffsetMilliamps().
-        print "Milliamps:", sensor.getRawMilliamps()
+        print("Milliamps:", sensor.getRawMilliamps())
 
         # we show both C and F for temperature
-        print "Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/temperature.py
+++ b/examples/python/temperature.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Brendan Le Foll <brendan.le.foll@intel.com>
 # Contributions: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
@@ -22,20 +23,20 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_temperature as upm
+from upm import pyupm_temperature as upm
 
 def main():
     # Create the temperature sensor object using AIO pin 0
     temp = upm.Temperature(0)
-    print temp.name()
+    print(temp.name())
 
     # Read the temperature ten times, printing both the Celsius and
     # equivalent Fahrenheit temperature, waiting one second between readings
     for i in range(0, 10):
         celsius = temp.value()
         fahrenheit = celsius * 9.0/5.0 + 32.0;
-        print "%d degrees Celsius, or %d degrees Fahrenheit" \
-            % (celsius, fahrenheit)
+        print("%d degrees Celsius, or %d degrees Fahrenheit" \
+            % (celsius, fahrenheit))
         time.sleep(1)
 
     # Delete the temperature sensor object

--- a/examples/python/tex00.py
+++ b/examples/python/tex00.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_tex00 as sensorObj
+from upm import pyupm_tex00 as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,23 +33,23 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
     atexit.register(exitHandler)
     signal.signal(signal.SIGINT, SIGINTHandler)
 
-    print "Initializing..."
+    print("Initializing...")
 
     # Instantiate an TEX00 instance, using A0 for the analog input.  In
     # this example, we are using a 10K Ohm balance resistor and a TED
     # (10k type 2) thermistor.
     sensor = sensorObj.TEX00(0, 10000, sensorObj.TEX00.STYPE_THERMISTOR_TED)
 
-    print "Minimum temperature:", sensor.getTemperatureRangeMin(), "C"
-    print "Maximum temperature:", sensor.getTemperatureRangeMax(), "C"
-    print
+    print("Minimum temperature:", sensor.getTemperatureRangeMin(), "C")
+    print("Maximum temperature:", sensor.getTemperatureRangeMax(), "C")
+    print()
 
     # update and print available values every second
     while (1):
@@ -56,13 +57,13 @@ def main():
         sensor.update()
 
         if (sensor.isOutOfRange()):
-            print "Temperature out of range"
+            print("Temperature out of range")
         else:
             # we show both C and F for temperature
-            print "Temperature:", sensor.getTemperature(), "C /",
-            print sensor.getTemperature(True), "F"
+            print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+            print(sensor.getTemperature(True), "F")
 
-        print
+        print()
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/tm1637.py
+++ b/examples/python/tm1637.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time, signal
-import pyupm_tm1637 as tm1637
+from upm import pyupm_tm1637 as tm1637
 
 def main():
     # Register exit handler for normal Ctrl+C exit
@@ -35,7 +36,7 @@ def main():
 
     # Get local time
     myTime = time.localtime(time.time())
-    print time.strftime("System time: %H:%M", myTime)
+    print(time.strftime("System time: %H:%M", myTime))
     print ("You can adjust your time zone by setting the TZ environment variable.")
 
     # Draw a box for 3 seconds using 7-segment encoding

--- a/examples/python/tp401.py
+++ b/examples/python/tp401.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
-import pyupm_gas as TP401
+from upm import pyupm_gas as TP401
 
 def main():
     # Give a qualitative meaning to the value from the sensor
@@ -36,11 +37,11 @@ def main():
     airSensor = TP401.TP401(0)
 
     # Wait for sensor to warm up
-    print "Sensor is warming up for 3 minutes..."
+    print("Sensor is warming up for 3 minutes...")
     for i in range (1, 4):
         sleep(60)
-        print i, "minute(s) passed."
-    print "Sensor is ready!"
+        print(i, "minute(s) passed.")
+    print("Sensor is ready!")
 
     # Loop indefinitely
     while True:
@@ -48,7 +49,7 @@ def main():
         value = airSensor.getSample()
         ppm = airSensor.getPPM()
 
-        print "raw: %4d" % value , " ppm: %5.2f   " % ppm , airQuality(value)
+        print("raw: %4d" % value , " ppm: %5.2f   " % ppm , airQuality(value))
 
         # Sleep for 2.5 s
         sleep(2.5)

--- a/examples/python/tsl2561.py
+++ b/examples/python/tsl2561.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_tsl2561 as upmTsl2561
+from upm import pyupm_tsl2561 as upmTsl2561
 
 def main():
     # Instantiate a digital light sensor TSL2561 on I2C
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myDigitalLightSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -43,7 +44,7 @@ def main():
     signal.signal(signal.SIGINT, SIGINTHandler)
 
     while(1):
-        print "Light value is " + str(myDigitalLightSensor.getLux())
+        print("Light value is " + str(myDigitalLightSensor.getLux()))
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/ttp223.py
+++ b/examples/python/ttp223.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #
@@ -21,7 +22,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import time
-import pyupm_ttp223 as ttp223
+from upm import pyupm_ttp223 as ttp223
 
 def main():
     # Create the TTP223 touch sensor object using GPIO pin 0
@@ -31,9 +32,9 @@ def main():
     # print accordingly, waiting one second between readings
     while 1:
         if touch.isPressed():
-            print touch.name(), 'is pressed'
+            print(touch.name(), 'is pressed')
         else:
-            print touch.name(), 'is not pressed'
+            print(touch.name(), 'is not pressed')
         time.sleep(1)
 
     # Delete the touch sensor object

--- a/examples/python/tzemt400.py
+++ b/examples/python/tzemt400.py
@@ -21,13 +21,14 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_ozw as sensorObj
+from upm import pyupm_ozw as sensorObj
 
 def main():
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -36,7 +37,7 @@ def main():
     defaultDev = "/dev/ttyACM0"
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
-    print "Using device", defaultDev
+    print("Using device", defaultDev)
 
     # Instantiate a TZEMT400 instance, on device node 13.  You will
     # almost certainly need to change this to reflect your own network.
@@ -48,38 +49,38 @@ def main():
     sensor.optionsLock()
 
     # Next, initialize it.
-    print "Initializing, this may take awhile depending on your ZWave network"
+    print("Initializing, this may take awhile depending on your ZWave network")
 
     sensor.init(defaultDev)
-    print "Initialization complete"
+    print("Initialization complete")
 
-    print "Querying data..."
+    print("Querying data...")
 
     while (True):
         sensor.update()
 
-        print "Temperature:", sensor.getTemperature(), "C /",
-        print sensor.getTemperature(True), "F"
+        print("Temperature:", sensor.getTemperature(), "C /", end=' ')
+        print(sensor.getTemperature(True), "F")
 
-        print "Mode:",
-        print sensor.getMode()
+        print("Mode:", end=' ')
+        print(sensor.getMode())
 
-        print "Operating State:",
-        print sensor.getOperatingState()
+        print("Operating State:", end=' ')
+        print(sensor.getOperatingState())
 
-        print "Heating Point:", sensor.getHeatingPointTemperature(), "C /",
-        print sensor.getHeatingPointTemperature(True), "F"
+        print("Heating Point:", sensor.getHeatingPointTemperature(), "C /", end=' ')
+        print(sensor.getHeatingPointTemperature(True), "F")
 
-        print "Cooling Point:", sensor.getCoolingPointTemperature(), "C /",
-        print sensor.getCoolingPointTemperature(True), "F"
+        print("Cooling Point:", sensor.getCoolingPointTemperature(), "C /", end=' ')
+        print(sensor.getCoolingPointTemperature(True), "F")
 
-        print "Fan Mode:",
-        print sensor.getFanMode()
+        print("Fan Mode:", end=' ')
+        print(sensor.getFanMode())
 
-        print "Fan State:",
-        print sensor.getFanState()
+        print("Fan State:", end=' ')
+        print(sensor.getFanState())
 
-        print
+        print()
         time.sleep(5)
 
 if __name__ == '__main__':

--- a/examples/python/uln200xa.py
+++ b/examples/python/uln200xa.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_uln200xa as upmULN200XA
+from upm import pyupm_uln200xa as upmULN200XA
 
 def main():
     # Instantiate a Stepper motor on a ULN200XA Darlington Motor Driver
@@ -39,7 +40,7 @@ def main():
     # This lets you run code on exit,
     # including functions from myUln200xa
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -49,13 +50,13 @@ def main():
     myUln200xa.setSpeed(5) # 5 RPMs
     myUln200xa.setDirection(upmULN200XA.ULN200XA.DIR_CW)
 
-    print "Rotating 1 revolution clockwise."
+    print("Rotating 1 revolution clockwise.")
     myUln200xa.stepperSteps(4096)
 
-    print "Sleeping for 2 seconds..."
+    print("Sleeping for 2 seconds...")
     time.sleep(2)
 
-    print "Rotating 1/2 revolution counter clockwise."
+    print("Rotating 1/2 revolution counter clockwise.")
     myUln200xa.setDirection(upmULN200XA.ULN200XA.DIR_CCW)
     myUln200xa.stepperSteps(2048)
 

--- a/examples/python/urm37-uart.py
+++ b/examples/python/urm37-uart.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_urm37 as sensorObj
+from upm import pyupm_urm37 as sensorObj
 
 def main():
     # Instantiate a URM37 sensor on UART 0, with the reset pin on D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -46,8 +47,8 @@ def main():
     # distance in cm, and temperature in degrees C
 
     while (1):
-        print "Detected distance (cm):", sensor.getDistance()
-        print "Temperature (C):", sensor.getTemperature()
+        print("Detected distance (cm):", sensor.getDistance())
+        print("Temperature (C):", sensor.getTemperature())
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/urm37.py
+++ b/examples/python/urm37.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_urm37 as sensorObj
+from upm import pyupm_urm37 as sensorObj
 
 def main():
     # Instantiate a URM37 sensor on analog pin A0, reset pin on D2,
@@ -36,7 +37,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,7 +48,7 @@ def main():
     # distance in cm.
 
     while (1):
-        print "Detected distance (cm):", sensor.getDistance()
+        print("Detected distance (cm):", sensor.getDistance())
         time.sleep(.5)
 
 if __name__ == '__main__':

--- a/examples/python/vcap.py
+++ b/examples/python/vcap.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_vcap as sensorObj
+from upm import pyupm_vcap as sensorObj
 
 def main():
     ## Exit handlers ##
@@ -32,7 +33,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting..."
+        print("Exiting...")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,8 +46,8 @@ def main():
     if (len(sys.argv) > 1):
         defaultDev = sys.argv[1]
 
-    print "Using device", defaultDev
-    print "Initializing..."
+    print("Using device", defaultDev)
+    print("Initializing...")
 
     # Instantiate an VCAP instance, using the specified video device
     sensor = sensorObj.VCAP(defaultDev)

--- a/examples/python/vdiv.py
+++ b/examples/python/vdiv.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_vdiv as upmvdiv
+from upm import pyupm_vdiv as upmvdiv
 
 def main():
     # Instantiate a Voltage Divider sensor on analog pin A0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myVoltageDivider
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,8 +48,8 @@ def main():
         val = myVoltageDivider.value(100)
         gain3val = myVoltageDivider.computedValue(3, val)
         gain10val = myVoltageDivider.computedValue(10, val)
-        print "ADC value: {0} Gain 3: {1}v Gain 10: {2}v".format(
-        val,  gain3val, gain10val)
+        print("ADC value: {0} Gain 3: {1}v Gain 10: {2}v".format(
+        val,  gain3val, gain10val))
 
         time.sleep(1)
 

--- a/examples/python/water.py
+++ b/examples/python/water.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_water as upmwater
+from upm import pyupm_water as upmwater
 
 def main():
     # Instantiate a Water sensor on digital pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myWaterSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,9 +45,9 @@ def main():
 
     while(1):
         if (myWaterSensor.isWet()):
-            print "Sensor is wet"
+            print("Sensor is wet")
         else:
-            print "Sensor is dry"
+            print("Sensor is dry")
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/waterlevel.py
+++ b/examples/python/waterlevel.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_waterlevel as upmWaterlevel
+from upm import pyupm_waterlevel as upmWaterlevel
 
 def main():
     # The was tested with the Water Level Sensor
@@ -37,7 +38,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myWaterLevel
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -46,9 +47,9 @@ def main():
 
     while(1):
         if (myWaterLevel.isSubmerged()):
-            print "Sensor is submerged in liquid"
+            print("Sensor is submerged in liquid")
         else:
-            print "Liquid is below water level sensor"
+            print("Liquid is below water level sensor")
 
         time.sleep(1)
 

--- a/examples/python/wfs.py
+++ b/examples/python/wfs.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_wfs as upmwfs
+from upm import pyupm_wfs as upmwfs
 
 def main():
     # Instantiate a Water Flow Sensor on digital pin D2
@@ -37,7 +38,7 @@ def main():
     # including functions from myWaterFlow
     def exitHandler():
         myWaterFlow.stopFlowCounter()
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -59,7 +60,7 @@ def main():
         # output milliseconds passed, flow count, and computed flow rate
         outputStr = "Millis: {0} Flow Count: {1} Flow Rate: {2} LPM".format(
         millis, flowCount, fr)
-        print outputStr
+        print(outputStr)
         time.sleep(2)
 
 if __name__ == '__main__':

--- a/examples/python/wheelencoder.py
+++ b/examples/python/wheelencoder.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_wheelencoder as sensorObj
+from upm import pyupm_wheelencoder as sensorObj
 
 def main():
     # Instantiate a DFRobot Wheel Encoder on digital pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -47,7 +48,7 @@ def main():
     sensor.startCounter();
 
     while (1):
-        print "Millis:", sensor.getMillis(), "Count:", sensor.counter()
+        print("Millis:", sensor.getMillis(), "Count:", sensor.counter())
         time.sleep(1)
 
 if __name__ == '__main__':

--- a/examples/python/wt5001.py
+++ b/examples/python/wt5001.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, signal, sys
-import pyupm_wt5001 as upmWt5001
+from upm import pyupm_wt5001 as upmWt5001
 
 def main():
     # Instantiate a WT5001 serial MP3 player on uart 0.
@@ -43,7 +44,7 @@ def main():
         cmd = int(sys.argv[1])
 
     if (not myMP3Player.setupTty(upmWt5001.cvar.int_B9600)):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(0)
 
     if cmd == 0:
@@ -63,19 +64,19 @@ def main():
     # print out some information
     vol = upmWt5001.uint8Array(0)
     myMP3Player.getVolume(vol)
-    print "The current volume is: " + str(vol.__getitem__(0))
+    print("The current volume is: " + str(vol.__getitem__(0)))
 
     ps = upmWt5001.uint8Array(0)
     myMP3Player.getPlayState(ps)
-    print "The current play state is: " + str(ps.__getitem__(0))
+    print("The current play state is: " + str(ps.__getitem__(0)))
 
     numf = upmWt5001.uint16Array(0)
     myMP3Player.getNumFiles(upmWt5001.WT5001.SD, numf)
-    print "The number of files on the SD card is: " + str(numf.__getitem__(0))
+    print("The number of files on the SD card is: " + str(numf.__getitem__(0)))
 
     curf = upmWt5001.uint16Array(0)
     myMP3Player.getCurrentFile(curf)
-    print "The current file is: " + str(curf.__getitem__(0))
+    print("The current file is: " + str(curf.__getitem__(0)))
 
     # set the date
     myMP3Player.setDate(2015, 3, 14)
@@ -91,7 +92,7 @@ def main():
     mp3date = str(month.__getitem__(0)) + "/"
     mp3date += (str(day.__getitem__(0)) + "/")
     mp3date += str(year.__getitem__(0))
-    print "The device date is: " + mp3date
+    print("The device date is: " + mp3date)
 
     hour = upmWt5001.uint8Array(0)
     minute = upmWt5001.uint8Array(0)
@@ -100,7 +101,7 @@ def main():
     mp3time = str(hour.__getitem__(0)) + ":"
     mp3time += (str(minute.__getitem__(0)) + ":")
     mp3time += str(second.__getitem__(0))
-    print "The device time is: " + mp3time
+    print("The device time is: " + mp3time)
 
 if __name__ == '__main__':
     main()

--- a/examples/python/xbee.py
+++ b/examples/python/xbee.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_xbee as sensorObj
+from upm import pyupm_xbee as sensorObj
 
 def main():
     # Instantiate a XBee Module on UART 0
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,7 +45,7 @@ def main():
 
     # Set the baud rate, 9600 baud is the default.
     if (sensor.setBaudRate(9600)):
-        print "Failed to set baud rate"
+        print("Failed to set baud rate")
         sys.exit(0)
 
     usageStr = ("Usage:\n"
@@ -52,7 +53,7 @@ def main():
     "sent to the module and the response is printed out.\n\n"
     "If no argument is used, then the firmware revision, serial number\n"
     "and the current IP address (if set) are queried.\n\n")
-    print usageStr
+    print(usageStr)
 
     # simple helper function to send a command and wait for a response
     def sendCommand(sensor, cmd):
@@ -65,30 +66,30 @@ def main():
             resp += sensor.readDataStr(1024)
 
         if not resp:
-            print "Timed out waiting for response"
+            print("Timed out waiting for response")
         else:
             resp = sensor.stringCR2LF(resp)
-            print "Returned (", len(resp), "bytes):"
-            print resp
+            print("Returned (", len(resp), "bytes):")
+            print(resp)
 
     if (len(sys.argv) > 1):
         # enable command mode
         sensor.commandMode()
-        print "Sending command line argument (" + sys.argv[1] + ")..."
+        print("Sending command line argument (" + sys.argv[1] + ")...")
         sendCommand(sensor, sys.argv[1])
     else:
         # enable command mode
         sensor.commandMode()
         # query the verbose firmware revision
-        print "Querying verbose firmware revision (ATVL)..."
+        print("Querying verbose firmware revision (ATVL)...")
         sendCommand(sensor, "ATVL")
         # query the number
-        print "Querying Serial Number High (ATSH)..."
+        print("Querying Serial Number High (ATSH)...")
         sendCommand(sensor, "ATSH")
-        print "Querying Serial Number Low (ATSL)..."
+        print("Querying Serial Number Low (ATSL)...")
         sendCommand(sensor, "ATSL")
 
-        print "Querying address, if set (ATMY)..."
+        print("Querying address, if set (ATMY)...")
         sendCommand(sensor, "ATMY");
 
         # For the XBee WiFi S6B

--- a/examples/python/yg1006.py
+++ b/examples/python/yg1006.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_yg1006 as upmYG1006
+from upm import pyupm_yg1006 as upmYG1006
 
 def main():
     # Instantiate a flame sensor on digital pin D2
@@ -35,7 +36,7 @@ def main():
 
     # This function lets you run code on exit, including functions from myFlameSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -44,9 +45,9 @@ def main():
 
     while(1):
         if (myFlameSensor.flameDetected()):
-            print "Flame detected."
+            print("Flame detected.")
         else:
-            print "No flame detected."
+            print("No flame detected.")
 
         time.sleep(1)
 

--- a/examples/python/zfm20-register.py
+++ b/examples/python/zfm20-register.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_zfm20 as upmZfm20
+from upm import pyupm_zfm20 as upmZfm20
 
 def main():
     # Instantiate a ZFM20 Fingerprint reader on UART 0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myFingerprintSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,7 +46,7 @@ def main():
 
     # make sure port is initialized properly.  57600 baud is the default.
     if (not myFingerprintSensor.setupTty(upmZfm20.cvar.int_B57600)):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(1)
 
     # This example demonstrates registering a fingerprint on the zfm20
@@ -63,69 +64,69 @@ def main():
     # now verify the password.  If this fails, any other commands
     # will be ignored, so we just bail.
     if (myFingerprintSensor.verifyPassword()):
-        print "Password verified."
+        print("Password verified.")
     else:
-        print "Password verification failed."
+        print("Password verification failed.")
         sys.exit(1)
 
-    print " "
+    print(" ")
 
     # get the first image
-    print "Place a finger on the sensor."
+    print("Place a finger on the sensor.")
     while (myFingerprintSensor.generateImage() != upmZfm20.ZFM20.ERR_OK):
         pass
 
     # in theory, we have an image
-    print "Image captured, converting..."
+    print("Image captured, converting...")
 
     rv = myFingerprintSensor.image2Tz(1)
 
     if (rv != upmZfm20.ZFM20.ERR_OK):
-        print "Image conversion failed with error code %d" % rv
+        print("Image conversion failed with error code %d" % rv)
         sys.exit(1)
 
-    print "Image conversion succeeded, remove finger."
+    print("Image conversion succeeded, remove finger.")
     time.sleep(1)
 
     while (myFingerprintSensor.generateImage() != upmZfm20.ZFM20.ERR_NO_FINGER):
         pass
 
-    print " "
-    print "Now place the same finger on the sensor."
+    print(" ")
+    print("Now place the same finger on the sensor.")
 
     while (myFingerprintSensor.generateImage() == upmZfm20.ZFM20.ERR_NO_FINGER):
         pass
 
-    print "Image captured, converting..."
+    print("Image captured, converting...")
 
     # save this one in slot 2
     rv = myFingerprintSensor.image2Tz(2)
     if (rv != upmZfm20.ZFM20.ERR_OK):
-        print "Image conversion failed with error code %d" % rv
+        print("Image conversion failed with error code %d" % rv)
         sys.exit(1)
 
-    print "Image conversion succeeded, remove finger."
-    print " "
+    print("Image conversion succeeded, remove finger.")
+    print(" ")
 
-    print "Storing fingerprint at id 1"
+    print("Storing fingerprint at id 1")
 
     # create the model
     rv = myFingerprintSensor.createModel()
     if (rv != upmZfm20.ZFM20.ERR_OK):
         if (rv == upmZfm20.ZFM20.ERR_FP_ENROLLMISMATCH):
-            print "Fingerprints did not match."
+            print("Fingerprints did not match.")
         else:
-            print "createModel failed with error code %d" % rv
+            print("createModel failed with error code %d" % rv)
         sys.exit(1)
 
     # now store it, we hard code the id (second arg) to 1 here
     rv = myFingerprintSensor.storeModel(1, 1)
     if (rv != upmZfm20.ZFM20.ERR_OK):
-        print "storeModel failed with error code %d" % rv
+        print("storeModel failed with error code %d" % rv)
         sys.exit(1)
 
-    print " "
-    print "Fingerprint stored at id 1."
+    print(" ")
+    print("Fingerprint stored at id 1.")
 
 if __name__ == '__main__':
     main()

--- a/examples/python/zfm20.py
+++ b/examples/python/zfm20.py
@@ -21,8 +21,9 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import time, sys, signal, atexit
-import pyupm_zfm20 as upmZfm20
+from upm import pyupm_zfm20 as upmZfm20
 
 def main():
     # Instantiate a ZFM20 Fingerprint reader on UART 0
@@ -36,7 +37,7 @@ def main():
     # This function lets you run code on exit,
     # including functions from myFingerprintSensor
     def exitHandler():
-        print "Exiting"
+        print("Exiting")
         sys.exit(0)
 
     # Register exit handlers
@@ -45,29 +46,29 @@ def main():
 
     # make sure port is initialized properly.  57600 baud is the default.
     if (not myFingerprintSensor.setupTty(upmZfm20.cvar.int_B57600)):
-        print "Failed to setup tty port parameters"
+        print("Failed to setup tty port parameters")
         sys.exit(1)
 
     # how many valid stored templates (fingerprints) do we have?
-    print "Total stored templates: %d" % myFingerprintSensor.getNumTemplates()
-    print " "
+    print("Total stored templates: %d" % myFingerprintSensor.getNumTemplates())
+    print(" ")
 
     # now spin waiting for a fingerprint to successfully image
-    print "Waiting for finger print..."
+    print("Waiting for finger print...")
 
     while (myFingerprintSensor.generateImage() == upmZfm20.ZFM20.ERR_NO_FINGER):
         pass
 
     # in theory, we have an image
-    print "Image captured, converting..."
+    print("Image captured, converting...")
 
     rv = myFingerprintSensor.image2Tz(1)
     if (rv != upmZfm20.ZFM20.ERR_OK):
-        print "Image conversion failed with error code %d" % rv
+        print("Image conversion failed with error code %d" % rv)
         sys.exit(1)
 
-    print "Image conversion succeeded."
-    print "Searching database..."
+    print("Image conversion succeeded.")
+    print("Searching database...")
 
     myid = upmZfm20.uint16Array(0)
     myid.__setitem__(0, 0)
@@ -79,14 +80,14 @@ def main():
     rv = myFingerprintSensor.search(1, myid, myscore)
     if (rv != upmZfm20.ZFM20.ERR_OK):
         if (rv == upmZfm20.ZFM20.ERR_FP_NOTFOUND):
-            print "Finger Print not found"
+            print("Finger Print not found")
             sys.exit(0)
         else:
-            print "Search failed with error code %d" % rv
+            print("Search failed with error code %d" % rv)
             sys.exit(1)
 
-    print "Fingerprint found!"
-    print "ID: %d, Score: %d" % (myid.__getitem__(0), myscore.__getitem__(0))
+    print("Fingerprint found!")
+    print("ID: %d, Score: %d" % (myid.__getitem__(0), myscore.__getitem__(0)))
 
 if __name__ == '__main__':
     main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,25 +38,18 @@ macro (upm_target_link_libraries target_name)
 
     # Call the swig link library method for each library
     if (BUILDSWIGNODE)
-      set_target_properties(${SWIG_MODULE_jsupm_${libname}_REAL_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
       swig_link_libraries (jsupm_${libname} ${_library})
     endif()
     # Build python2 AND/OR python3 modules
     if (BUILDSWIGPYTHON)
-      # python2?
       if (PYTHON2LIBS_FOUND)
-        set (pymod_target_name pyupm_${target_name}-python${PYTHON2_VERSION_MAJOR})
-        set_target_properties(${SWIG_MODULE_pyupm_${pymod_target_name}_REAL_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
-        swig_link_libraries (${pymod_target_name} ${_library})
+        swig_link_libraries (pyupm_${libname}-python2 ${_library})
       endif (PYTHON2LIBS_FOUND)
       if (PYTHON3LIBS_FOUND)
-        set (pymod_target_name pyupm_${target_name}-python${PYTHON3_VERSION_MAJOR})
-        set_target_properties(${SWIG_MODULE_pyupm_${pymod_target_name}_REAL_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
-        swig_link_libraries (${pymod_target_name} ${_library})
+        swig_link_libraries (pyupm_${libname}-python3 ${_library})
       endif (PYTHON3LIBS_FOUND)
     endif()
     if (BUILDSWIGJAVA)
-      set_target_properties(${SWIG_MODULE_javaupm_${libname}_REAL_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
       swig_link_libraries (javaupm_${libname} ${_library})
     endif()
   endforeach(_library ${ARGN})
@@ -64,9 +57,6 @@ endmacro (upm_target_link_libraries target_name)
 
 # Create a single swig target for python
 macro(_upm_swig_python)
-  # Create a target name which includes python version
-  set (pymod_target_name pyupm_${libname}-python${PYTHON_VERSION_MAJOR})
-
   include_directories (${CMAKE_CURRENT_SOURCE_DIR}/..)
 
   set_source_files_properties (pyupm_${libname}.i PROPERTIES CPLUSPLUS ON)
@@ -82,9 +72,14 @@ macro(_upm_swig_python)
   set(CMAKE_SWIG_OUTDIR_SAVED ${CMAKE_SWIG_OUTDIR})
   set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_PYTHON_BINARY_DIR})
 
-  swig_add_module (${pymod_target_name} python pyupm_${libname}.i)
-  swig_link_libraries (${pymod_target_name} ${PYTHON_LIBRARIES} ${MRAA_LIBRARIES} ${libname})
-  target_include_directories (${SWIG_MODULE_${pymod_target_name}_REAL_NAME}
+  # Swig module name (example: pyupm_a110x-python2)
+  set (python_wrapper_name pyupm_${libname}-python${PYTHON_VERSION_MAJOR})
+  swig_add_module (${python_wrapper_name} python pyupm_${libname}.i)
+  # Get target library name (example _pyupm_a110x-python2)
+  set (python_wrapper_target ${SWIG_MODULE_${python_wrapper_name}_REAL_NAME})
+
+  swig_link_libraries (${python_wrapper_name} ${PYTHON_LIBRARIES} ${MRAA_LIBRARIES} ${libname})
+  target_include_directories (${python_wrapper_target}
       PUBLIC
       "${PYTHON_INCLUDE_PATH}"
       "${PYTHON_INCLUDE_DIRS}")
@@ -92,26 +87,26 @@ macro(_upm_swig_python)
   # Add C++ comments to ALL python modules (requires doc build)
   if (BUILDDOC)
     # Python module depends on doxy2swig .i file generated from the monolithic doxygen xml file
-    add_dependencies(${SWIG_MODULE_${pymod_target_name}_REAL_NAME} pyupm_doxy2swig )
+    add_dependencies(${python_wrapper_target} pyupm_doxy2swig )
 
     # The pydoc target depends on EACH python module
-    add_dependencies(pydoc ${SWIG_MODULE_${pymod_target_name}_REAL_NAME})
+    add_dependencies(pydoc ${python_wrapper_target})
   endif (BUILDDOC)
 
-  # Python collateral names with be the same for python2/3 w/different library dirs
-  set_target_properties (${SWIG_MODULE_${pymod_target_name}_REAL_NAME} PROPERTIES
+  # Python collateral names will be the same for python2/3 w/different library dirs
+  set_target_properties (${python_wrapper_target} PROPERTIES
       OUTPUT_NAME _pyupm_${libname}
       COMPILE_FLAGS "${CMAKE_C_FLAGS}"
       LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_PYTHON_BINARY_DIR})
 
-  # Install py to per-python version site-packages
+  # Install .py's to python packages directory/upm
   install (FILES ${CMAKE_SWIG_OUTDIR}/pyupm_${libname}.py
-      DESTINATION ${LIB_INSTALL_DIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/
+      DESTINATION ${PYTHON_PACKAGES_PATH}/upm
       COMPONENT ${libname})
 
-  # Install python wrapped library with TARGETS to correctly handle RPATH
-  install (TARGETS ${SWIG_MODULE_${pymod_target_name}_REAL_NAME}
-      DESTINATION ${LIB_INSTALL_DIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/)
+  # Install python wrapper module library
+  install (TARGETS ${python_wrapper_target}
+      DESTINATION ${PYTHON_PACKAGES_PATH}/upm)
 
   # Restore OUTDIR
   set(CMAKE_SWIG_OUTDIR ${CMAKE_SWIG_OUTDIR_SAVED})
@@ -119,34 +114,35 @@ endmacro(_upm_swig_python)
 
 # Generate both python2 and python3 modules if possible
 macro(upm_swig_python)
-  # Return if not building python
-  if (NOT BUILDSWIGPYTHON)
-    return ()
-  endif (NOT BUILDSWIGPYTHON)
+  # Skip if the libname is in the blacklist
+  if (NOT ";${PYTHONSWIG_BLACKLIST};" MATCHES ";${libname};")
+    # Generate python2 module if python2 libs are available
+    if (PYTHON2LIBS_FOUND)
+      set(PYTHON_INCLUDE_DIRS ${PYTHON2_INCLUDE_DIRS})
+      set(PYTHON_INCLUDE_PATH ${PYTHON2_INCLUDE_PATH})
+      set(PYTHON_LIBRARIES ${PYTHON2_LIBRARIES})
+      set(PYTHON_VERSION_MAJOR ${PYTHON2_VERSION_MAJOR})
+      set(PYTHON_VERSION_MINOR ${PYTHON2_VERSION_MINOR})
+      set(PYTHON_PACKAGES_PATH ${PYTHON2_PACKAGES_PATH})
+      _upm_swig_python()
+    endif (PYTHON2LIBS_FOUND)
 
-  # Generate python2 module if python2 libs are available
-  if (PYTHON2LIBS_FOUND)
-    set(PYTHON_INCLUDE_DIRS ${PYTHON2_INCLUDE_DIRS})
-    set(PYTHON_INCLUDE_PATH ${PYTHON2_INCLUDE_PATH})
-    set(PYTHON_LIBRARIES ${PYTHON2_LIBRARIES})
-    set(PYTHON_VERSION_MAJOR ${PYTHON2_VERSION_MAJOR})
-    set(PYTHON_VERSION_MINOR ${PYTHON2_VERSION_MINOR})
-    _upm_swig_python()
-  endif (PYTHON2LIBS_FOUND)
-
-  # Generate python3 module if python3 libs are available
-  if (PYTHON3LIBS_FOUND)
-    set(PYTHON_INCLUDE_DIRS ${PYTHON3_INCLUDE_DIRS})
-    set(PYTHON_INCLUDE_PATH ${PYTHON3_INCLUDE_PATH})
-    set(PYTHON_LIBRARIES ${PYTHON3_LIBRARIES})
-    set(PYTHON_VERSION_MAJOR ${PYTHON3_VERSION_MAJOR})
-    set(PYTHON_VERSION_MINOR ${PYTHON3_VERSION_MINOR})
-    _upm_swig_python()
-  endif (PYTHON3LIBS_FOUND)
+    # Generate python3 module if python3 libs are available
+    if (PYTHON3LIBS_FOUND)
+      set(PYTHON_INCLUDE_DIRS ${PYTHON3_INCLUDE_DIRS})
+      set(PYTHON_INCLUDE_PATH ${PYTHON3_INCLUDE_PATH})
+      set(PYTHON_LIBRARIES ${PYTHON3_LIBRARIES})
+      set(PYTHON_VERSION_MAJOR ${PYTHON3_VERSION_MAJOR})
+      set(PYTHON_VERSION_MINOR ${PYTHON3_VERSION_MINOR})
+      set(PYTHON_PACKAGES_PATH ${PYTHON3_PACKAGES_PATH})
+      _upm_swig_python()
+    endif (PYTHON3LIBS_FOUND)
+  endif (NOT ";${PYTHONSWIG_BLACKLIST};" MATCHES ";${libname};")
 endmacro(upm_swig_python)
 
 macro(upm_swig_node)
-  if (BUILDSWIGNODE)
+  # Skip if the libname is in the blacklist
+  if (NOT ";${NODESWIG_BLACKLIST};" MATCHES ";${libname};")
     # SWIG treats SWIG_FLAGS as a list and not a string so semicolon seperation is
     # required. This hardcodes V8_VERSION to be <10 but I assume that's not going
     # to be a problem for a little while! SWIG uses a padded SWIG_V8 version which
@@ -199,17 +195,17 @@ macro(upm_swig_node)
             set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UPM_CXX11_WORKAROUND_OPTION} ")
           endif ()
       endif ()
-
     endif()
+
     createpackagejson(${libname})
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/jsupm_${libname}.node
-         DESTINATION ${NODE_MODULE_INSTALL_PATH} COMPONENT ${libname})
-  endif()
+
+    install (TARGETS jsupm_${libname} DESTINATION ${NODE_MODULE_INSTALL_PATH})
+  endif (NOT ";${NODESWIG_BLACKLIST};" MATCHES ";${libname};")
 endmacro(upm_swig_node)
 
 macro(upm_swig_java)
-  if (BUILDSWIGJAVA)
-
+  # Skip if the libname is in the blacklist
+  if (NOT ";${JAVASWIG_BLACKLIST};" MATCHES ";${libname};")
     FIND_PACKAGE (JNI REQUIRED)
     pkg_check_modules (MRAAJAVA REQUIRED mraajava>=0.8.0)
 
@@ -233,8 +229,12 @@ macro(upm_swig_java)
       PREFIX "lib"
       SUFFIX ".so"
     )
+
     install (TARGETS javaupm_${libname} LIBRARY DESTINATION ${LIB_INSTALL_DIR})
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/upm_${libname}.jar DESTINATION ${LIB_INSTALL_DIR}/../lib/java)
+    # Java jar always goes under lib.  This fixes the case where LIB_INSTALL_DIR
+    # is lib64, in which case they still install to lib: lib64/../lib
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/upm_${libname}.jar
+        DESTINATION ${LIB_INSTALL_DIR}/../lib/java)
 
     if (NOT DEFINED $ENV{JAVA_HOME_NATIVE})
         set (JAVAC $ENV{JAVA_HOME}/bin/javac)
@@ -255,8 +255,7 @@ macro(upm_swig_java)
 
     configure_file (${CMAKE_CURRENT_SOURCE_DIR}/../pom.xml.in
         ${CMAKE_CURRENT_BINARY_DIR}/upm_${libname}-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.pom)
-
-  endif()
+  endif (NOT ";${JAVASWIG_BLACKLIST};" MATCHES ";${libname};")
 endmacro(upm_swig_java)
 
 macro(upm_doxygen)
@@ -412,17 +411,17 @@ macro(upm_module_init)
   upm_create_install_pkgconfig (${pcname} ${LIB_INSTALL_DIR}/pkgconfig)
 
   # Don't SWIG C
-  if (SWIG_FOUND AND NOT IS_C_LIBRARY)
-    if (NOT ";${PYTHONSWIG_BLACKLIST};" MATCHES ";${libname};")
+  if (NOT IS_C_LIBRARY)
+    if (BUILDSWIGPYTHON)
       upm_swig_python()
-    endif()
-    if (NOT ";${NODESWIG_BLACKLIST};" MATCHES ";${libname};")
+    endif (BUILDSWIGPYTHON)
+    if (BUILDSWIGNODE)
       upm_swig_node()
-    endif()
-    if (NOT ";${JAVASWIG_BLACKLIST};" MATCHES ";${libname};")
+    endif (BUILDSWIGNODE)
+    if (BUILDSWIGJAVA)
       upm_swig_java()
-    endif()
-  endif (SWIG_FOUND AND NOT IS_C_LIBRARY)
+    endif (BUILDSWIGJAVA)
+  endif (NOT IS_C_LIBRARY)
 
   # Skip doxygen run on C (for now)
   if (BUILDDOC AND NOT IS_C_LIBRARY)
@@ -437,6 +436,21 @@ macro(upm_module_init)
     set(CPACK_COMPONENT_${libname}_DESCRIPTION "${libdescription}")
   endif()
 endmacro(upm_module_init)
+
+# Top-level module init
+if (BUILDSWIGPYTHON)
+  file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/__init__.py "# UPM python modules")
+  if(PYTHON2LIBS_FOUND)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
+        DESTINATION ${PYTHON2_PACKAGES_PATH}/upm
+        COMPONENT python2)
+  endif(PYTHON2LIBS_FOUND)
+  if(PYTHON3LIBS_FOUND)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
+        DESTINATION ${PYTHON3_PACKAGES_PATH}/upm
+        COMPONENT python3)
+  endif(PYTHON3LIBS_FOUND)
+endif (BUILDSWIGPYTHON)
 
 # Generate python module documentation from doxygen collateral
 if (BUILDDOC AND BUILDSWIGPYTHON)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,10 +56,16 @@ if (BUILDSWIGPYTHON AND PYTHON2INTERP_FOUND)
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/)
 endif (BUILDSWIGPYTHON AND PYTHON2INTERP_FOUND)
 
-# Add a python3 test
+# Add some python3 tests
 if (BUILDSWIGPYTHON AND PYTHON3INTERP_FOUND)
     add_test (NAME check_load_modules_python3 COMMAND ${PYTHON3_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/check_pythonload.py
         ${CMAKE_BINARY_DIR}/src/*/python${PYTHON3_VERSION_MAJOR}.${PYTHON3_VERSION_MINOR}/*.py
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/)
+
+    # Test load examples w/python3
+    add_test (NAME check_load_examples_python3 COMMAND ${PYTHON3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/check_pythonload.py
+        ${CMAKE_SOURCE_DIR}/examples/python/*.py
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src/)
 endif (BUILDSWIGPYTHON AND PYTHON3INTERP_FOUND)

--- a/tests/check_pythonload.py
+++ b/tests/check_pythonload.py
@@ -59,7 +59,9 @@ class loadModule(unittest.TestCase):
         skeys = list(failures.keys())
         skeys.sort()
         self.assertEqual(len(failures), 0,
-                '\n\nFailed to load %d modules:\n' % len(failures) +
+                '\n\n%s' % '\n'.join((['%s=%s' % (k, os.environ[k]) for k in list(os.environ.keys())])) +
+                '\npython %s\n' % ' '.join(sys.version.strip().split()) +
+                '\nFailed to load %d modules:\n' % len(failures) +
                 '\n'.join(['%s: %s' % (k, failures[k]) for k in skeys]))
 
 if __name__ == '__main__':


### PR DESCRIPTION
    * Grouped UPM python modules into upm directory, for example:
      /usr/local/lib/python2.7/dist-packages/upm
    * Updated UPM example import statements
    * Removed unused RPATH statements from UPM src CMakeLists.txt,
      currently build collateral contains an explicit RPATH which
      is stripped from the install collateral.
    * Converted python examples to work on both python2 AND python3
    * Added ctest for loading examples w/python3
    * Removed returns from swig macros

Signed-off-by: Noel Eck <noel.eck@intel.com>