### PR TITLE
Modify MHZ16 to use mraa_uart_init_raw() or mraa_uart_init()

### DIFF
--- a/src/mhz16/mhz16.cxx
+++ b/src/mhz16/mhz16.cxx
@@ -37,12 +37,24 @@ MHZ16::MHZ16(int uart)
 {
   m_ttyFd = -1;
 
-  if ( !(m_uart = mraa_uart_init(uart)) )
-    {
-      throw std::invalid_argument(std::string(__FUNCTION__) +
-                                  ": mraa_uart_init() failed");
-      return;
-    }
+  if (uart == 99)
+     {
+        if ( !(m_uart = mraa_uart_init_raw(path)) )
+          {
+             throw std::invalid_argument(std::string(__FUNCTION__) +
+                                         ": mraa_uart_init_raw() failed");
+             return;
+          }
+     }
+   else
+     {
+        if ( !(m_uart = mraa_uart_init(uart)) )
+          {
+             throw std::invalid_argument(std::string(__FUNCTION__) +
+                                         ": mraa_uart_init() failed");
+             return;
+          }
+     }
 
   // This requires a recent MRAA (1/2015)
   const char *devPath = mraa_uart_get_dev_path(m_uart);

--- a/src/mhz16/mhz16.hpp
+++ b/src/mhz16/mhz16.hpp
@@ -41,6 +41,7 @@
 #include <mraa/uart.h>
 
 const int MHZ16_DEFAULT_UART = 0;
+const char *  MHZ16_DEFAULT_UART_PATH = "/dev/ttyS0";
 
 // protocol start and end codes
 const uint8_t MHZ16_START = 0x7e;
@@ -80,9 +81,10 @@ namespace upm {
     /**
      * MHZ16 constructor
      *
-     * @param uart Default UART to use (0 or 1)
+     * @param uart Default UART to use (0 or 1 or 99) 0 and 1 are default standard devices 
+     * @param path Default PATH to device  choose uart=99 to select path instead of standard device
      */
-    MHZ16(int uart);
+    MHZ16(int uart, char * path);
 
     /**
      * MHZ16 destructor


### PR DESCRIPTION
with
**mraa_uart_init()** function
this proposal enables to use also
**mraa_uart_init_raw()** function to choose another path for UART

Signed-off-by: g-vidal <gerard.vidal@ens-lyon.fr>