### PR TITLE
sonar-scan.sh: correct SonarCloud URL

### DIFF
--- a/scripts/sonar-scan.sh
+++ b/scripts/sonar-scan.sh
@@ -54,7 +54,7 @@ sonar_cmd_base="build-wrapper-linux-x86-64 --out-dir ${bw_output_path} make -j8 
         -Dsonar.java.binaries='src' \
         -Dsonar.coverage.exclusions='**/*' \
         -Dsonar.cfamily.build-wrapper-output=${bw_output_path} \
-        -Dsonar.host.url=https://sonarqube.com \
+        -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.organization=${SONAR_ORG} \
         -Dsonar.login=${SONAR_TOKEN} \
 "


### PR DESCRIPTION
According to SonarCloud's email notification,
they're dropping sonarqube.com in favor of sonarcloud.io.

/cc @arfoll, @Propanu 