### PR TITLE
travis: build examples in additional jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,8 @@ jobs:
     - <<: *run-additional-jobs
       env: TARGET=android
     - <<: *run-additional-jobs
+      env: TARGET=examples
+    - <<: *run-additional-jobs
       env: TARGET=sonar-scan
     - <<: *run-additional-jobs
       env: TARGET=ipk

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '2.1'
 services:
 
   base:
-    image: inteliotdevkit/upm-base
+    image: inteliotdevkit/upm-base:move-examples-to-addition-jobs
     environment:
       - http_proxy
       - https_proxy
@@ -14,7 +14,7 @@ services:
       - BUILDSWIGPYTHON=${BUILDSWIGPYTHON:-OFF}
       - BUILDSWIGJAVA=${BUILDSWIGJAVA:-OFF}
       - BUILDSWIGNODE=${BUILDSWIGNODE:-OFF}
-      - BUILDEXAMPLES=${BUILDEXAMPLES:-ON}
+      - BUILDEXAMPLES=${BUILDEXAMPLES:-OFF}
       - IPK=${IPK:-OFF}
       - RPM=${RPM:-OFF}
       - NPM=${NPM:-OFF}
@@ -28,7 +28,7 @@ services:
 
   all:
     extends: base
-    image: inteliotdevkit/upm-all
+    image: inteliotdevkit/upm-all:move-examples-to-addition-jobs
 
   doc:
     extends: all
@@ -38,6 +38,15 @@ services:
       - BUILDSWIGNODE=ON
       - BUILDDOC=ON
     command: bash -c "./scripts/run-cmake.sh && ./scripts/build-doc.sh"
+
+  examples:
+    extends: all
+    environment:
+      - BUILDSWIGPYTHON=ON
+      - BUILDSWIGJAVA=ON
+      - BUILDSWIGNODE=ON
+      - BUILDEXAMPLES=ON
+    command: bash -c "./scripts/run-cmake.sh && cd build && make -j8"
 
   ipk:
     extends: all
@@ -66,7 +75,7 @@ services:
       - BUILDSWIGPYTHON=ON
       - BUILDSWIGNODE=ON
       - BUILDSWIGJAVA=ON
-      - BUILDSWIGEXAMPLES=ON
+      - BUILDEXAMPLES=ON
       - SONAR_TOKEN
       - SONAR_ORG
       - SONAR_PROJ_KEY
@@ -79,36 +88,36 @@ services:
 
   python:
     extends: base
-    image: inteliotdevkit/upm-python
+    image: inteliotdevkit/upm-python:move-examples-to-addition-jobs
     environment:
       - BUILDSWIGPYTHON=ON
     command: bash -c "./scripts/run-cmake.sh && cd build && make -j8 && make -j8 install && ldconfig && ctest --output-on-failure"
 
   java:
     extends: base
-    image: inteliotdevkit/upm-java
+    image: inteliotdevkit/upm-java:move-examples-to-addition-jobs
     environment:
       - BUILDSWIGJAVA=ON
     command: bash -c "./scripts/run-cmake.sh && cd build && make -j8 && make -j8 install && ldconfig && ctest --output-on-failure"
 
   android:
     extends: java
-    image: inteliotdevkit/upm-android
+    image: inteliotdevkit/upm-android:move-examples-to-addition-jobs
     environment:
       - BUILDTESTS=OFF
     command: bash -c "./scripts/build-android.sh"
 
   node4:
     extends: base
-    image: inteliotdevkit/upm-node4
+    image: inteliotdevkit/upm-node4:move-examples-to-addition-jobs
     environment:
       - BUILDSWIGNODE=ON
     command: bash -c "./scripts/run-cmake.sh && cd build && make -j8 && make -j8 install && ldconfig && ctest --output-on-failure -E examplenames_js"
 
   node5:
     extends: node4
-    image: inteliotdevkit/upm-node5
+    image: inteliotdevkit/upm-node5:move-examples-to-addition-jobs
 
   node6:
     extends: node4
-    image: inteliotdevkit/upm-node6
+    image: inteliotdevkit/upm-node6:move-examples-to-addition-jobs

--- a/scripts/run-cmake.sh
+++ b/scripts/run-cmake.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -x
+set -e
+
 # Run cmake
 cmake \
   -DSWIG_EXECUTABLE=/usr/bin/swig \


### PR DESCRIPTION
This changes the default value of the BUILDEXAMPLES flag to OFF. Examples are now built in a different job.
It also use an updated docker image with mraa with firmata and imraa support. https://github.com/intel-iot-devkit/docker-image-builders/pull/2

Signed-off-by: Nicolas Oliver <dario.n.oliver@intel.com>