### PR TITLE
bno055: enhance error detection and propagation

### DIFF
--- a/src/bno055/bno055.cxx
+++ b/src/bno055/bno055.cxx
@@ -61,7 +61,12 @@ void BNO055::update()
 
 uint8_t BNO055::readReg(uint8_t reg)
 {
-    return bno055_read_reg(m_bno055, reg);
+    uint8_t rv = 0;
+    if (bno055_read_reg(m_bno055, reg, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_read_reg() failed");
+
+    return rv;
 }
 
 void BNO055::readRegs(uint8_t reg, uint8_t *buffer, int len)
@@ -87,32 +92,62 @@ void BNO055::writeRegs(uint8_t reg, uint8_t *buffer, int len)
 
 uint8_t BNO055::getChipID()
 {
-    return bno055_get_chip_id(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_chip_id(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_chip_id() failed");
+
+    return rv;
 }
 
 uint8_t BNO055::getACCID()
 {
-    return bno055_get_acc_id(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_acc_id(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_acc_id() failed");
+
+    return rv;
 }
 
 uint8_t BNO055::getMAGID()
 {
-    return bno055_get_mag_id(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_mag_id(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_mag_id() failed");
+
+    return rv;
 }
 
 uint8_t BNO055::getGYRID()
 {
-    return bno055_get_gyr_id(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_gyr_id(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_gyr_id() failed");
+
+    return rv;
 }
 
 uint16_t BNO055::getSWRevID()
 {
-    return bno055_get_sw_revision(m_bno055);
+    uint16_t rv = 0;
+    if (bno055_get_sw_revision(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_sw_revision() failed");
+
+    return rv;
 }
 
 uint8_t BNO055::getBootLoaderID()
 {
-    return bno055_get_bootloader_id(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_bootloader_id(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_bootloader_id() failed");
+
+    return rv;
 }
 
 void BNO055::setPage(uint8_t page, bool force)
@@ -124,37 +159,51 @@ void BNO055::setPage(uint8_t page, bool force)
 
 void BNO055::setClockExternal(bool extClock)
 {
-    bno055_set_clock_external(m_bno055, extClock);
+    if (bno055_set_clock_external(m_bno055, extClock))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_clock_external() failed");
 }
 
 void BNO055::setTemperatureSource(BNO055_TEMP_SOURCES_T src)
 {
-    bno055_set_temperature_source(m_bno055, src);
+    if (bno055_set_temperature_source(m_bno055, src))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_temperature_source() failed");
 }
 
 void BNO055::setAccelerometerUnits(bool mg)
 {
-    bno055_set_accelerometer_units(m_bno055, mg);
+    if (bno055_set_accelerometer_units(m_bno055, mg))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_accelerometer_units() failed");
 }
 
 void BNO055::setGyroscopeUnits(bool radians)
 {
-    bno055_set_gyroscope_units(m_bno055, radians);
+    if (bno055_set_gyroscope_units(m_bno055, radians))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_gyroscope_units() failed");
 }
 
 void BNO055::setEulerUnits(bool radians)
 {
-    bno055_set_euler_units(m_bno055, radians);
+    if (bno055_set_euler_units(m_bno055, radians))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_euler_units() failed");
 }
 
 void BNO055::setOperationMode(BNO055_OPERATION_MODES_T mode)
 {
-    bno055_set_operation_mode(m_bno055, mode);
+    if (bno055_set_operation_mode(m_bno055, mode))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_operation_mode() failed");
 }
 
 void BNO055::getCalibrationStatus(int *mag, int *acc, int *gyr, int *sys)
 {
-    bno055_get_calibration_status(m_bno055, mag, acc, gyr, sys);
+    if (bno055_get_calibration_status(m_bno055, mag, acc, gyr, sys))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_calibration_status() failed");
 }
 
 vector<int> BNO055::getCalibrationStatus()
@@ -172,47 +221,80 @@ bool BNO055::isFullyCalibrated()
 
 void BNO055::resetSystem()
 {
-    bno055_reset_system(m_bno055);
+    if (bno055_reset_system(m_bno055))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_reset_system() failed");
 }
 
 void BNO055::resetInterruptStatus()
 {
-    bno055_reset_interrupt_status(m_bno055);
+    if (bno055_reset_interrupt_status(m_bno055))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": reset_interrupt_status() failed");
 }
 
 uint8_t BNO055::getInterruptStatus()
 {
-    return bno055_get_interrupt_status(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_interrupt_status(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055get_interrupt_status() failed");
+
+    return rv;
 }
 
 uint8_t BNO055::getInterruptEnable()
 {
-    return bno055_get_interrupt_enable(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_interrupt_enable(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_interrupt_enable() failed");
+
+    return rv;
 }
 
 void BNO055::setInterruptEnable(uint8_t enables)
 {
-    return bno055_set_interrupt_enable(m_bno055, enables);
+    if (bno055_set_interrupt_enable(m_bno055, enables))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_interrupt_enable() failed");
 }
 
 uint8_t BNO055::getInterruptMask()
 {
-    return bno055_get_interrupt_mask(m_bno055);
+    uint8_t rv = 0;
+    if (bno055_get_interrupt_mask(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_interrupt_mask() failed");
+
+    return rv;
 }
 
 void BNO055::setInterruptMask(uint8_t mask)
 {
-    return bno055_set_interrupt_mask(m_bno055, mask);
+    if (bno055_set_interrupt_mask(m_bno055, mask))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_interrupt_mask() failed");
 }
 
 BNO055_SYS_STATUS_T BNO055::getSystemStatus()
 {
-    return bno055_get_system_status(m_bno055);
+    BNO055_SYS_STATUS_T rv;
+    if (bno055_get_system_status(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_system_status() failed");
+
+    return rv;
 }
 
 BNO055_SYS_ERR_T BNO055::getSystemError()
 {
-    return bno055_get_system_error(m_bno055);
+    BNO055_SYS_ERR_T rv;
+    if (bno055_get_system_error(m_bno055, &rv))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_get_system_error() failed");
+
+    return rv;
 }
 
 std::vector<uint8_t> BNO055::readCalibrationData()
@@ -334,21 +416,27 @@ void BNO055::setAccelerationConfig(BNO055_ACC_RANGE_T range,
                                    BNO055_ACC_BW_T bw,
                                    BNO055_ACC_PWR_MODE_T pwr)
 {
-    bno055_set_acceleration_config(m_bno055, range, bw, pwr);
+    if (bno055_set_acceleration_config(m_bno055, range, bw, pwr))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_acceleration_config() failed");
 }
 
 void BNO055::setMagnetometerConfig(BNO055_MAG_ODR_T odr,
                                    BNO055_MAG_OPR_T opr,
                                    BNO055_MAG_POWER_T pwr)
 {
-    bno055_set_magnetometer_config(m_bno055, odr, opr, pwr);
+    if (bno055_set_magnetometer_config(m_bno055, odr, opr, pwr))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_magnetometer_config() failed");
 }
 
 void BNO055::setGyroscopeConfig(BNO055_GYR_RANGE_T range,
                                 BNO055_GYR_BW_T bw,
                                 BNO055_GYR_POWER_MODE_T pwr)
 {
-    bno055_set_gyroscope_config(m_bno055, range, bw, pwr);
+    if (bno055_set_gyroscope_config(m_bno055, range, bw, pwr))
+        throw std::runtime_error(string(__FUNCTION__)
+                                 + ": bno055_set_gyroscope_config() failed");
 }
 
 void BNO055::installISR(int gpio, mraa_gpio_edge_t level,

--- a/src/bno055/bno055.h
+++ b/src/bno055/bno055.h
@@ -145,49 +145,61 @@ extern "C" {
      * Return the chip ID.
      *
      * @param dev The device context.
-     * @return The chip ID (BNO055_CHIPID).
+     * @param chip_id The chip ID (BNO055_CHIPID).
+     * @return UPM result.
      */
-    uint8_t bno055_get_chip_id(const bno055_context dev);
+    upm_result_t bno055_get_chip_id(const bno055_context dev,
+                                    uint8_t *chip_id);
 
     /**
      * Return the accelerometer chip ID.
      *
      * @param dev The device context.
-     * @return The chip ID.
+     * @param chip_id The chip ID
+     * @return UPM result.
      */
-    uint8_t bno055_get_acc_id(const bno055_context dev);
+    upm_result_t bno055_get_acc_id(const bno055_context dev,
+                                   uint8_t *chip_id);
 
     /**
      * Return the magnetometer chip ID.
      *
      * @param dev The device context.
-     * @return The chip ID.
+     * @param chip_id The chip ID
+     * @return UPM result.
      */
-    uint8_t bno055_get_mag_id(const bno055_context dev);
+    upm_result_t bno055_get_mag_id(const bno055_context dev,
+                                   uint8_t *chip_id);
 
     /**
      * Return the gyroscope chip ID.
      *
      * @param dev The device context.
-     * @return The chip ID.
+     * @param chip_id The chip ID
+     * @return UPM result.
      */
-    uint8_t bno055_get_gyr_id(const bno055_context dev);
+    upm_result_t bno055_get_gyr_id(const bno055_context dev,
+                                   uint8_t *chip_id);
 
     /**
      * Return the fusion firmware revison.
      *
      * @param dev The device context.
-     * @return The firmware revison.
+     * @param sw_rev The firmware revison.
+     * @return UPM result.
      */
-    uint16_t bno055_get_sw_revision(const bno055_context dev);
+    upm_result_t bno055_get_sw_revision(const bno055_context dev,
+                                        uint16_t *sw_rev);
 
     /**
      * Return the bootloader ID.
      *
      * @param dev The device context.
-     * @return The bootloader ID.
+     * @param bl_id The bootloader ID.
+     * @return UPM result.
      */
-    uint8_t bno055_get_bootloader_id(const bno055_context dev);
+    upm_result_t bno055_get_bootloader_id(const bno055_context dev,
+                                          uint8_t *bl_id);
 
     /**
      * Enable or disables the use of the external clock.  The Adafriut
@@ -196,8 +208,10 @@ extern "C" {
      *
      * @param dev The device context.
      * @param extClock true to use external clock, false otherwise.
+     * @return UPM result.
      */
-    void bno055_set_clock_external(const bno055_context dev, bool extClock);
+    upm_result_t bno055_set_clock_external(const bno055_context dev,
+                                           bool extClock);
 
     /**
      * Select the temperature source.  This can be the accelerometer
@@ -206,16 +220,18 @@ extern "C" {
      *
      * @param dev The device context.
      * @param src One of the TEMP_SOURCES_T values.
+     * @return UPM result.
      */
-    void bno055_set_temperature_source(const bno055_context dev,
-                                       BNO055_TEMP_SOURCES_T src);
+    upm_result_t bno055_set_temperature_source(const bno055_context dev,
+                                               BNO055_TEMP_SOURCES_T src);
 
     /**
      * Set the temperature units of the device to Celsius (always).
      *
      * @param dev The device context.
+     * @return UPM result.
      */
-    void bno055_set_temperature_units_celsius(const bno055_context dev);
+    upm_result_t bno055_set_temperature_units_celsius(const bno055_context dev);
 
     /**
      * Set the operating mode for the device.  This places the device
@@ -226,9 +242,10 @@ extern "C" {
      *
      * @param dev The device context.
      * @param mode One of the OPERATION_MODES_T values.
+     * @return UPM result.
      */
-    void bno055_set_operation_mode(const bno055_context dev,
-                                   BNO055_OPERATION_MODES_T mode);
+    upm_result_t bno055_set_operation_mode(const bno055_context dev,
+                                           BNO055_OPERATION_MODES_T mode);
 
     /**
      * Reboot the sensor.  This is equivalent to a power on reset.
@@ -236,8 +253,9 @@ extern "C" {
      * re-calibrated.
      *
      * @param dev The device context.
+     * @return UPM result.
      */
-    void bno055_reset_system(const bno055_context dev);
+    upm_result_t bno055_reset_system(const bno055_context dev);
 
     /**
      * Read the calibration status registers and return them.  The
@@ -248,10 +266,11 @@ extern "C" {
      * @param acc The calibration status of the accelerometer.
      * @param mag The calibration status of the gyroscope.
      * @param mag The calibration status of the overall system.
+     * @return UPM result.
      */
-    void bno055_get_calibration_status(const bno055_context dev,
-                                       int *mag, int *acc,
-                                       int *gyr, int *sys);
+    upm_result_t bno055_get_calibration_status(const bno055_context dev,
+                                               int *mag, int *acc,
+                                               int *gyr, int *sys);
 
     /**
      * Read the calibration status registers and return true or false,
@@ -437,11 +456,12 @@ extern "C" {
      * @param range One of the BNO055_ACC_RANGE_T values.
      * @param bw One of the BNO055_ACC_BW_T values.
      * @param pwr One of the BNO055_ACC_PWR_MODE_T values.
+     * @return UPM result.
      */
-    void bno055_set_acceleration_config(const bno055_context dev,
-                                        BNO055_ACC_RANGE_T range,
-                                        BNO055_ACC_BW_T bw,
-                                        BNO055_ACC_PWR_MODE_T pwr);
+    upm_result_t bno055_set_acceleration_config(const bno055_context dev,
+                                                BNO055_ACC_RANGE_T range,
+                                                BNO055_ACC_BW_T bw,
+                                                BNO055_ACC_PWR_MODE_T pwr);
 
     /**
      * Set the output data rate, operating mode and power mode of the
@@ -451,11 +471,12 @@ extern "C" {
      * @param odr One of the BNO055_MAG_ODR_T values.
      * @param opr One of the BNO055_MAG_OPR_T values.
      * @param pwr One of the BNO055_MAG_POWER_T values.
+     * @return UPM result.
      */
-    void bno055_set_magnetometer_config(const bno055_context dev,
-                                        BNO055_MAG_ODR_T odr,
-                                        BNO055_MAG_OPR_T opr,
-                                        BNO055_MAG_POWER_T pwr);
+    upm_result_t bno055_set_magnetometer_config(const bno055_context dev,
+                                                BNO055_MAG_ODR_T odr,
+                                                BNO055_MAG_OPR_T opr,
+                                                BNO055_MAG_POWER_T pwr);
 
     /**
      * Set the range, bandwidth and power modes of the gyroscope.  In
@@ -465,11 +486,12 @@ extern "C" {
      * @param range One of the BNO055_GYR_RANGE_T values.
      * @param bw One of the BNO055_GYR_BW_T values.
      * @param pwr One of the BNO055_GYR_POWER_MODE_T values.
+     * @return UPM result.
      */
-    void bno055_set_gyroscope_config(const bno055_context dev,
-                                     BNO055_GYR_RANGE_T range,
-                                     BNO055_GYR_BW_T bw,
-                                     BNO055_GYR_POWER_MODE_T pwr);
+    upm_result_t bno055_set_gyroscope_config(const bno055_context dev,
+                                             BNO055_GYR_RANGE_T range,
+                                             BNO055_GYR_BW_T bw,
+                                             BNO055_GYR_POWER_MODE_T pwr);
 
     /**
      * Set the unit of measurement for the accelerometer related
@@ -478,8 +500,10 @@ extern "C" {
      *
      * @param dev The device context.
      * @param mg true for mg, false for m/s^2.
+     * @return UPM result.
      */
-    void bno055_set_accelerometer_units(const bno055_context dev, bool mg);
+    upm_result_t bno055_set_accelerometer_units(const bno055_context dev,
+                                                bool mg);
 
     /**
      * Set the unit of measurement for the gyroscope related sensor
@@ -488,8 +512,10 @@ extern "C" {
      *
      * @param dev The device context.
      * @param radians true for radians, false for degrees.
+     * @return UPM result.
      */
-    void bno055_set_gyroscope_units(const bno055_context dev, bool radians);
+    upm_result_t bno055_set_gyroscope_units(const bno055_context dev,
+                                            bool radians);
 
     /**
      * Set the unit of measurement for the Euler Angle related sensor
@@ -498,34 +524,41 @@ extern "C" {
      *
      * @param dev The device context.
      * @param radians true for radians, false for degrees.
+     * @return UPM result.
      */
-    void bno055_set_euler_units(const bno055_context dev, bool radians);
+    upm_result_t bno055_set_euler_units(const bno055_context dev,
+                                        bool radians);
 
     /**
      * Reset all interrupt status bits and interrupt output.
      *
      * @param dev The device context.
+     * @return UPM result.
      */
-    void bno055_reset_interrupt_status(const bno055_context dev);
+    upm_result_t bno055_reset_interrupt_status(const bno055_context dev);
 
     /**
-     * Return the interrupt status register.  This is a bitmask of the
+     * Get the interrupt status register.  This is a bitmask of the
      * INT_STA_BITS_T bits.
      *
      * @param dev The device context.
-     * @return a bitmask of INT_STA_BITS_T bits.
+     * @param istat A bitmask of INT_STA_BITS_T bits.
+     * @return UPM result.
      */
-    uint8_t bno055_get_interrupt_status(const bno055_context dev);
+    upm_result_t bno055_get_interrupt_status(const bno055_context dev,
+                                             uint8_t *istat);
 
     /**
-     * Return the interrupt enables register.  This is a bitmask of the
+     * Get the interrupt enables register.  This is a bitmask of the
      * INT_STA_BITS_T bits.
      *
      * @param dev The device context.
-     * @return a bitmask of INT_STA_BITS_T bits currently set in the
+     * @param ienable A bitmask of INT_STA_BITS_T bits currently set in the
      * enable register.
+     * @return UPM result.
      */
-    uint8_t bno055_get_interrupt_enable(const bno055_context dev);
+    upm_result_t bno055_get_interrupt_enable(const bno055_context dev,
+                                             uint8_t *ienable);
 
     /**
      * Set the interrupt enable register. This is composed of a
@@ -533,22 +566,25 @@ extern "C" {
      *
      * @param dev The device context.
      * @param enables a bitmask of INT_STA_BITS_T bits to enable
+     * @return UPM result.
      */
-    void bno055_set_interrupt_enable(const bno055_context dev,
-                                     uint8_t enables);
+    upm_result_t bno055_set_interrupt_enable(const bno055_context dev,
+                                             uint8_t enables);
 
     /**
-     * Return the interrupt mask register.  This is a bitmask of the
+     * Get the interrupt mask register.  This is a bitmask of the
      * INT_STA_BITS_T bits.  The interrupt mask is used to mask off
      * enabled interrupts from generating a hardware interrupt.  The
      * interrupt status register can still be used to detect masked
      * interrupts if they are enabled.
      *
      * @param dev The device context.
-     * @return a bitmask of INT_STA_BITS_T bits currently set in the
+     * @param imask a bitmask of INT_STA_BITS_T bits currently set in the
      * interrupt mask register.
+     * @return UPM result.
      */
-    uint8_t bno055_get_interrupt_mask(const bno055_context dev);
+    upm_result_t bno055_get_interrupt_mask(const bno055_context dev,
+                                           uint8_t *imask);
 
     /**
      * Set the interrupt mask register.  This is a bitmask of the
@@ -560,17 +596,21 @@ extern "C" {
      * @param dev The device context.
      * @param mask A bitmask of INT_STA_BITS_T bits to set in the interrupt
      * mask register.
+     * @return UPM result.
      */
-    void bno055_set_interrupt_mask(const bno055_context dev, uint8_t mask);
+    upm_result_t bno055_set_interrupt_mask(const bno055_context dev,
+                                           uint8_t mask);
 
     /**
-     * Return the value of the system status register.  This method
+     * Get the value of the system status register.  This method
      * can be used to determine the overall status of the device.
      *
      * @param dev The device context.
-     * @return One of the SYS_STATUS_T values.
+     * @param sys_stat One of the SYS_STATUS_T values.
+     * @return UPM result.
      */
-    BNO055_SYS_STATUS_T bno055_get_system_status(const bno055_context dev);
+    upm_result_t bno055_get_system_status(const bno055_context dev,
+                                          BNO055_SYS_STATUS_T *sys_stat);
 
     /**
      * Return the value of the system error register.  This mathod can
@@ -578,9 +618,11 @@ extern "C" {
      * conditions.
      *
      * @param dev The device context.
-     * @return One of the SYS_ERR_T values.
+     * @param sys_stat One of the SYS_ERR_T values.
+     * @return UPM result.
      */
-    BNO055_SYS_ERR_T bno055_get_system_error(const bno055_context dev);
+    upm_result_t bno055_get_system_error(const bno055_context dev,
+                                         BNO055_SYS_ERR_T *sys_err);
 
     /**
      * install an interrupt handler.
@@ -625,9 +667,11 @@ extern "C" {
      *
      * @param dev The device context.
      * @param reg The register to read
-     * @return The value of the register
+     * @param retval The returned value of the register
+     * @return UPM result.
      */
-    uint8_t bno055_read_reg(const bno055_context dev, uint8_t reg);
+    upm_result_t bno055_read_reg(const bno055_context dev, uint8_t reg,
+                                 uint8_t *retval);
 
     /**
      * Read contiguous registers into a buffer.  This is a low level

--- a/src/bno055/bno055.hpp
+++ b/src/bno055/bno055.hpp
@@ -138,6 +138,7 @@ namespace upm {
          * Return the chip ID.
          *
          * @return The chip ID (BNO055_CHIPID).
+         * @throws std::runtime_error on failure.
          */
         uint8_t getChipID();
 
@@ -145,6 +146,7 @@ namespace upm {
          * Return the accelerometer chip ID.
          *
          * @return The chip ID.
+         * @throws std::runtime_error on failure.
          */
         uint8_t getACCID();
 
@@ -152,6 +154,7 @@ namespace upm {
          * Return the magnetometer chip ID.
          *
          * @return The chip ID.
+         * @throws std::runtime_error on failure.
          */
         uint8_t getMAGID();
 
@@ -159,6 +162,7 @@ namespace upm {
          * Return the gyroscope chip ID.
          *
          * @return The chip ID.
+         * @throws std::runtime_error on failure.
          */
         uint8_t getGYRID();
 
@@ -166,6 +170,7 @@ namespace upm {
          * Return the fusion firmware revison.
          *
          * @return The firmware revison.
+         * @throws std::runtime_error on failure.
          */
         uint16_t getSWRevID();
 
@@ -173,6 +178,7 @@ namespace upm {
          * Return the bootloader ID.
          *
          * @return The bootloader ID.
+         * @throws std::runtime_error on failure.
          */
         uint8_t getBootLoaderID();
 
@@ -182,6 +188,7 @@ namespace upm {
          * stable.  By default, the internal clock is used.
          *
          * @param extClock true to use external clock, false otherwise.
+         * @throws std::runtime_error on failure.
          */
         void setClockExternal(bool extClock);
 
@@ -191,6 +198,7 @@ namespace upm {
          * used as the source.
          *
          * @param src One of the BNO055_TEMP_SOURCES_T values.
+         * @throws std::runtime_error on failure.
          */
         void setTemperatureSource(BNO055_TEMP_SOURCES_T src);
 
@@ -202,6 +210,7 @@ namespace upm {
          * configuration operations.  See the datasheet for details.
          *
          * @param mode One of the BNO055_OPERATION_MODES_T values.
+         * @throws std::runtime_error on failure.
          */
         void setOperationMode(BNO055_OPERATION_MODES_T mode);
 
@@ -209,6 +218,7 @@ namespace upm {
          * Reboot the sensor.  This is equivalent to a power on reset.
          * All calibration data will be lost, and the device must be
          * recalibrated.
+         * @throws std::runtime_error on failure.
          */
         void resetSystem();
 
@@ -220,6 +230,7 @@ namespace upm {
          * @param acc The calibration status of the accelerometer.
          * @param mag The calibration status of the gyroscope.
          * @param mag The calibration status of the overall system.
+         * @throws std::runtime_error on failure.
          */
         void getCalibrationStatus(int *mag, int *acc, int *gyr, int *sys);
 
@@ -230,6 +241,7 @@ namespace upm {
          *
          * @return An integer vector containing the values in the
          * order: mag, acc, gyr, and sys.
+         * @throws std::runtime_error on failure.
          */
         std::vector<int> getCalibrationStatus();
 
@@ -467,6 +479,7 @@ namespace upm {
          * @param range One of the BNO055_ACC_RANGE_T values.
          * @param bw One of the BNO055_ACC_BW_T values.
          * @param pwr One of the BNO055_ACC_PWR_MODE_T values.
+         * @throws std::runtime_error on failure.
          */
         void setAccelerationConfig(BNO055_ACC_RANGE_T range,
                                    BNO055_ACC_BW_T bw,
@@ -479,6 +492,7 @@ namespace upm {
          * @param odr One of the BNO055_MAG_ODR_T values.
          * @param opr One of the BNO055_MAG_OPR_T values.
          * @param pwr One of the BNO055_MAG_POWER_T values.
+         * @throws std::runtime_error on failure.
          */
         void setMagnetometerConfig(BNO055_MAG_ODR_T odr,
                                    BNO055_MAG_OPR_T opr,
@@ -491,6 +505,7 @@ namespace upm {
          * @param range One of the BNO055_GYR_RANGE_T values.
          * @param bw One of the BNO055_GYR_BW_T values.
          * @param pwr One of the BNO055_GYR_POWER_MODE_T values.
+         * @throws std::runtime_error on failure.
          */
         void setGyroscopeConfig(BNO055_GYR_RANGE_T range,
                                 BNO055_GYR_BW_T bw,
@@ -502,6 +517,7 @@ namespace upm {
          * per-second squared (m/s^2).  The default is m/s^2.
          *
          * @param mg true for mg, false for m/s^2.
+         * @throws std::runtime_error on failure.
          */
         void setAccelerometerUnits(bool mg=false);
 
@@ -511,6 +527,7 @@ namespace upm {
          * degrees.
          *
          * @param radians true for radians, false for degrees.
+         * @throws std::runtime_error on failure.
          */
         void setGyroscopeUnits(bool radians=false);
 
@@ -520,11 +537,14 @@ namespace upm {
          * degrees.
          *
          * @param radians true for radians, false for degrees.
+         * @throws std::runtime_error on failure.
          */
         void setEulerUnits(bool radians=false);
 
         /**
          * Reset all interrupt status bits and interrupt output.
+         *
+         * @throws std::runtime_error on failure.
          */
         void resetInterruptStatus();
 
@@ -533,6 +553,7 @@ namespace upm {
          * BNO055_INT_STA_BITS_T bits.
          *
          * @return a bitmask of BNO055_INT_STA_BITS_T bits.
+         * @throws std::runtime_error on failure.
          */
         uint8_t getInterruptStatus();
 
@@ -542,6 +563,7 @@ namespace upm {
          *
          * @return a bitmask of BNO055_INT_STA_BITS_T bits currently set in the
          * enable register.
+         * @throws std::runtime_error on failure.
          */
         uint8_t getInterruptEnable();
 
@@ -550,6 +572,7 @@ namespace upm {
          * bitmask of the BNO055_INT_STA_BITS_T bits.
          *
          * @param enables a bitmask of BNO055_INT_STA_BITS_T bits to enable
+         * @throws std::runtime_error on failure.
          */
         void setInterruptEnable(uint8_t enables);
 
@@ -562,6 +585,7 @@ namespace upm {
          *
          * @return a bitmask of BNO055_INT_STA_BITS_T bits currently set in the
          * interrupt mask register.
+         * @throws std::runtime_error on failure.
          */
         uint8_t getInterruptMask();
 
@@ -574,6 +598,7 @@ namespace upm {
          *
          * @param mask A bitmask of BNO055_INT_STA_BITS_T bits to set in
          * the interrupt mask register.
+         * @throws std::runtime_error on failure.
          */
         void setInterruptMask(uint8_t mask);
 
@@ -582,6 +607,7 @@ namespace upm {
          * can be used to determine the overall status of the device.
          *
          * @return One of the BNO055_SYS_STATUS_T values.
+         * @throws std::runtime_error on failure.
          */
         BNO055_SYS_STATUS_T getSystemStatus();
 
@@ -591,6 +617,7 @@ namespace upm {
          * conditions.
          *
          * @return One of the BNO055_SYS_ERR_T values.
+         * @throws std::runtime_error on failure.
          */
         BNO055_SYS_ERR_T getSystemError();
 
@@ -643,6 +670,7 @@ namespace upm {
          *
          * @param reg The register to read
          * @return The value of the register
+         * @throws std::runtime_error on failure.
          */
         uint8_t readReg(uint8_t reg);
 


### PR DESCRIPTION
This patch reworks error handling in the C driver to more reliably detect
errors, and for C++, throw exceptions when they are detected.

The C++ API is unchanged aside from the fact that more methods will
throw an exception on errors now.

This addresses the error handling deficiencies reported in Issue #593.

Signed-off-by: Jon Trulson <jtrulson@ics.com>