### PR TITLE
Fix kx122 python

### DIFF
--- a/docs/apichanges.md
+++ b/docs/apichanges.md
@@ -14,6 +14,8 @@ compatibility between releases:
  mostly considered a bundle for ssd lcd display controllers only
  * The **zfm20** class constructor has been overloaded with a string variant
  that allows initialization using any UART device
+ * The interface of **kx122** has been modified to return values instead of 
+ receiving pointers
 
 # v1.5.0
 

--- a/src/common_top.i
+++ b/src/common_top.i
@@ -46,6 +46,11 @@ void cleanUp();
 // Disable nested struct warnings
 #pragma SWIG nowarn=312,325
 
+#if SWIGPYTHON
+/* Apply all uints as 'unsigned int' for python */
+%apply unsigned int {uint};
+#endif
+
 /* The pyupm_doxy2swig.i file is created via doxy2swig.py from doxygen xml
  * output during doc build.  This file is used by swig to provide native
  * python module documentation.

--- a/src/kx122/kx122.cxx
+++ b/src/kx122/kx122.cxx
@@ -56,11 +56,15 @@ float KX122::getSamplePeriod()
   return kx122_get_sample_period(m_kx122);
 }
 
-void KX122::getWhoAmI(uint8_t *data)
+uint8_t KX122::getWhoAmI()
 {
-  if(kx122_get_who_am_i(m_kx122,data)){
+  uint8_t data;
+
+  if(kx122_get_who_am_i(m_kx122, &data)){
 	throw std::runtime_error(std::string(__FUNCTION__) + "kx122_get_who_am_i failed");
   }
+
+  return data;
 }
 void KX122::getRawAccelerationData(float *x, float *y, float *z)
 {
@@ -220,11 +224,14 @@ bool KX122::getInterruptStatus()
   return kx122_get_interrupt_status(m_kx122);
 }
 
-void KX122::getInterruptSource(uint8_t *data)
+uint8_t KX122::getInterruptSource()
 {
-  if(kx122_get_interrupt_source(m_kx122,data)){
+  uint8_t data;
+  if(kx122_get_interrupt_source(m_kx122, &data)){
     throw std::runtime_error(std::string(__FUNCTION__) + "kx122_get_interrupt_source failed");
   }
+
+  return data;
 }
 
 void KX122::clearInterrupt()
@@ -304,25 +311,53 @@ void KX122::setBufferMode(KX122_BUFFER_MODE_T mode)
   }
 }
 
-void KX122::getBufferStatus(uint *samples)
+uint KX122::getBufferStatus()
 {
-  if(kx122_get_buffer_status(m_kx122,samples)){
+  uint nb_samples = 0;
+  if(kx122_get_buffer_status(m_kx122, &nb_samples)){
     throw std::runtime_error(std::string(__FUNCTION__) + "kx122_get_buffer_status failed");
   }
+  
+  return nb_samples;
 }
 
-void KX122::getRawBufferSamples(uint len, float *x_array, float *y_array, float *z_array)
+//Maximum number of samples that can be stored in the buffer of the KX122
+#define MAX_SAMPLES_IN_BUFFER 681
+
+std::vector<float> KX122::getRawBufferSamples(uint len)
 {
-  if(kx122_read_buffer_samples_raw(m_kx122,len,x_array,y_array,z_array)){
+  float bufferx[MAX_SAMPLES_IN_BUFFER], buffery[MAX_SAMPLES_IN_BUFFER], bufferz[MAX_SAMPLES_IN_BUFFER];
+  if(kx122_read_buffer_samples_raw(m_kx122,len,bufferx,buffery,bufferz)){
     throw std::runtime_error(std::string(__FUNCTION__) + "kx122_read_buffer_samples_raw failed");
   }
+
+  std::vector<float> xyz_array(len * 3);
+  for (uint i = 0; i < len; i++)
+  {
+	  xyz_array[i * 3 + 0] = bufferx[i];
+	  xyz_array[i * 3 + 1] = buffery[i];
+	  xyz_array[i * 3 + 2] = bufferz[i];
+  }
+  
+  return xyz_array;
 }
 
-void KX122::getBufferSamples(uint len, float *x_array, float *y_array, float *z_array)
+std::vector<float> KX122::getBufferSamples(uint len)
 {
-  if(kx122_read_buffer_samples(m_kx122,len,x_array,y_array,z_array)){
+  float bufferx[MAX_SAMPLES_IN_BUFFER], buffery[MAX_SAMPLES_IN_BUFFER], bufferz[MAX_SAMPLES_IN_BUFFER];
+  if(kx122_read_buffer_samples(m_kx122,len,bufferx,buffery,bufferz)){
     throw std::runtime_error(std::string(__FUNCTION__) + "kx122_read_buffer_samples failed");
   }
+ 
+  std::vector<float> xyz_array(len * 3);
+  for (uint i = 0; i < len; i++)
+  {
+	  xyz_array[i * 3 + 0] = bufferx[i];
+	  xyz_array[i * 3 + 1] = buffery[i];
+	  xyz_array[i * 3 + 2] = bufferz[i];
+  }
+  
+  return xyz_array;
 }
 
 void KX122::clearBuffer()

--- a/src/kx122/kx122.hpp
+++ b/src/kx122/kx122.hpp
@@ -82,10 +82,10 @@ namespace upm{
       /**
       Gets who am i value of the sensor.
 
-      @param data Pointer to a uint8_t variable to store the value.
+      @return Who am I value of the sensor.
       @throws std::runtime_error on failure.
       */
-      void getWhoAmI(uint8_t *data);
+      uint8_t getWhoAmI();
 
       /**
       Gets raw accelerometer data from the sensor.
@@ -339,10 +339,10 @@ namespace upm{
 
       See datasheet for more details.
 
-      @param data Pointer to a uint8_t variable to store the value.
+      @return Interrupt source value.
       @throws std::runtime_error on failure.
       */
-      void getInterruptSource(uint8_t *data);
+      uint8_t getInterruptSource();
 
       /**
       Clears latching interrupts (Wakeup, Data Ready).
@@ -470,36 +470,28 @@ namespace upm{
       /**
       Gets the current amount of samples in the buffer.
 
-      @param samples Pointer to an uint variable to store the data.
+      @return number of samples in the buffer.
       @throws std::runtime_error on failure.
       */
-      void getBufferStatus(uint *samples);
+      uint getBufferStatus();
 
       /**
       Gets the specified amount of raw acceleration samples from the buffer.
 
-      Make sure the array size is at least the amount of samples to be read.
-
       @param len The amount of samples to read from the buffer.
-      @param x_array Pointer to an floating point array to store the x-axis data. Can be set to NULL if not wanted.
-      @param y_array Pointer to an floating point array to store the y-axis data. Can be set to NULL if not wanted.
-      @param z_array Pointer to an floating point array to store the z-axis data. Can be set to NULL if not wanted.
+      @return vector containing x, y & z-axis data
       @throws std::runtime_error on failure.
       */
-      void getRawBufferSamples(uint len, float *x_array, float *y_array, float *z_array);
+      std::vector<float> getRawBufferSamples(uint len);
 
       /**
       Gets the specified amount of converted (m/s^2) acceleration samples from the buffer.
 
-      Make sure the array size is at least the amount of samples to be read.
-
       @param len The amount of samples to read from the buffer.
-      @param x_array Pointer to an floating point array to store the x-axis data. Can be set to NULL if not wanted.
-      @param y_array Pointer to an floating point array to store the y-axis data. Can be set to NULL if not wanted.
-      @param z_array Pointer to an floating point array to store the z-axis data. Can be set to NULL if not wanted.
+      @return vector containing x, y & z-axis data
       @throws std::runtime_error on failure.
       */
-      void getBufferSamples(uint len, float *x_array, float *y_array, float *z_array);
+      std::vector<float> getBufferSamples(uint len);
 
       /**
       Clears the buffer, removing all existing samples from the buffer.


### PR DESCRIPTION
Many of the methods were unusable in Python through SWIG due to these problems:

- uint was seen as an 'object' by SWIG
- using pointers to return values
