### PR TITLE
lis2ds12: remove surplus accFactor coefficient

### DIFF
--- a/src/lis2ds12/lis2ds12.c
+++ b/src/lis2ds12/lis2ds12.c
@@ -238,40 +238,6 @@ upm_result_t lis2ds12_set_odr(const lis2ds12_context dev,
     if (lis2ds12_write_reg(dev, LIS2DS12_REG_CTRL1, reg))
         return UPM_ERROR_OPERATION_FAILED;
 
-    switch(odr)
-    {
-    case LIS2DS12_ODR_12_5HZ:
-    case LIS2DS12_ODR_25HZ:
-    case LIS2DS12_ODR_50HZ:
-    case LIS2DS12_ODR_100HZ:
-        // 14b
-        dev->accFactor = 4.0;
-        break;
-
-        // these are special - possibly HF modes.  Since we've already
-        // stripped the HF indicator, we check the hf_mode here.  HF
-        // modes are 12b resolution, otherwise resolution is 14b.
-    case LIS2DS12_ODR_200HZ:
-    case LIS2DS12_ODR_400HZ:
-    case LIS2DS12_ODR_800HZ:
-        if (hf_mode)
-            dev->accFactor = 16.0;
-        else
-            dev->accFactor = 4.0;
-        break;
-
-        // choose something safe
-    case LIS2DS12_ODR_POWER_DOWN:
-        dev->accFactor = 1.0;
-        break;
-
-        // the rest are low power modes, 10b
-    default:
-        dev->accFactor = 64.0;
-        break;
-    }
-
-
     return UPM_SUCCESS;
 }
 
@@ -452,16 +418,16 @@ void lis2ds12_get_accelerometer(const lis2ds12_context dev,
 {
     assert(dev != NULL);
 
-    float scale = (dev->accScale * dev->accFactor) / 1000.0;
+    float scale = dev->accScale / 1000.0;
 
     if (x)
-        *x = (dev->accX / dev->accFactor) * scale;
+        *x = dev->accX * scale;
 
     if (y)
-        *y = (dev->accY / dev->accFactor) * scale;
+        *y = dev->accY * scale;
 
     if (z)
-        *z = (dev->accZ / dev->accFactor) * scale;
+        *z = dev->accZ * scale;
 }
 
 float lis2ds12_get_temperature(const lis2ds12_context dev)

--- a/src/lis2ds12/lis2ds12.h
+++ b/src/lis2ds12/lis2ds12.h
@@ -69,7 +69,6 @@ extern "C" {
 
         // acc scaling
         float accScale;
-        float accFactor;
     } *lis2ds12_context;
 
     /**


### PR DESCRIPTION
As we've established in PR #623 (adding lis3dh support), this coefficient is not needed and actually is cancelled out in calculations, so remove it.

I don't have a lis2ds12 sensor to do an ultimate test, but given the nature of the change and pretty much mathematical proof of the fact that the coeficient is not really used, I don't see any real way for this change to break it. Compilation itself surely passes.

If anyone has the sensor to give it a try, you are more than welcome to chime in.