### PR TITLE
Java unclean bindings fixes

### DIFF
--- a/src/bh1750/CMakeLists.txt
+++ b/src/bh1750/CMakeLists.txt
@@ -1,6 +1,6 @@
 upm_mixed_module_init (NAME bh1750
     DESCRIPTION "Digital Light Sensor"
-    C_HDR bh1750.h
+    C_HDR bh1750.h bh1750_defs.h
     C_SRC bh1750.c
     CPP_HDR bh1750.hpp
     CPP_SRC bh1750.cxx

--- a/src/bh1750/bh1750.h
+++ b/src/bh1750/bh1750.h
@@ -31,6 +31,8 @@
 #include "upm.h"
 #include "upm_types.h"
 
+#include "bh1750_defs.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -43,42 +45,6 @@ extern "C" {
  * @include bh1750.c
  */
 
-#define BH1750_DEFAULT_I2C_BUS              0
-#define BH1750_DEFAULT_I2C_ADDR             0x23
-
-// BH1750 commands
-
-#define BH1750_CMD_POWER_DOWN               0x00
-#define BH1750_CMD_POWER_UP                 0x01
-
-#define BH1750_CMD_RESET                    0x07
-
-// continuous modes
-#define BH1750_CMD_CONT_H_RES_MODE1         0x10 // 1 lx resolution
-#define BH1750_CMD_CONT_H_RES_MODE2         0x11 // .5 lx resolution
-#define BH1750_CMD_CONT_L_RES_MODE          0x13 // 4 lx resolution
-
-// one-time modes
-#define BH1750_CMD_ONETIME_H_RES_MODE1      0x20
-#define BH1750_CMD_ONETIME_H_RES_MODE2      0x21
-#define BH1750_CMD_ONETIME_L_RES_MODE       0x23
-
-// max measurement time in ms (for H modes)
-#define BH1750_MAX_MEAS_TIME_H              180
-
-// max measurement time in ms (for L modes)
-#define BH1750_MAX_MEAS_TIME_L              30
-
-// an enum for the operating mode to pass to init
-typedef enum {
-  BH1750_OPMODE_H1_CONT, // continuous 1 lx high resolution
-  BH1750_OPMODE_H2_CONT, // continuous .5 lx high resolution
-  BH1750_OPMODE_L_CONT,  // continuous 4 lx low resolution
-  BH1750_OPMODE_H1_ONCE, // onetime 1 lx high resolution
-  BH1750_OPMODE_H2_ONCE, // onetime .5 lx high resolution
-  BH1750_OPMODE_L_ONCE,  // onetime 4 lx low resolution
-} BH1750_OPMODES_T;
-    
 /**
  * device context
  */
@@ -86,7 +52,7 @@ typedef struct _bh1750_context
 {
   int                 bus;
   mraa_i2c_context    i2c;
-  
+
   // these are set by bh1750_set_opmode()
   uint8_t             opmode;
   bool                is_continuous;

--- a/src/bh1750/bh1750_defs.h
+++ b/src/bh1750/bh1750_defs.h
@@ -1,0 +1,71 @@
+/*
+ * Authors: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#define BH1750_DEFAULT_I2C_BUS              0
+#define BH1750_DEFAULT_I2C_ADDR             0x23
+
+// BH1750 commands
+
+#define BH1750_CMD_POWER_DOWN               0x00
+#define BH1750_CMD_POWER_UP                 0x01
+
+#define BH1750_CMD_RESET                    0x07
+
+// continuous modes
+#define BH1750_CMD_CONT_H_RES_MODE1         0x10 // 1 lx resolution
+#define BH1750_CMD_CONT_H_RES_MODE2         0x11 // .5 lx resolution
+#define BH1750_CMD_CONT_L_RES_MODE          0x13 // 4 lx resolution
+
+// one-time modes
+#define BH1750_CMD_ONETIME_H_RES_MODE1      0x20
+#define BH1750_CMD_ONETIME_H_RES_MODE2      0x21
+#define BH1750_CMD_ONETIME_L_RES_MODE       0x23
+
+// max measurement time in ms (for H modes)
+#define BH1750_MAX_MEAS_TIME_H              180
+
+// max measurement time in ms (for L modes)
+#define BH1750_MAX_MEAS_TIME_L              30
+
+// an enum for the operating mode to pass to init
+    typedef enum {
+        BH1750_OPMODE_H1_CONT, // continuous 1 lx high resolution
+        BH1750_OPMODE_H2_CONT, // continuous .5 lx high resolution
+        BH1750_OPMODE_L_CONT,  // continuous 4 lx low resolution
+        BH1750_OPMODE_H1_ONCE, // onetime 1 lx high resolution
+        BH1750_OPMODE_H2_ONCE, // onetime .5 lx high resolution
+        BH1750_OPMODE_L_ONCE,  // onetime 4 lx low resolution
+    } BH1750_OPMODES_T;
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/src/bh1750/javaupm_bh1750.i
+++ b/src/bh1750/javaupm_bh1750.i
@@ -2,11 +2,12 @@
 %include "../upm.i"
 %include "std_string.i"
 
+
+%include "bh1750_defs.h"
+%include "bh1750.hpp"
 %{
     #include "bh1750.hpp"
 %}
-
-%include "bh1750.hpp"
 
 
 %pragma(java) jniclasscode=%{

--- a/src/bh1750/jsupm_bh1750.i
+++ b/src/bh1750/jsupm_bh1750.i
@@ -2,9 +2,9 @@
 %include "../upm.i"
 %include "std_string.i"
 
+%include "bh1750_defs.h"
+%include "bh1750.hpp"
 %{
     #include "bh1750.hpp"
 %}
-
-%include "bh1750.hpp"
 

--- a/src/bh1750/pyupm_bh1750.i
+++ b/src/bh1750/pyupm_bh1750.i
@@ -6,8 +6,9 @@
 
 %feature("autodoc", "3");
 
+%include "bh1750_defs.h"
+%include "bh1750.hpp"
 %{
     #include "bh1750.hpp"
 %}
-%include "bh1750.hpp"
 

--- a/src/bmi160/CMakeLists.txt
+++ b/src/bmi160/CMakeLists.txt
@@ -1,6 +1,6 @@
 upm_mixed_module_init (NAME bmi160
     DESCRIPTION "Bosch Sensortec IMU (triaxial Accelerometer, Triaxial Gyroscope and Magnetometer Interface)"
-    C_HDR bmi160.h bosch_bmi160.h
+    C_HDR bmi160.h bmi160_defs.h bosch_bmi160.h
     C_SRC bmi160.c bosch_bmi160.c
     CPP_HDR bmi160.hpp
     CPP_SRC bmi160.cxx

--- a/src/bmi160/bmi160.h
+++ b/src/bmi160/bmi160.h
@@ -33,8 +33,7 @@ extern "C" {
 #endif
 
 #include "bosch_bmi160.h"
-
-#define BMI160_CHIP_ID 0xd1
+#include "bmi160_defs.h"
 
   /**
    * @brief BMI160 3-axis Accelerometer, Gyroscope and (optionally) a
@@ -88,21 +87,6 @@ extern "C" {
         bool magEnabled;
 
     } *bmi160_context;
-
-    typedef enum {
-      BMI160_ACC_RANGE_2G                        = 0, // 2 Gravities
-      BMI160_ACC_RANGE_4G,
-      BMI160_ACC_RANGE_8G,
-      BMI160_ACC_RANGE_16G
-    } BMI160_ACC_RANGE_T;
-
-    typedef enum {
-      BMI160_GYRO_RANGE_125                      = 0, // 125 degrees/sec
-      BMI160_GYRO_RANGE_250,
-      BMI160_GYRO_RANGE_500,
-      BMI160_GYRO_RANGE_1000,
-      BMI160_GYRO_RANGE_2000
-    } BMI160_GYRO_RANGE_T;
 
     /**
      * bmi160 constructor

--- a/src/bmi160/bmi160_defs.h
+++ b/src/bmi160/bmi160_defs.h
@@ -1,0 +1,51 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2017 Intel Corporation.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BMI160_CHIP_ID 0xd1
+
+    typedef enum {
+        BMI160_ACC_RANGE_2G                        = 0, // 2 Gravities
+        BMI160_ACC_RANGE_4G,
+        BMI160_ACC_RANGE_8G,
+        BMI160_ACC_RANGE_16G
+    } BMI160_ACC_RANGE_T;
+
+    typedef enum {
+        BMI160_GYRO_RANGE_125                      = 0, // 125 degrees/sec
+        BMI160_GYRO_RANGE_250,
+        BMI160_GYRO_RANGE_500,
+        BMI160_GYRO_RANGE_1000,
+        BMI160_GYRO_RANGE_2000
+    } BMI160_GYRO_RANGE_T;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/bmi160/javaupm_bmi160.i
+++ b/src/bmi160/javaupm_bmi160.i
@@ -5,6 +5,7 @@
 %include "../java_buffer.i"
 %include "std_string.i"
 
+%include "bmi160_defs.h"
 %{
     #include "bmi160.hpp"
 %}

--- a/src/bmi160/jsupm_bmi160.i
+++ b/src/bmi160/jsupm_bmi160.i
@@ -5,6 +5,7 @@
 
 %pointer_functions(float, floatp);
 
+%include "bmi160_defs.h"
 %include "bmi160.hpp"
 %{
     #include "bmi160.hpp"

--- a/src/bmi160/pyupm_bmi160.i
+++ b/src/bmi160/pyupm_bmi160.i
@@ -11,6 +11,7 @@
 
 %pointer_functions(float, floatp);
 
+%include "bmi160_defs.h"
 %include "bmi160.hpp"
 %{
     #include "bmi160.hpp"

--- a/src/ims/CMakeLists.txt
+++ b/src/ims/CMakeLists.txt
@@ -1,6 +1,6 @@
 upm_mixed_module_init (NAME ims
     DESCRIPTION "I2C Moisture Sensor"
-    C_HDR ims.h
+    C_HDR ims.h ims_defs.h
     C_SRC ims.c
     CPP_HDR ims.hpp
     CPP_SRC ims.cxx

--- a/src/ims/ims.h
+++ b/src/ims/ims.h
@@ -30,39 +30,11 @@
 #include "mraa/i2c.h"
 #include "upm.h"
 
+#include "ims_defs.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define IMS_ADDRESS_DEFAULT 0x20
-
- /* @brief Moisture sensor I2C READ commands */
-typedef enum _IMS_RD_COMMAND {
-        /* Read capacitance (moisture) register */
-        IMS_GET_CAPACITANCE = 0x00, /*    (r) 2 */
-        /* Read I2C address register */
-        IMS_GET_ADDRESS     = 0x02, /*    (r) 1 */
-        /* Read light register (requires write to IMS_MEASURE_LIGHT) */
-        IMS_GET_LIGHT       = 0x04, /*    (r) 2 */
-        /* Read temperature register */
-        IMS_GET_TEMPERATURE = 0x05, /*    (r) 2 */
-        /* Read version register */
-        IMS_GET_VERSION     = 0x07, /*    (r) 1 */
-        /* Read busy register (0 = ready, 1 = sampling) */
-        IMS_GET_BUSY        = 0x09, /*    (r) 1 */
-} IMS_RD_COMMAND;
-
- /* @brief Moisture sensor I2C WRITE commands */
-typedef enum {
-        /* Write I2C address register (latched w/IMS_RESET) */
-        IMS_SET_ADDRESS     = 0x01, /*    (w) 1 */
-        /* Initiate light measurement */
-        IMS_MEASURE_LIGHT   = 0x03, /*    (w) 0 */
-        /* Reset device */
-        IMS_RESET           = 0x06, /*    (w) 0 */
-        /* Sleep microcontroller, wake on any I2C request */
-        IMS_SLEEP           = 0x08, /*    (w) 0 */
-} IMS_WR_COMMAND;
 
 /**
  * @file ims.h

--- a/src/ims/ims.hpp
+++ b/src/ims/ims.hpp
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include "mraa/i2c.h"
 #include "ims.h"
 
 namespace upm {

--- a/src/ims/ims_defs.h
+++ b/src/ims/ims_defs.h
@@ -1,0 +1,64 @@
+/*
+ * Author: Noel Eck <noel.eck@intel.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IMS_ADDRESS_DEFAULT 0x20
+
+ /* @brief Moisture sensor I2C READ commands */
+typedef enum _IMS_RD_COMMAND {
+        /* Read capacitance (moisture) register */
+        IMS_GET_CAPACITANCE = 0x00, /*    (r) 2 */
+        /* Read I2C address register */
+        IMS_GET_ADDRESS     = 0x02, /*    (r) 1 */
+        /* Read light register (requires write to IMS_MEASURE_LIGHT) */
+        IMS_GET_LIGHT       = 0x04, /*    (r) 2 */
+        /* Read temperature register */
+        IMS_GET_TEMPERATURE = 0x05, /*    (r) 2 */
+        /* Read version register */
+        IMS_GET_VERSION     = 0x07, /*    (r) 1 */
+        /* Read busy register (0 = ready, 1 = sampling) */
+        IMS_GET_BUSY        = 0x09, /*    (r) 1 */
+} IMS_RD_COMMAND;
+
+ /* @brief Moisture sensor I2C WRITE commands */
+typedef enum {
+        /* Write I2C address register (latched w/IMS_RESET) */
+        IMS_SET_ADDRESS     = 0x01, /*    (w) 1 */
+        /* Initiate light measurement */
+        IMS_MEASURE_LIGHT   = 0x03, /*    (w) 0 */
+        /* Reset device */
+        IMS_RESET           = 0x06, /*    (w) 0 */
+        /* Sleep microcontroller, wake on any I2C request */
+        IMS_SLEEP           = 0x08, /*    (w) 0 */
+} IMS_WR_COMMAND;
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ims/javaupm_ims.i
+++ b/src/ims/javaupm_ims.i
@@ -5,7 +5,7 @@
     #include "ims.hpp"
 %}
 
-%include "ims.h"
+%include "ims_defs.h"
 %include "ims.hpp"
 
 %pragma(java) jniclasscode=%{

--- a/src/ims/jsupm_ims.i
+++ b/src/ims/jsupm_ims.i
@@ -5,5 +5,5 @@
     #include "ims.hpp"
 %}
 
-%include "ims.h"
+%include "ims_defs.h"
 %include "ims.hpp"

--- a/src/ims/pyupm_ims.i
+++ b/src/ims/pyupm_ims.i
@@ -9,5 +9,5 @@
     #include "ims.hpp"
 %}
 
-%include "ims.h"
+%include "ims_defs.h"
 %include "ims.hpp"

--- a/src/mcp2515/javaupm_mcp2515.i
+++ b/src/mcp2515/javaupm_mcp2515.i
@@ -4,7 +4,6 @@
 %include "arrays_java.i"
 %include "../java_buffer.i"
 %include "std_string.i"
-%include "../carrays_uint8_t.i"
 
 %include "mcp2515_regs.h"
 %include "mcp2515.hpp"

--- a/src/md/CMakeLists.txt
+++ b/src/md/CMakeLists.txt
@@ -1,9 +1,8 @@
 upm_mixed_module_init (NAME md
     DESCRIPTION "I2C Motor Driver"
-    C_HDR md.h
+    C_HDR md.h md_defs.h
     C_SRC md.c
     CPP_HDR md.hpp
     CPP_SRC md.cxx
-#    FTI_SRC md_fti.c
     CPP_WRAPS_C
     REQUIRES mraa)

--- a/src/md/javaupm_md.i
+++ b/src/md/javaupm_md.i
@@ -5,7 +5,7 @@
     #include "md.hpp"
 %}
 
-%include "md.h"
+%include "md_defs.h"
 %include "md.hpp"
 
 %pragma(java) jniclasscode=%{

--- a/src/md/jsupm_md.i
+++ b/src/md/jsupm_md.i
@@ -1,7 +1,7 @@
 %module jsupm_md
 %include "../upm.i"
 
-%include "md.h"
+%include "md_defs.h"
 %include "md.hpp"
 %{
     #include "md.hpp"

--- a/src/md/md.h
+++ b/src/md/md.h
@@ -26,11 +26,7 @@
 #include <upm.h>
 #include <mraa/i2c.h>
 
-#define MD_I2C_BUS 0
-#define MD_DEFAULT_I2C_ADDR 0x0f
-
-// This is a NOOP value used to pad packets
-#define MD_NOOP 0x01
+#include "md_defs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,36 +39,6 @@ extern "C" {
      *
      * @include md.c
      */
-
-    // MD registers
-    typedef enum {
-        MD_REG_SET_SPEED           = 0x82,
-        MD_REG_SET_PWM_FREQ        = 0x84,
-        MD_REG_SET_DIRECTION       = 0xaa,
-        MD_REG_SET_MOTOR_A         = 0xa1, // not documented
-        MD_REG_SET_MOTOR_B         = 0xa5, // not documented
-        MD_REG_STEPPER_ENABLE      = 0x1a,
-        MD_REG_STEPPER_DISABLE     = 0x1b,
-        MD_REG_STEPPER_NUM_STEPS   = 0x1c
-    } MD_REG_T;
-
-    // legal directions for the stepper
-    typedef enum {
-        MD_STEP_DIR_CCW    = 0x01,
-        MD_STEP_DIR_CW     = 0x00
-    } MD_STEP_DIRECTION_T;
-
-    // legal directions for individual DC motors
-    typedef enum {
-        MD_DIR_CCW    = 0x02,
-        MD_DIR_CW     = 0x01
-    } MD_DC_DIRECTION_T;
-
-    // stepper modes
-    typedef enum {
-        MD_STEP_MODE1 = 0x00,
-        MD_STEP_MODE2 = 0x01
-    } MD_STEP_MODE_T;
 
     /**
      * Device context

--- a/src/md/md_defs.h
+++ b/src/md/md_defs.h
@@ -1,0 +1,69 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MD_I2C_BUS 0
+#define MD_DEFAULT_I2C_ADDR 0x0f
+
+// This is a NOOP value used to pad packets
+#define MD_NOOP 0x01
+
+
+    // MD registers
+    typedef enum {
+        MD_REG_SET_SPEED           = 0x82,
+        MD_REG_SET_PWM_FREQ        = 0x84,
+        MD_REG_SET_DIRECTION       = 0xaa,
+        MD_REG_SET_MOTOR_A         = 0xa1, // not documented
+        MD_REG_SET_MOTOR_B         = 0xa5, // not documented
+        MD_REG_STEPPER_ENABLE      = 0x1a,
+        MD_REG_STEPPER_DISABLE     = 0x1b,
+        MD_REG_STEPPER_NUM_STEPS   = 0x1c
+    } MD_REG_T;
+
+    // legal directions for the stepper
+    typedef enum {
+        MD_STEP_DIR_CCW    = 0x01,
+        MD_STEP_DIR_CW     = 0x00
+    } MD_STEP_DIRECTION_T;
+
+    // legal directions for individual DC motors
+    typedef enum {
+        MD_DIR_CCW    = 0x02,
+        MD_DIR_CW     = 0x01
+    } MD_DC_DIRECTION_T;
+
+    // stepper modes
+    typedef enum {
+        MD_STEP_MODE1 = 0x00,
+        MD_STEP_MODE2 = 0x01
+    } MD_STEP_MODE_T;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/md/pyupm_md.i
+++ b/src/md/pyupm_md.i
@@ -9,7 +9,7 @@
 %include "md_doc.i"
 #endif
 
-%include "md.h"
+%include "md_defs.h"
 %include "md.hpp"
 %{
     #include "md.hpp"

--- a/src/sht1x/CMakeLists.txt
+++ b/src/sht1x/CMakeLists.txt
@@ -1,6 +1,6 @@
 upm_mixed_module_init (NAME sht1x
     DESCRIPTION "Temperature and Humidity Sensor"
-    C_HDR sht1x.h
+    C_HDR sht1x.h sht1x_defs.h
     C_SRC sht1x.c
     CPP_HDR sht1x.hpp
     CPP_SRC sht1x.cxx

--- a/src/sht1x/javaupm_sht1x.i
+++ b/src/sht1x/javaupm_sht1x.i
@@ -4,6 +4,7 @@
 %include "stdint.i"
 %include "typemaps.i"
 
+%include "sht1x_defs.h"
 %include "sht1x.hpp"
 %{
     #include "sht1x.hpp"

--- a/src/sht1x/jsupm_sht1x.i
+++ b/src/sht1x/jsupm_sht1x.i
@@ -2,6 +2,7 @@
 %include "../upm.i"
 %include "std_string.i"
 
+%include "sht1x_defs.h"
 %include "sht1x.hpp"
 %{
     #include "sht1x.hpp"

--- a/src/sht1x/pyupm_sht1x.i
+++ b/src/sht1x/pyupm_sht1x.i
@@ -6,6 +6,7 @@
 
 %feature("autodoc", "3");
 
+%include "sht1x_defs.h"
 %include "sht1x.hpp"
 %{
     #include "sht1x.hpp"

--- a/src/sht1x/sht1x.h
+++ b/src/sht1x/sht1x.h
@@ -28,6 +28,8 @@
 #include "upm.h"
 #include "mraa/gpio.h"
 
+#include "sht1x_defs.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -66,40 +68,6 @@ extern "C" {
     float                    coeff_t1;
     float                    coeff_t2;
   } *sht1x_context;
-
-  // SHT1X commands.  The first 3 msb's are the address, which are
-  // always 0.  The following 5 bits are the actual command.
-  typedef enum {
-    SHT1X_CMD_MEAS_TEMPERATURE            = 0x03,
-    SHT1X_CMD_MEAS_HUMIDITY               = 0x05,
-    SHT1X_CMD_WRITE_STATUS                = 0x06,
-    SHT1X_CMD_READ_STATUS                 = 0x07,
-    SHT1X_CMD_SOFT_RESET                  = 0x1e
-  } SHT1X_CMD_T;
-
-  // status register bits
-  typedef enum {
-    SHT1X_STATUS_RESOLUTION_LOW           = 0x01, // 0=12b RH/14b temp (dflt)
-    SHT1X_STATUS_NO_RELOAD_FROM_OTP       = 0x02,
-    SHT1X_STATUS_HEATER_EN                = 0x04,
-
-    // 0x08-0x20 reserved
-
-    SHT1X_STATUS_LOW_VOLT                 = 0x40 // low battery
-
-    // 0x80 reserved
-  } SHT1X_STATUS_BITS_T;
-
-  // The Vdd voltage can affect the temperature coefficients, so we
-  // provide a way to indicate the closest voltage and set up the
-  // compensation accordingly.
-  typedef enum {
-    SHT1X_VOLTS_5                         = 0, // 5 volts
-    SHT1X_VOLTS_4                         = 1,
-    SHT1X_VOLTS_3_5                       = 2, // 3.5v
-    SHT1X_VOLTS_3                         = 3,
-    SHT1X_VOLTS_2_5                       = 4
-  } SHT1X_VOLTS_T;
 
   /**
    * SHT1X Initializer

--- a/src/sht1x/sht1x_defs.h
+++ b/src/sht1x/sht1x_defs.h
@@ -1,0 +1,68 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+  // SHT1X commands.  The first 3 msb's are the address, which are
+  // always 0.  The following 5 bits are the actual command.
+  typedef enum {
+    SHT1X_CMD_MEAS_TEMPERATURE            = 0x03,
+    SHT1X_CMD_MEAS_HUMIDITY               = 0x05,
+    SHT1X_CMD_WRITE_STATUS                = 0x06,
+    SHT1X_CMD_READ_STATUS                 = 0x07,
+    SHT1X_CMD_SOFT_RESET                  = 0x1e
+  } SHT1X_CMD_T;
+
+  // status register bits
+  typedef enum {
+    SHT1X_STATUS_RESOLUTION_LOW           = 0x01, // 0=12b RH/14b temp (dflt)
+    SHT1X_STATUS_NO_RELOAD_FROM_OTP       = 0x02,
+    SHT1X_STATUS_HEATER_EN                = 0x04,
+
+    // 0x08-0x20 reserved
+
+    SHT1X_STATUS_LOW_VOLT                 = 0x40 // low battery
+
+    // 0x80 reserved
+  } SHT1X_STATUS_BITS_T;
+
+  // The Vdd voltage can affect the temperature coefficients, so we
+  // provide a way to indicate the closest voltage and set up the
+  // compensation accordingly.
+  typedef enum {
+    SHT1X_VOLTS_5                         = 0, // 5 volts
+    SHT1X_VOLTS_4                         = 1,
+    SHT1X_VOLTS_3_5                       = 2, // 3.5v
+    SHT1X_VOLTS_3                         = 3,
+    SHT1X_VOLTS_2_5                       = 4
+  } SHT1X_VOLTS_T;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/uln200xa/CMakeLists.txt
+++ b/src/uln200xa/CMakeLists.txt
@@ -1,6 +1,6 @@
 upm_mixed_module_init (NAME uln200xa
     DESCRIPTION "Darlington Stepper Driver"
-    C_HDR uln200xa.h
+    C_HDR uln200xa.h uln200xa_defs.h
     C_SRC uln200xa.c
     CPP_HDR uln200xa.hpp
     CPP_SRC uln200xa.cxx

--- a/src/uln200xa/javaupm_uln200xa.i
+++ b/src/uln200xa/javaupm_uln200xa.i
@@ -1,7 +1,7 @@
 %module javaupm_uln200xa
 %include "../upm.i"
 
-%include "uln200xa.h"
+%include "uln200xa_defs.h"
 %include "uln200xa.hpp"
 %{
     #include "uln200xa.hpp"

--- a/src/uln200xa/jsupm_uln200xa.i
+++ b/src/uln200xa/jsupm_uln200xa.i
@@ -1,7 +1,7 @@
 %module jsupm_uln200xa
 %include "../upm.i"
 
-%include "uln200xa.h"
+%include "uln200xa_defs.h"
 %include "uln200xa.hpp"
 %{
     #include "uln200xa.hpp"

--- a/src/uln200xa/pyupm_uln200xa.i
+++ b/src/uln200xa/pyupm_uln200xa.i
@@ -5,7 +5,7 @@
 
 %feature("autodoc", "3");
 
-%include "uln200xa.h"
+%include "uln200xa_defs.h"
 %include "uln200xa.hpp"
 %{
     #include "uln200xa.hpp"

--- a/src/uln200xa/uln200xa.h
+++ b/src/uln200xa/uln200xa.h
@@ -29,6 +29,8 @@
 
 #include <mraa/gpio.h>
 
+#include "uln200xa_defs.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -57,14 +59,6 @@ extern "C" {
         int      stepDirection;
 
     } *uln200xa_context;
-
-    /**
-     * Enum to specify the direction of a motor
-     */
-    typedef enum {
-      ULN200XA_DIR_CW   = 0x01,
-      ULN200XA_DIR_CCW  = 0x02
-    } ULN200XA_DIRECTION_T;
 
     /**
      * ULN200XA constructor

--- a/src/uln200xa/uln200xa_defs.h
+++ b/src/uln200xa/uln200xa_defs.h
@@ -1,0 +1,41 @@
+/*
+ * Author: Jon Trulson <jtrulson@ics.com>
+ * Copyright (c) 2016 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    /**
+     * Enum to specify the direction of a motor
+     */
+    typedef enum {
+      ULN200XA_DIR_CW   = 0x01,
+      ULN200XA_DIR_CCW  = 0x02
+    } ULN200XA_DIRECTION_T;
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This corrects the issues reported in PR #529, at least with regard to using driver C header files in SWIG interface files.  The drivers included in this PR have had their enum and #defines moved into a separate C header file which is safe for SWIGing.

@stefan-andritoiu please take a look at these and let me know if they solve that particular problem with Java.