### PR TITLE
LICENSE: Update license to be clearer and add 2016 copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright © 2014-2015 Intel Corporation
+The MIT License (MIT)
+Copyright © 2014-2016 Intel Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
MIT licenses should start with the following line to identify it as an MIT
license.

Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>