### PR TITLE
examples/python: Add/update shebang line

### DIFF
--- a/examples/python/a110x.py
+++ b/examples/python/a110x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/abp.py
+++ b/examples/python/abp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Abhishek Malik <abhishek.malik@intel.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/ad8232.py
+++ b/examples/python/ad8232.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/adafruitms1438-stepper.py
+++ b/examples/python/adafruitms1438-stepper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/adafruitms1438.py
+++ b/examples/python/adafruitms1438.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/adc121c021.py
+++ b/examples/python/adc121c021.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ads1015.py
+++ b/examples/python/ads1015.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/ads1115.py
+++ b/examples/python/ads1115.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/adxl335.py
+++ b/examples/python/adxl335.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/adxl345.py
+++ b/examples/python/adxl345.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/adxrs610.py
+++ b/examples/python/adxrs610.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/aeotecdsb09104.py
+++ b/examples/python/aeotecdsb09104.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/aeotecdw2e.py
+++ b/examples/python/aeotecdw2e.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/aeotecsdg2.py
+++ b/examples/python/aeotecsdg2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/aeotecss6.py
+++ b/examples/python/aeotecss6.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/ak8975.py
+++ b/examples/python/ak8975.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/apa102.py
+++ b/examples/python/apa102.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author:  Yannick Adam <yannick.adam@gmail.com>
 # Copyright (c) 2016 Yannick Adam
 #

--- a/examples/python/apds9002.py
+++ b/examples/python/apds9002.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/at42qt1070.py
+++ b/examples/python/at42qt1070.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/bh1750.py
+++ b/examples/python/bh1750.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/biss0001.py
+++ b/examples/python/biss0001.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/bma220.py
+++ b/examples/python/bma220.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/bma250e.py
+++ b/examples/python/bma250e.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016-2017 Intel Corporation.
 #

--- a/examples/python/bmc150.py
+++ b/examples/python/bmc150.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/bme280.py
+++ b/examples/python/bme280.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/bmg160.py
+++ b/examples/python/bmg160.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/bmi055.py
+++ b/examples/python/bmi055.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/bmi160.py
+++ b/examples/python/bmi160.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/bmm150.py
+++ b/examples/python/bmm150.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016-2017 Intel Corporation.
 #

--- a/examples/python/bmp280.py
+++ b/examples/python/bmp280.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/bmpx8x.py
+++ b/examples/python/bmpx8x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2014-2017 Intel Corporation.

--- a/examples/python/bmx055.py
+++ b/examples/python/bmx055.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/bno055.py
+++ b/examples/python/bno055.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016-2017 Intel Corporation.
 #

--- a/examples/python/button.py
+++ b/examples/python/button.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/buzzer.py
+++ b/examples/python/buzzer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/cjq4435.py
+++ b/examples/python/cjq4435.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/collision.py
+++ b/examples/python/collision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/curieimu.py
+++ b/examples/python/curieimu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Author: Ron Evans (@deadprogram)
 # Copyright (c) 2016 Intel Corporation.

--- a/examples/python/cwlsxxa.py
+++ b/examples/python/cwlsxxa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/dfrec.py
+++ b/examples/python/dfrec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/dfrorp.py
+++ b/examples/python/dfrorp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/dfrph.py
+++ b/examples/python/dfrph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ds1307.py
+++ b/examples/python/ds1307.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ds18b20.py
+++ b/examples/python/ds18b20.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016-2017 Intel Corporation.
 #

--- a/examples/python/ds2413.py
+++ b/examples/python/ds2413.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/e50hx.py
+++ b/examples/python/e50hx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/eboled.py
+++ b/examples/python/eboled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ecezo.py
+++ b/examples/python/ecezo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/ehr.py
+++ b/examples/python/ehr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/eldriver.py
+++ b/examples/python/eldriver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/electromagnet.py
+++ b/examples/python/electromagnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/emg.py
+++ b/examples/python/emg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/enc03r.py
+++ b/examples/python/enc03r.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/es08a.py
+++ b/examples/python/es08a.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: John Van Drasek <john.r.van.drasek@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/gp2y0a.py
+++ b/examples/python/gp2y0a.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/gprs.py
+++ b/examples/python/gprs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovebutton.py
+++ b/examples/python/grovebutton.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/grovecircularled.py
+++ b/examples/python/grovecircularled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/grovecollision.py
+++ b/examples/python/grovecollision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/groveehr.py
+++ b/examples/python/groveehr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/groveeldriver.py
+++ b/examples/python/groveeldriver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/groveelectromagnet.py
+++ b/examples/python/groveelectromagnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/groveemg.py
+++ b/examples/python/groveemg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovegprs.py
+++ b/examples/python/grovegprs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovegsr.py
+++ b/examples/python/grovegsr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/groveled.py
+++ b/examples/python/groveled.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/groveledbar.py
+++ b/examples/python/groveledbar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovelight.py
+++ b/examples/python/grovelight.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/grovelinefinder.py
+++ b/examples/python/grovelinefinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovemd-stepper.py
+++ b/examples/python/grovemd-stepper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovemd.py
+++ b/examples/python/grovemd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovemoisture.py
+++ b/examples/python/grovemoisture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/groveo2.py
+++ b/examples/python/groveo2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/groverelay.py
+++ b/examples/python/groverelay.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/groverotary.py
+++ b/examples/python/groverotary.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/grovescam.py
+++ b/examples/python/grovescam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/groveslide.py
+++ b/examples/python/groveslide.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/grovespeaker.py
+++ b/examples/python/grovespeaker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovetemp.py
+++ b/examples/python/grovetemp.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Brendan Le Foll <brendan.le.foll@intel.com>
 # Contributions: Sarah Knepper <sarah.knepper@intel.com>

--- a/examples/python/grovevdiv.py
+++ b/examples/python/grovevdiv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovewater.py
+++ b/examples/python/grovewater.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/grovewfs.py
+++ b/examples/python/grovewfs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/gsr.py
+++ b/examples/python/gsr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/guvas12d.py
+++ b/examples/python/guvas12d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 #         Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015-2016 Intel Corporation.

--- a/examples/python/h3lis331dl.py
+++ b/examples/python/h3lis331dl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/h803x.py
+++ b/examples/python/h803x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/hcsr04.py
+++ b/examples/python/hcsr04.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Abhishek Malik <abhishek.malik@intel.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/hdc1000.py
+++ b/examples/python/hdc1000.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Norbert Wesp <nwesp@phytec.de>
 # Copyright (c) 2017 Phytec Messtechnik GmbH.
 #

--- a/examples/python/hdxxvxta.py
+++ b/examples/python/hdxxvxta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/hka5.py
+++ b/examples/python/hka5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/hm11.py
+++ b/examples/python/hm11.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/hmc5883l.py
+++ b/examples/python/hmc5883l.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/hmtrp.py
+++ b/examples/python/hmtrp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/hp20x.py
+++ b/examples/python/hp20x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ht9170.py
+++ b/examples/python/ht9170.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/htu21d.py
+++ b/examples/python/htu21d.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2017 Intel Corporation.

--- a/examples/python/hwxpxx.py
+++ b/examples/python/hwxpxx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/ili9341.py
+++ b/examples/python/ili9341.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Shawn Hymel
 # Copyright (c) 2016 SparkFun Electronics
 #

--- a/examples/python/ims.py
+++ b/examples/python/ims.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Noel Eck <noel.eck@intel.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/ina132.py
+++ b/examples/python/ina132.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/isd1820.py
+++ b/examples/python/isd1820.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/itg3200.py
+++ b/examples/python/itg3200.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: John Van Drasek <john.r.van.drasek@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/jhd1313m1-lcd.py
+++ b/examples/python/jhd1313m1-lcd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Brendan Le Foll <brendan.le.foll@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #

--- a/examples/python/joystick12.py
+++ b/examples/python/joystick12.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/l298-stepper.py
+++ b/examples/python/l298-stepper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/l298.py
+++ b/examples/python/l298.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/lcdks.py
+++ b/examples/python/lcdks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/ldt0028.py
+++ b/examples/python/ldt0028.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/le910.py
+++ b/examples/python/le910.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/led.py
+++ b/examples/python/led.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/light.py
+++ b/examples/python/light.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2014 Intel Corporation.
 #

--- a/examples/python/linefinder.py
+++ b/examples/python/linefinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/lis2ds12.py
+++ b/examples/python/lis2ds12.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016-2017 Intel Corporation.
 #

--- a/examples/python/lm35.py
+++ b/examples/python/lm35.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/loudness.py
+++ b/examples/python/loudness.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/lsm303agr.py
+++ b/examples/python/lsm303agr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/lsm303d.py
+++ b/examples/python/lsm303d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/lsm303dlh.py
+++ b/examples/python/lsm303dlh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Author: Brendan Le Foll <brendan.le.foll@intel.com>
 # Contributions: Zion Orent <zorent@ics.com>

--- a/examples/python/lsm6ds3h.py
+++ b/examples/python/lsm6ds3h.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016-2017 Intel Corporation.
 #

--- a/examples/python/lsm6dsl.py
+++ b/examples/python/lsm6dsl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016-2017 Intel Corporation.
 #

--- a/examples/python/lsm9ds0.py
+++ b/examples/python/lsm9ds0.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/m24lr64e.py
+++ b/examples/python/m24lr64e.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mag3110.py
+++ b/examples/python/mag3110.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Norbert Wesp <nwesp@phytec.de>
 # Copyright (c) 2017 Phytec Messtechnik GmbH.
 #

--- a/examples/python/max30100.py
+++ b/examples/python/max30100.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Noel Eck <noel.eck@intel.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/maxsonarez.py
+++ b/examples/python/maxsonarez.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mb704x.py
+++ b/examples/python/mb704x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/mcp2515-txrx.py
+++ b/examples/python/mcp2515-txrx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/mcp2515.py
+++ b/examples/python/mcp2515.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/md-stepper.py
+++ b/examples/python/md-stepper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/md.py
+++ b/examples/python/md.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mg811.py
+++ b/examples/python/mg811.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mhz16.py
+++ b/examples/python/mhz16.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mic.py
+++ b/examples/python/mic.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: John Van Drasek <john.r.van.drasek@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/mma7361.py
+++ b/examples/python/mma7361.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/mma7660.py
+++ b/examples/python/mma7660.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mma8x5x.py
+++ b/examples/python/mma8x5x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Norbert Wesp <nwesp@phytec.de>
 # Copyright (c) 2017 Phytec Messtechnik GmbH.
 #

--- a/examples/python/moisture.py
+++ b/examples/python/moisture.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mpr121.py
+++ b/examples/python/mpr121.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mpu60x0.py
+++ b/examples/python/mpu60x0.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mpu9150.py
+++ b/examples/python/mpu9150.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mpu9250.py
+++ b/examples/python/mpu9250.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq2.py
+++ b/examples/python/mq2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq3.py
+++ b/examples/python/mq3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq303a.py
+++ b/examples/python/mq303a.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq4.py
+++ b/examples/python/mq4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq5.py
+++ b/examples/python/mq5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq6.py
+++ b/examples/python/mq6.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq7.py
+++ b/examples/python/mq7.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq8.py
+++ b/examples/python/mq8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/mq9.py
+++ b/examples/python/mq9.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ms5803.py
+++ b/examples/python/ms5803.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/nlgpio16.py
+++ b/examples/python/nlgpio16.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/nmea_gps.py
+++ b/examples/python/nmea_gps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/nmea_gps_i2c.py
+++ b/examples/python/nmea_gps_i2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/nunchuck.py
+++ b/examples/python/nunchuck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/o2.py
+++ b/examples/python/o2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/oled_ssd1308.py
+++ b/examples/python/oled_ssd1308.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/oled_ssd1327.py
+++ b/examples/python/oled_ssd1327.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/otp538u.py
+++ b/examples/python/otp538u.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ozwdump.py
+++ b/examples/python/ozwdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015-2016 Intel Corporation.
 #

--- a/examples/python/p9813.py
+++ b/examples/python/p9813.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Sergey Kiselev <sergey.kiselev@intel.com>
 # Copyright (c) 2016 Sergey Kiselev
 # Based on the apa102 driver writen by Yannick Adam <yannick.adam@gmail.com>

--- a/examples/python/pn532-writeurl.py
+++ b/examples/python/pn532-writeurl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/pn532.py
+++ b/examples/python/pn532.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ppd42ns.py
+++ b/examples/python/ppd42ns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/relay.py
+++ b/examples/python/relay.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/rfr359f.py
+++ b/examples/python/rfr359f.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/rgbringcoder.py
+++ b/examples/python/rgbringcoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/rhusb.py
+++ b/examples/python/rhusb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/rn2903-p2p-rx.py
+++ b/examples/python/rn2903-p2p-rx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/rn2903-p2p-tx.py
+++ b/examples/python/rn2903-p2p-tx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/rn2903.py
+++ b/examples/python/rn2903.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/rotary.py
+++ b/examples/python/rotary.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/rotaryencoder.py
+++ b/examples/python/rotaryencoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/rpr220.py
+++ b/examples/python/rpr220.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/rsc.py
+++ b/examples/python/rsc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Abhishek Malik <abhishek.malik@intel.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/scam.py
+++ b/examples/python/scam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/sensortemplate.py
+++ b/examples/python/sensortemplate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # The MIT License (MIT)
 #
 # Author: Your Full Name <your@email.address>

--- a/examples/python/sht1x.py
+++ b/examples/python/sht1x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/si114x.py
+++ b/examples/python/si114x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/slide.py
+++ b/examples/python/slide.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/sm130.py
+++ b/examples/python/sm130.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/speaker.py
+++ b/examples/python/speaker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/speaker_pwm.py
+++ b/examples/python/speaker_pwm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/stepmotor.py
+++ b/examples/python/stepmotor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author:  Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/sx1276-fsk.py
+++ b/examples/python/sx1276-fsk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/sx1276-lora.py
+++ b/examples/python/sx1276-lora.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/sx6119.py
+++ b/examples/python/sx6119.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/t3311.py
+++ b/examples/python/t3311.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/t8100.py
+++ b/examples/python/t8100.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/ta12200.py
+++ b/examples/python/ta12200.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/tb7300.py
+++ b/examples/python/tb7300.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/tcs3414cs.py
+++ b/examples/python/tcs3414cs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/tcs37727.py
+++ b/examples/python/tcs37727.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Norbert Wesp <nwesp@phytec.de>
 # Copyright (c) 2017 Phytec Messtechnik GmbH.
 #

--- a/examples/python/teams.py
+++ b/examples/python/teams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/temperature.py
+++ b/examples/python/temperature.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Brendan Le Foll <brendan.le.foll@intel.com>
 # Contributions: Sarah Knepper <sarah.knepper@intel.com>

--- a/examples/python/tex00.py
+++ b/examples/python/tex00.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/tm1637.py
+++ b/examples/python/tm1637.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/tmp006.py
+++ b/examples/python/tmp006.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Norbert Wesp <nwesp@phytec.de>
 # Copyright (c) 2017 Phytec Messtechnik GmbH.
 #

--- a/examples/python/tp401.py
+++ b/examples/python/tp401.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Mihai Tudor Panu <mihai.tudor.panu@intel.com>
 # Copyright (c) 2014 Intel Corporation.

--- a/examples/python/tsl2561.py
+++ b/examples/python/tsl2561.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/ttp223.py
+++ b/examples/python/ttp223.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 # Author: Sarah Knepper <sarah.knepper@intel.com>
 # Copyright (c) 2015 Intel Corporation.

--- a/examples/python/tzemt400.py
+++ b/examples/python/tzemt400.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/uln200xa.py
+++ b/examples/python/uln200xa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author:  Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015-2016 Intel Corporation.
 #

--- a/examples/python/urm37-uart.py
+++ b/examples/python/urm37-uart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/urm37.py
+++ b/examples/python/urm37.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/vcap.py
+++ b/examples/python/vcap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2016 Intel Corporation.
 #

--- a/examples/python/vdiv.py
+++ b/examples/python/vdiv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/veml6070.py
+++ b/examples/python/veml6070.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Abhishek Malik <abhishek.malik@intel.com>
 # Copyright (c) 2017 Intel Corporation.
 #

--- a/examples/python/water.py
+++ b/examples/python/water.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/waterlevel.py
+++ b/examples/python/waterlevel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/wfs.py
+++ b/examples/python/wfs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/wheelencoder.py
+++ b/examples/python/wheelencoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/wt5001.py
+++ b/examples/python/wt5001.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/xbee.py
+++ b/examples/python/xbee.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Jon Trulson <jtrulson@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/yg1006.py
+++ b/examples/python/yg1006.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/zfm20-register.py
+++ b/examples/python/zfm20-register.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #

--- a/examples/python/zfm20.py
+++ b/examples/python/zfm20.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Author: Zion Orent <zorent@ics.com>
 # Copyright (c) 2015 Intel Corporation.
 #


### PR DESCRIPTION
Added/updated the shebang line on all python examples with:

Also chmod +x a few of the python examples.

Signed-off-by: Noel Eck <noel.eck@intel.com>