### PR TITLE
iio: pass argument to interrupt service routine

### DIFF
--- a/src/kxcjk1013/kxcjk1013.cxx
+++ b/src/kxcjk1013/kxcjk1013.cxx
@@ -65,9 +65,9 @@ KXCJK1013::~KXCJK1013()
 }
 
 void
-KXCJK1013::installISR(void (*isr)(char*), void* arg)
+KXCJK1013::installISR(void (*isr)(char*, void*), void* arg)
 {
-    mraa_iio_trigger_buffer(m_iio, isr, NULL);
+    mraa_iio_trigger_buffer(m_iio, isr, arg);
 }
 
 int64_t

--- a/src/kxcjk1013/kxcjk1013.hpp
+++ b/src/kxcjk1013/kxcjk1013.hpp
@@ -74,7 +74,7 @@ class KXCJK1013
      * @param arg Pointer to an object to be supplied as an
      * argument to the ISR.
      */
-    void installISR(void (*isr)(char*), void* arg);
+    void installISR(void (*isr)(char*, void*), void* arg);
 
     /**
      * Extract the channel value based on channel type

--- a/src/l3gd20/l3gd20.cxx
+++ b/src/l3gd20/l3gd20.cxx
@@ -344,9 +344,9 @@ uint8_t L3GD20::getStatusBits()
 
 
 void
-L3GD20::installISR(void (*isr)(char*), void* arg)
+L3GD20::installISR(void (*isr)(char*, void*), void* arg)
 {
-    mraa_iio_trigger_buffer(m_iio, isr, NULL);
+    mraa_iio_trigger_buffer(m_iio, isr, arg);
 }
 
 int64_t

--- a/src/l3gd20/l3gd20.hpp
+++ b/src/l3gd20/l3gd20.hpp
@@ -547,7 +547,7 @@ class L3GD20
      * @param arg Pointer to an object to be supplied as an
      * argument to the ISR.
      */
-    void installISR(void (*isr)(char*), void* arg);
+    void installISR(void (*isr)(char*, void*), void* arg);
 
     /**
      * Extract the channel value based on channel type. IIO only.

--- a/src/mmc35240/mmc35240.cxx
+++ b/src/mmc35240/mmc35240.cxx
@@ -99,9 +99,9 @@ MMC35240::~MMC35240()
 }
 
 void
-MMC35240::installISR(void (*isr)(char*), void* arg)
+MMC35240::installISR(void (*isr)(char*, void*), void* arg)
 {
-    mraa_iio_trigger_buffer(m_iio, isr, NULL);
+    mraa_iio_trigger_buffer(m_iio, isr, arg);
 }
 
 int64_t

--- a/src/mmc35240/mmc35240.hpp
+++ b/src/mmc35240/mmc35240.hpp
@@ -108,7 +108,7 @@ class MMC35240
      * @param arg Pointer to an object to be supplied as an
      * argument to the ISR.
      */
-    void installISR(void (*isr)(char*), void* arg);
+    void installISR(void (*isr)(char*, void*), void* arg);
 
     /**
      * Extract the channel value based on channel type


### PR DESCRIPTION
This change allows to pass an argument to the interrupt service routine.
It fixes the UPM compilation issue, caused by MRAA commit
65e30bf7d31cf48f6d75ebc191e7cf74a5b778c4, that changed the function
signature of mraa_iio_trigger_buffer()

Signed-off-by: Sergey Kiselev <sergey.kiselev@intel.com>