### PR TITLE
examples/lis2ds12.py: fix comment typo

### DIFF
--- a/examples/python/lis2ds12.py
+++ b/examples/python/lis2ds12.py
@@ -26,7 +26,7 @@ import time, sys, signal, atexit
 from upm import pyupm_lis2ds12 as sensorObj
 
 def main():
-    # Instantiate a BMP250E instance using default i2c bus and address
+    # Instantiate a LIS2DS12 instance using default i2c bus and address
     sensor = sensorObj.LIS2DS12()
 
     # For SPI, bus 0, you would pass -1 as the address, and a valid pin for CS:


### PR DESCRIPTION
Just a small typo fix in LIS2DS12 Python example to avoid user confusion.