### PR TITLE
led: Update LED init API

### DIFF
--- a/src/led/led.c
+++ b/src/led/led.c
@@ -76,7 +76,7 @@ led_context led_init_str(const char* name){
     dev->gpio = NULL;
 
     dev->name = name;
-    dev->gpioled = mraa_led_init(name);
+    dev->gpioled = mraa_led_init_raw(name);
 
     if (!dev->gpioled) {
         printf("%s: Unable to initialize gpioled device (%s).\n", __FUNCTION__, dev->name);


### PR DESCRIPTION
mraa_led_init API expects led number. So, replace it with
mraa_led_init_raw for initializing an LED based on label.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>