### PR TITLE
Remove unused-result message when compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option (RPM "Generate RPM using CPack" OFF)
 option (NPM "Generate NPM/GYP tarballs" OFF)
 option (BUILDTESTS "Generate check-ups for upm" OFF)
 option (WERROR "Make all warnings into errors." ON)
+option (WUNUSED "Remove warnings if return value unused" OFF)
 
 # Warn if building in source root
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
@@ -103,6 +104,13 @@ if (WERROR)
   list (APPEND C_CXX_WARNING_FLAGS -Werror)
   message (STATUS "Warnings as errors enabled (-Werror), disable with -DWERROR=off")
 endif (WERROR)
+
+# Remove Warnings for "unused return"  ?
+if (WUNUSED)
+  list (APPEND C_CXX_WARNING_FLAGS -Wno-unused-result)
+   message (STATUS "Warnings for unused-result enabled, disable with -DWUNUSED=on")
+endif (WUNUSED)
+
 
 # Set C compiler warning flags at top-level scope and emit a warning about
 # unsupported flags

--- a/src/mhz16/mhz16.cxx
+++ b/src/mhz16/mhz16.cxx
@@ -65,6 +65,38 @@ MHZ16::MHZ16(int uart)
     }
 }
 
+MHZ16::MHZ16(char * uart_raw)
+{
+  m_ttyFd = -1;
+
+  if ( !(m_uart = mraa_uart_init_raw(uart_raw)) )
+    {
+      throw std::invalid_argument(std::string(__FUNCTION__) +
+                                  ": mraa_uart_init_raw() failed");
+      return;
+    }
+
+  // This requires a recent MRAA (1/2015)
+  const char *devPath = mraa_uart_get_dev_path(m_uart);
+
+  if (!devPath)
+    {
+      throw std::runtime_error(std::string(__FUNCTION__) +
+                               ": mraa_uart_get_dev_path() failed");
+      return;
+    }
+
+  // now open the tty
+  if ( (m_ttyFd = open(devPath, O_RDWR)) == -1)
+    {
+      throw std::runtime_error(std::string(__FUNCTION__) +
+                               ": open of " + 
+                               string(devPath) + " failed: " +
+                               string(strerror(errno)));
+      return;
+    }
+
+
 MHZ16::~MHZ16()
 {
   if (m_ttyFd != -1)

--- a/src/mhz16/mhz16.hpp
+++ b/src/mhz16/mhz16.hpp
@@ -41,6 +41,7 @@
 #include <mraa/uart.h>
 
 const int MHZ16_DEFAULT_UART = 0;
+const char * MHZ16_DEFAULT_UART_RAW="/dev/ttyS0";
 
 // protocol start and end codes
 const uint8_t MHZ16_START = 0x7e;
@@ -84,6 +85,13 @@ namespace upm {
      */
     MHZ16(int uart);
 
+    /**
+     * MHZ16 constructor
+     *
+     * @param uart File path (/dev/ttyXXX to uart)
+     */
+     MHZ16(char * uart_raw);
+     
     /**
      * MHZ16 destructor
      */


### PR DESCRIPTION
warning messages about unused result occur.
This commit enables to remove the messages uding the option
-DWUNUSED=on
which makes a cleaner log

Signed-off-by: g-vidal <gerard.vidal@ens-lyon.fr>