### PR TITLE
upm: enable Elementz IR Proximity sensor library and example

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -342,6 +342,7 @@ add_example (hdc1000)
 add_example (bmg160)
 add_example (bma250e)
 add_example (bmm150)
+add_example (elementzir)
 
 # These are special cases where you specify example binary, source file and module(s)
 include_directories (${PROJECT_SOURCE_DIR}/src)

--- a/examples/c++/elementzir.cxx
+++ b/examples/c++/elementzir.cxx
@@ -1,0 +1,65 @@
+/*
+ * Author: Saloni Jain <saloni.jain@tcs.com>
+ * Author: Niti Rohilla<niti.rohilla@tcs.com>
+ * Copyright (c) 2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <signal.h>
+#include "elementzir.hpp"
+
+using namespace std;
+
+int shouldRun = true;
+
+void sig_handler(int signo)
+{
+  if (signo == SIGINT)
+    shouldRun = false;
+}
+
+
+int main()
+{
+  signal(SIGINT, sig_handler);
+
+//! [Interesting]
+  // This example uses a simple method to detect obstacle
+
+  // Instantiate an ElementzIR digital pin D23
+  upm::ElementzIR* elementzir = new upm::ElementzIR(23);
+  
+  while (shouldRun)
+    {
+      if (elementzir->obstacleDetected())
+        cout << "Obstacle detected" << endl;
+      
+      usleep(100000);           // 100ms
+    }
+//! [Interesting]
+
+  cout << "Exiting..." << endl;
+
+  delete elementzir;
+  return 0;
+}

--- a/src/elementzir/CMakeLists.txt
+++ b/src/elementzir/CMakeLists.txt
@@ -1,0 +1,5 @@
+set (libname "elementzir")
+set (libdescription "Infrared Proximity sensor")
+set (module_src ${libname}.cxx)
+set (module_hpp ${libname}.hpp)
+upm_module_init(mraa)

--- a/src/elementzir/elementzir.cxx
+++ b/src/elementzir/elementzir.cxx
@@ -1,0 +1,67 @@
+/*
+ * Author: Saloni Jain <saloni.jain@tcs.com>
+ * Author: Niti Rohilla <niti.rohilla@tcs.com>
+ * Copyright (c) 2014-2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <unistd.h>
+#include <stdlib.h>
+#include <functional>
+
+#ifdef JAVACALLBACK
+#undef JAVACALLBACK
+#endif
+
+#include "elementzir.hpp"
+
+using namespace upm;
+
+ElementzIR::ElementzIR (int pin) {
+    m_name              = "ElementzIR";
+
+    m_pinCtx     = mraa_gpio_init_raw (pin);
+    if (m_pinCtx == NULL) {
+        throw std::invalid_argument(std::string(__FUNCTION__) +
+                                    ": mraa_gpio_init_raw() failed, invalid pin?");
+        return;
+    }
+
+    mraa_gpio_dir(m_pinCtx, MRAA_GPIO_IN);
+}
+
+ElementzIR::~ElementzIR () {
+    mraa_result_t error = MRAA_SUCCESS;
+
+    error = mraa_gpio_close (m_pinCtx);
+    if (error != MRAA_SUCCESS) {
+        mraa_result_print (error);
+    }
+}
+
+bool
+ElementzIR::obstacleDetected()
+{
+    return (mraa_gpio_read(m_pinCtx) ? true : false);
+}

--- a/src/elementzir/elementzir.hpp
+++ b/src/elementzir/elementzir.hpp
@@ -1,0 +1,93 @@
+/*
+ * Author: Saloni Jain <saloni.jain@tcs.com>
+ * Author: Niti Rohilla <niti.rohilla@tcs.com>
+ * Copyright (c) 2014-2015 Intel Corporation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include <mraa/aio.h>
+#include <mraa/gpio.h>
+#include <mraa/pwm.h>
+#include <sys/time.h>
+
+namespace upm {
+/**
+ * @brief ELEMENTZ IR Proximity Sensor library
+ * @defgroup elementzir libupm-elementzir
+ * @ingroup generic gpio light
+ */
+
+/**
+ * @library elementzir
+ * @sensor elementzir
+ * @comname Infrared Proximity Sensor
+ * @type light
+ * @man elementz
+ * @con gpio
+ * @web https://elementzonline.com/ir-infrared-proximity-obstacle-sensor-module-95
+ *
+ * @brief API for the Elementz Infrared Proximity Sensor
+ *
+ * This module defines the Infrared interface for libelementz
+ *
+ * @image html elementzir.jpg
+ * @snippet elementzir.cxx Interesting
+ */
+class ElementzIR {
+    public:
+        /**
+         * Instantiates an ElementzIR object
+         *
+         * @param pin Digital pin to use
+         * @param fptr Function pointer to handle rising-edge
+         * interrupts
+         */
+        ElementzIR (int pin);
+        /**
+         * ElementzIR object destructor
+         */
+        ~ElementzIR ();
+
+        /**
+         * Gets the status of the pin; true means black has been detected
+         *
+         * @Return True if sensor has detected black
+         */
+        bool obstacleDetected ();
+
+        /**
+         * Returns the name of the sensor
+         */
+        std::string name()
+        {
+            return m_name;
+        }
+
+    private:
+
+        mraa_gpio_context   m_pinCtx;
+
+        std::string         m_name;
+};
+
+}

--- a/src/elementzir/javaupm_elementzir.i
+++ b/src/elementzir/javaupm_elementzir.i
@@ -1,0 +1,20 @@
+%module javaupm_elementzir
+%include "../upm.i"
+
+%{
+    #include "elementzir.hpp"
+%}
+
+%include "elementzir.hpp"
+
+%pragma(java) jniclasscode=%{
+    static {
+        try {
+            System.loadLibrary("javaupm_elementzir");
+        } catch (UnsatisfiedLinkError e) {
+            System.err.println("Native code library failed to load. \n" + e);
+            System.exit(1);
+        }
+    }
+%}
+

--- a/src/elementzir/jsupm_elementzir.i
+++ b/src/elementzir/jsupm_elementzir.i
@@ -1,0 +1,8 @@
+%module jsupm_elementzir
+%include "../upm.i"
+
+%{
+    #include "elementzir.hpp"
+%}
+
+%include "elementzir.hpp"

--- a/src/elementzir/pyupm_elementzir.i
+++ b/src/elementzir/pyupm_elementzir.i
@@ -1,0 +1,11 @@
+// Include doxygen-generated documentation
+%include "pyupm_doxy2swig.i"
+%module pyupm_elementzir
+%include "../upm.i"
+
+%feature("autodoc", "3");
+
+%include "elementzir.hpp"
+%{
+    #include "elementzir.hpp"
+%}


### PR DESCRIPTION
Elementz IR Infrared Proximity /Obstacle Detector Sensor Module

This sensor module works on INFRARED, for obstacles with reflective surfaces
(white colored), the maximum range will be higher and for non-reflective
surfaces (black colored), the maximum range will be lower. This can in turn
be used for detecting white/black lines (in line follower ROBOTs) or
bright/dark objects (in object identification ROBOTs)

The library provided is libupm-elementzir.so
The example provided is elementzir.cxx where it will print "Obstacle detected"
whenever an obstacle is detected by the sensor. This is being tested on Raspberry
Pi 2 Model B V1.1. 

The image of the sensor is at docs/images/elementzir.jpg

Signed-off-by: Saloni Jain <saloni.jain@tcs.com>
Signed-off-by: Niti Rohilla <niti.rohilla@tcs.com>