### PR TITLE
Use IdleNotificationDeadline as deprecated IdleNotification has been …

### DIFF
--- a/src/common_top.i
+++ b/src/common_top.i
@@ -28,9 +28,9 @@ void cleanUp()
      * See https://codereview.chromium.org/412163003 for this API change
      */
 #if (SWIG_V8_VERSION < 0x032838)
-    while (!v8::V8::IdleNotification())
+    while (!v8::V8::IdleNotificationDeadline())
 #else
-    while (!v8::Isolate::GetCurrent()->IdleNotification(1000))
+    while (!v8::Isolate::GetCurrent()->IdleNotificationDeadline(1000))
 #endif
     {;}
 }


### PR DESCRIPTION
…removed

In v8 API 6.5 the long deprecated IdleNotification has been removed so we
need to use IdleNotificationDeadline as nodejs 10.x uses newer v8.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>