### PR TITLE
swigjava: Added SWIGJAVA define to java module build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -310,7 +310,7 @@ macro(upm_swig_java)
       ${DEPEND_DIRS}
      )
     set_target_properties (javaupm_${libname} PROPERTIES
-      COMPILE_FLAGS "-fpermissive -DJAVACALLBACK"
+      COMPILE_FLAGS "-fpermissive -DJAVACALLBACK -DSWIGJAVA"
       PREFIX "lib"
       SUFFIX ".so"
     )


### PR DESCRIPTION
SWIGJAVA is defined for the swig interface file processing but is not
defined for the sensor library source build.  There are multiple sensors
that appear to rely solely on SWIGJAVA - these are not building
correctly.  Adding SWIGJAVA define for the java module src build.

Signed-off-by: Noel Eck <noel.eck@intel.com>