### PR TITLE
Added bus autodetect to Intel Aero sensor C++ samples

### DIFF
--- a/examples/c++/bmi160.cxx
+++ b/examples/c++/bmi160.cxx
@@ -23,6 +23,7 @@
  */
 
 #include <unistd.h>
+#include <string>
 #include <iostream>
 #include <signal.h>
 #include "bmi160.hpp"
@@ -41,10 +42,30 @@ void sig_handler(int signo)
 int main(int argc, char **argv)
 {
   signal(SIGINT, sig_handler);
+  upm::BMI160 *sensor = NULL;
 //! [Interesting]
 
-  // Instantiate a BMI160 instance using default i2c bus and address
-  upm::BMI160 *sensor = new upm::BMI160();
+  // Instantiate a BMI160 instance using default i2c bus and address.
+  // If that fails, try default spi bus.
+  try
+  {
+    sensor = new upm::BMI160();
+  }
+  catch (std::exception& e)
+  {
+    std::cout << "Failed to connect via I2C, trying default SPI bus" << std::endl;
+  }
+
+  try
+  {
+    if (sensor == NULL)
+      sensor = new upm::BMI160(0, -1);
+  }
+  catch (std::exception& e)
+  {
+    std::cout << "Failed to connect via SPI, exiting." << std::endl;
+    return -1;
+  }
 
   while (shouldRun)
     {

--- a/examples/c++/bmm150.cxx
+++ b/examples/c++/bmm150.cxx
@@ -44,8 +44,25 @@ int main(int argc, char **argv)
 //! [Interesting]
 
   // Instantiate an BMM150 using default I2C parameters
-  upm::BMM150 *sensor = new upm::BMM150();
+  upm::BMM150 *sensor = NULL;
 
+  for (int i = 0; i < 4 && sensor == NULL; ++i)
+  {
+    try
+    {
+      cout << "Trying i2c address " << hex << showbase << BMM150_DEFAULT_ADDR + i << endl;
+      sensor = new upm::BMM150(BMM150_I2C_BUS, BMM150_DEFAULT_ADDR + i);
+    }
+    catch (std::exception& e)
+    {
+    }
+
+  }
+
+  if (sensor == NULL)
+  {
+    cout << "Sensor not detected." << endl;
+  }
   // For SPI, bus 0, you would pass -1 as the address, and a valid pin
   // for CS: BMM150(0, -1, 10);
 

--- a/src/ms5611/ms5611.cxx
+++ b/src/ms5611/ms5611.cxx
@@ -54,7 +54,7 @@ using namespace upm;
 MS5611::MS5611(int i2cBus, int address)
 {
     status = mraa::ERROR_INVALID_RESOURCE;
-    i2c = new mraa::I2c(2);
+    i2c = new mraa::I2c(i2cBus);
     this->address = address;
     i2c->address(address);
     prom = new uint16_t[MS5611_PROM_SIZE];


### PR DESCRIPTION
bmi160, bmm150 and ms5611 C++ samples now autodetect i2c and spi busses.