### PR TITLE
kx122: Allow setting communication bus speed

### DIFF
--- a/examples/c/kx122.c
+++ b/examples/c/kx122.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
   signal(SIGINT,sig_handler);
 
   //! [Interesting]
-  kx122_context sensor = kx122_init(0,-1,24);
+  kx122_context sensor = kx122_init(0, -1, 24, 10000);
   if (!sensor)
   {
       printf("kx122_init() failed.\n");

--- a/src/kx122/kx122.c
+++ b/src/kx122/kx122.c
@@ -161,7 +161,7 @@ Sets acceleration scale of sensor and the buffer.
 */
 static void kx122_map_grange(const kx122_context dev, KX122_RANGE_T grange);
 
-kx122_context kx122_init(int bus, int addr, int chip_select_pin)
+kx122_context kx122_init(int bus, int addr, int chip_select_pin, int spi_bus_frequency)
 {
   kx122_context dev = (kx122_context)malloc(sizeof(struct _kx122_context));
 
@@ -190,6 +190,12 @@ kx122_context kx122_init(int bus, int addr, int chip_select_pin)
 
   if(dev->using_spi){
 
+    if (spi_bus_frequency > 10000000){	// KX122 has a maximum SPI bus speed of 10MHz
+      printf("%s: bus frequency too high - KX122 has a maximum SPI bus speed of 10MHz.\n", __FUNCTION__);
+      kx122_close(dev);
+      return NULL;
+    }
+
     if (!(dev->spi = mraa_spi_init(bus))){
       printf("%s: mraa_spi_init() failed.\n", __FUNCTION__);
       kx122_close(dev);
@@ -205,7 +211,7 @@ kx122_context kx122_init(int bus, int addr, int chip_select_pin)
     mraa_gpio_dir(dev->chip_select,MRAA_GPIO_OUT);
     mraa_spi_mode(dev->spi,MRAA_SPI_MODE0);
 
-    if (mraa_spi_frequency(dev->spi,SPI_FREQUENCY)){
+    if (mraa_spi_frequency(dev->spi, spi_bus_frequency)){
       printf("%s: mraa_spi_frequency() failed.\n", __FUNCTION__);
       kx122_close(dev);
       return NULL;

--- a/src/kx122/kx122.cxx
+++ b/src/kx122/kx122.cxx
@@ -32,7 +32,8 @@
 
 using namespace upm;
 
-KX122::KX122(int bus, int addr, int chip_select) : m_kx122(kx122_init(bus,addr,chip_select))
+KX122::KX122(int bus, int addr, int chip_select, int spi_bus_frequency)
+  : m_kx122(kx122_init(bus,addr,chip_select,spi_bus_frequency))
 {
   if(!m_kx122){
     throw std::runtime_error(std::string(__FUNCTION__) + "kx122_init() failed");

--- a/src/kx122/kx122.h
+++ b/src/kx122/kx122.h
@@ -47,7 +47,7 @@ extern "C"{
  */
 
 //Frequency of the SPI connection
-#define SPI_FREQUENCY 10000
+#define DEFAULT_SPI_FREQUENCY 10000
 
 //Default slave addresses for the sensor
 #define KX122_DEFAULT_SLAVE_ADDR_1 0x1F
@@ -170,9 +170,10 @@ If no errors occur, the device gets initialized with default values and gets set
 @param bus I2C or SPI bus to use.
 @param addr I2C address of the sensor.
 @param chip_select Chip select pin for SPI.
+@param spi_bus_frequency Speed of the SPI communication bus in Hz (ignored when using I2C).
 @return The device context, or NULL if an error occurs.
 */
-kx122_context kx122_init(int bus, int addr, int chip_select_pin);
+kx122_context kx122_init(int bus, int addr, int chip_select_pin, int spi_bus_frequency);
 
 /**
 KX122 destructor

--- a/src/kx122/kx122.hpp
+++ b/src/kx122/kx122.hpp
@@ -50,9 +50,10 @@ namespace upm{
       @param bus I2C or SPI bus to use.
       @param addr I2C address of the sensor.
       @param chip_select Chip select pin for SPI.
+      @param spi_bus_frequency Speed of the SPI communication bus in Hz.
       @throws std::runtime_error on initialization failure.
       */
-      KX122(int bus, int addr, int chip_select);
+      KX122(int bus, int addr, int chip_select, int spi_bus_frequency = DEFAULT_SPI_FREQUENCY);
 
       /**
       KX122 destructor


### PR DESCRIPTION
SPI bus speed was hardcoded to 10kHz, which is much slower than what the device is capable (10MHz).
