### PR TITLE
led: update usage of mraa led api to mraa 2 spec

### DIFF
--- a/src/led/led.c
+++ b/src/led/led.c
@@ -76,7 +76,7 @@ led_context led_init_str(const char* name){
     dev->gpio = NULL;
 
     dev->name = name;
-    dev->gpioled = mraa_led_init(name);
+    dev->gpioled = mraa_led_init_raw(name);
 
     if (!dev->gpioled) {
         printf("%s: Unable to initialize gpioled device (%s).\n", __FUNCTION__, dev->name);


### PR DESCRIPTION
Function mraa_led_init used to take char* for its arg. This has changed
and now takes a int from the board definition. mraa_led_init_raw seems
to be the same

Discovered during PPA builds. Patch to included in deb as package
maintainer patch.

Signed-off-by: Thomas Ingleby <thomas.ingleby@intel.com>