### PR TITLE
lis2ds12.{h,hpp}: add missing parameter description

### DIFF
--- a/src/lis2ds12/lis2ds12.h
+++ b/src/lis2ds12/lis2ds12.h
@@ -299,6 +299,7 @@ extern "C" {
      * Read contiguous registers into a buffer
      *
      * @param dev The device context
+     * @param reg The register to start the read from
      * @param buffer The buffer to store the results
      * @param len The number of registers to read
      * @return The number of bytes read, or -1 on error

--- a/src/lis2ds12/lis2ds12.hpp
+++ b/src/lis2ds12/lis2ds12.hpp
@@ -292,6 +292,7 @@ namespace upm {
         /**
          * Read contiguous registers into a buffer
          *
+         * @param reg The register to start the read from
          * @param buffer The buffer to store the results
          * @param len The number of registers to read
          * @return The number of bytes read


### PR DESCRIPTION
I'm working on a LIS3DH sensor module as discussed earlier in #617 and use @jontrulson's [nice] lis2ds12 one as the base. Noticed a missing parameter description, so here goes the fix.