### PR TITLE
travis: use images from inteliotdevkit

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '2.1'
 services:
 
   base:
-    image: dnoliver/upm-base
+    image: inteliotdevkit/upm-base:docker-inteliotdevkit
     environment:
       - http_proxy
       - https_proxy
@@ -26,9 +26,12 @@ services:
     volumes:
       - .:${UPM_SRC_DIR:-/usr/src/app}
 
-  doc:
+  all:
     extends: base
-    image: dnoliver/upm-all
+    image: inteliotdevkit/upm-all:docker-inteliotdevkit
+
+  doc:
+    extends: all
     environment:
       - BUILDSWIGPYTHON=ON
       - BUILDSWIGJAVA=ON
@@ -37,29 +40,28 @@ services:
     command: bash -c "./scripts/run-cmake.sh && ./scripts/build-doc.sh"
 
   ipk:
-    extends: base
+    extends: all
     environment:
       - IPK=ON
       - BUILDDOC=OFF
     command: bash -c "./scripts/run-cmake.sh && make -Cbuild -j8 package"
 
   rpm:
-    extends: doc
+    extends: all
     environment:
       - RPM=ON
       - BUILDDOC=OFF
     command: bash -c "./scripts/run-cmake.sh && make -Cbuild -j8 package"
 
   npm:
-    extends: doc
+    extends: all
     environment:
       - NPM=ON
       - BUILDDOC=OFF
     command: bash -c "./scripts/run-cmake.sh && make -Cbuild -j8 npmpkg"
 
   sonar-scan:
-    extends: base
-    image: dnoliver/upm-all
+    extends: all
     environment:
       - BUILDSWIGPYTHON=ON
       - BUILDSWIGNODE=ON
@@ -77,36 +79,36 @@ services:
 
   python:
     extends: base
-    image: dnoliver/upm-python
+    image: inteliotdevkit/upm-python:docker-inteliotdevkit
     environment:
       - BUILDSWIGPYTHON=ON
     command: bash -c "./scripts/run-cmake.sh && cd build && make -j8 && make -j8 install && ldconfig && ctest --output-on-failure"
 
   java:
     extends: base
-    image: dnoliver/upm-java
+    image: inteliotdevkit/upm-java:docker-inteliotdevkit
     environment:
       - BUILDSWIGJAVA=ON
     command: bash -c "./scripts/run-cmake.sh && cd build && make -j8 && make -j8 install && ldconfig && ctest --output-on-failure"
 
   android:
     extends: java
-    image: dnoliver/upm-android
+    image: inteliotdevkit/upm-android:docker-inteliotdevkit
     environment:
       - BUILDTESTS=OFF
     command: bash -c "./scripts/build-android.sh"
 
   node4:
     extends: base
-    image: dnoliver/upm-node4
+    image: inteliotdevkit/upm-node4:docker-inteliotdevkit
     environment:
       - BUILDSWIGNODE=ON
     command: bash -c "./scripts/run-cmake.sh && cd build && make -j8 && make -j8 install && ldconfig && ctest --output-on-failure -E examplenames_js"
 
   node5:
     extends: node4
-    image: dnoliver/upm-node5
+    image: inteliotdevkit/upm-node5:docker-inteliotdevkit
 
   node6:
     extends: node4
-    image: dnoliver/upm-node6
+    image: inteliotdevkit/upm-node6:docker-inteliotdevkit

--- a/docs/building.md
+++ b/docs/building.md
@@ -192,7 +192,7 @@ $ docker run \
       --env BUILDSWIGPYTHON=ON \
       --env BUILDSWIGJAVA=OFF \
       --env BUILDSWIGNODE=OFF \
-      dnoliver/upm-python \
+      inteliotdevkit/upm-python \
       bash -c "./scripts/run-cmake.sh && make -Cbuild"
 ```
 
@@ -226,6 +226,6 @@ $ docker run \
     --env http_proxy=$http_proxy \
     --env https_proxy=$https_proxy \
     --env no_proxy=$no_proxy \
-    dnoliver/upm-python \
+    inteliotdevkit/upm-python \
     bash -c "./scripts/run-cmake.sh && make -Cbuild"
 ```


### PR DESCRIPTION
Related PR for docker-image-builders https://github.com/intel-iot-devkit/docker-image-builders/pull/1

This is currently using images with **docker-inteliotdevkit** tag. Once the related PR is merged into master, I will change this to use **latest** tags

Signed-off-by: Nicolas Oliver <dario.n.oliver@intel.com>
