### PR TITLE
cmake: Consolidated BUILDJAVAEXAMPLES and BUILDEXAMPLES

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - sudo make install
   - sudo ldconfig
   # Build/install UPM
-  - cd $UPM_ROOT && mkdir $UPM_BUILD && cd $_ && cmake -DNODE_ROOT_DIR:PATH="${NODE_ROOT_DIR}" -DBUILDSWIGJAVA=$BUILDJAVA -DBUILDEXAMPLES=ON -DBUILDJAVAEXAMPLES=$BUILDJAVA -DBUILDTESTS=ON -DBUILDFTI=ON .. && sudo make install && sudo ldconfig && ctest --output-on-failure -E examplenames_js
+  - cd $UPM_ROOT && mkdir $UPM_BUILD && cd $_ && cmake -DNODE_ROOT_DIR:PATH="${NODE_ROOT_DIR}" -DBUILDSWIGJAVA=$BUILDJAVA -DBUILDEXAMPLES=ON -DBUILDTESTS=ON -DBUILDFTI=ON .. && sudo make install && sudo ldconfig && ctest --output-on-failure -E examplenames_js
 addons:
   apt:
     sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ option (BUILDFTI "Build Funtion Table Interface (FTI) in C sensor libraries" OFF
 option (BUILDSWIGPYTHON "Build swig python modules" ON)
 option (BUILDSWIGNODE "Build swig node modules" ON)
 option (BUILDSWIGJAVA "Build swig java modules" OFF)
-option (BUILDEXAMPLES "Build C/C++ example binaries" OFF)
-option (BUILDJAVAEXAMPLES "Build java example jars" OFF)
+option (BUILDEXAMPLES "Build C/C++/JAVA examples" OFF)
 option (IPK "Generate IPK using CPack" OFF)
 option (RPM "Generate RPM using CPack" OFF)
 option (NPM "Generate NPM/GYP tarballs" OFF)
@@ -138,6 +137,13 @@ find_package (JPEG)
 if (BUILDSWIGNODE)
   find_package (Node REQUIRED)
 endif (BUILDSWIGNODE)
+
+# Find JAVA/JNI
+if (BUILDSWIGJAVA)
+  find_package (Java REQUIRED)
+  find_package (JNI REQUIRED)
+  pkg_check_modules (MRAAJAVA REQUIRED mraajava>=0.8.0)
+endif (BUILDSWIGJAVA)
 
 # Find swig if any wrapper is enabled
 if (BUILDSWIGPYTHON OR BUILDSWIGNODE OR BUILDSWIGJAVA)
@@ -417,7 +423,8 @@ if(BUILDEXAMPLES)
   endif(BUILDCPP)
 endif()
 
-if(BUILDJAVAEXAMPLES)
+# Build java examples
+if(BUILDSWIGJAVA AND BUILDEXAMPLES)
   add_subdirectory (examples/java)
 endif()
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -80,13 +80,9 @@ Building documentation
 ~~~~~~~~~~~~~
 -DBUILDDOC=ON
 ~~~~~~~~~~~~~
-Build C++ example binaries
+Build C/C++/JAVA examples
 ~~~~~~~~~~~~~
 -DBUILDEXAMPLES=ON
-~~~~~~~~~~~~~
-Build Java examples
-~~~~~~~~~~~~~
--DBUILDJAVAEXAMPLES=ON
 ~~~~~~~~~~~~~
 
 If you intend to turn on all the options and build everything at once

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,9 +221,6 @@ endmacro(upm_swig_node)
 macro(upm_swig_java)
   # Skip if the libname is in the blacklist
   if (NOT ";${JAVASWIG_BLACKLIST};" MATCHES ";${libname};")
-    FIND_PACKAGE (JNI REQUIRED)
-    pkg_check_modules (MRAAJAVA REQUIRED mraajava>=0.8.0)
-
     include_directories (
       ${JAVA_INCLUDE_PATH}
       ${JAVA_INCLUDE_PATH2}


### PR DESCRIPTION
The java examples will now build if BUILDSWIGJAVA=on and
BUILDEXAMPLES=on.  This is similar to the C/C++ examples.

    * Replaced BUILDJAVAEXAMPLES w/BUILDEXAMPLES
    * Updated docs
    * Updated travis-ci

Signed-off-by: Noel Eck <noel.eck@intel.com>