### PR TITLE
examples: gcc8 fixes for -Werror=format-truncation

### DIFF
--- a/examples/c++/tm1637.cxx
+++ b/examples/c++/tm1637.cxx
@@ -49,7 +49,7 @@ main(int argc, char** argv)
     int timezone = -7; // Your UTC offset
     time_t rawtime;
     struct tm* gmt;
-    char myTime[5];
+    char myTime[15];
 
     fprintf(stdout, "TM1637 Display Example\n");
     signal(SIGINT, sig_handler);
@@ -66,7 +66,7 @@ main(int argc, char** argv)
         int hour = (gmt) ? gmt->tm_hour : 0;
         int min = (gmt) ? gmt->tm_min : 0;
         // Format and store the time in 24 hour format
-        snprintf(myTime, 5, "%2d%02d", (hour + timezone + 24) % 24, min);
+        snprintf(myTime, 15, "%2d%02d", (hour + timezone + 24) % 24, min);
 
         myDisplay.write(myTime);           // Write to display as string
         myDisplay.setColon(point ^= true); // Toggle the dots on the display

--- a/examples/c/jhd1313m1.c
+++ b/examples/c/jhd1313m1.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     }
 
     int ndx = 0;
-    char str[20];
+    char str[23];
     uint8_t rgb[7][3] = {
         {0xd1, 0x00, 0x00},
         {0xff, 0x66, 0x22},


### PR DESCRIPTION
Fixes below issues:
tm1637.cxx:69:29: error: "%2d%02d" directive output may be truncated writing between 5 and 15 bytes into a destination of size 5 [-Werror=format-truncation=]
          snprintf(myTime, 5, "%2d%02d", (hour + timezone + 24) % 24, min);

jhd1313m1.c:65:49: error: '%d' directive output may be truncated writing between 1 and 10 bytes into a region of size 8 [-Werror=format-truncation=]
          snprintf(str, sizeof(str), "Hello World %d", ndx);

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>